### PR TITLE
feat(style): add REVERSE text modifier

### DIFF
--- a/src/render/cell.rs
+++ b/src/render/cell.rs
@@ -19,6 +19,8 @@ bitflags! {
         const DIM = 0b00001000;
         /// Strikethrough/crossed out text
         const CROSSED_OUT = 0b00010000;
+        /// Reverse video (swap foreground/background)
+        const REVERSE = 0b00100000;
     }
 }
 
@@ -143,6 +145,12 @@ impl Cell {
         self
     }
 
+    /// Set reverse modifier (swap foreground/background)
+    pub fn reverse(mut self) -> Self {
+        self.modifier |= Modifier::REVERSE;
+        self
+    }
+
     /// Reset the cell to default state
     pub fn reset(&mut self) {
         self.symbol = ' ';
@@ -251,5 +259,18 @@ mod tests {
         assert!(cell.sequence_id.is_some());
         cell.reset();
         assert!(cell.sequence_id.is_none());
+    }
+
+    #[test]
+    fn test_cell_reverse() {
+        let cell = Cell::new('X').reverse();
+        assert!(cell.modifier.contains(Modifier::REVERSE));
+    }
+
+    #[test]
+    fn test_modifier_reverse_combined() {
+        let cell = Cell::new('X').bold().reverse();
+        assert!(cell.modifier.contains(Modifier::BOLD));
+        assert!(cell.modifier.contains(Modifier::REVERSE));
     }
 }

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -297,6 +297,9 @@ impl<W: Write> Terminal<W> {
             if cell.modifier.contains(Modifier::CROSSED_OUT) {
                 queue!(self.writer, SetAttribute(Attribute::CrossedOut))?;
             }
+            if cell.modifier.contains(Modifier::REVERSE) {
+                queue!(self.writer, SetAttribute(Attribute::Reverse))?;
+            }
 
             state.modifier = cell.modifier;
         }

--- a/src/widget/richtext.rs
+++ b/src/widget/richtext.rs
@@ -39,6 +39,8 @@ pub struct Style {
     pub dim: bool,
     /// Strikethrough text
     pub strikethrough: bool,
+    /// Reverse video (swap fg/bg)
+    pub reverse: bool,
 }
 
 impl Style {
@@ -86,6 +88,12 @@ impl Style {
     /// Set strikethrough
     pub fn strikethrough(mut self) -> Self {
         self.strikethrough = true;
+        self
+    }
+
+    /// Set reverse video (swap foreground/background)
+    pub fn reverse(mut self) -> Self {
+        self.reverse = true;
         self
     }
 
@@ -145,6 +153,9 @@ impl Style {
         }
         if self.strikethrough {
             m |= Modifier::CROSSED_OUT;
+        }
+        if self.reverse {
+            m |= Modifier::REVERSE;
         }
         m
     }
@@ -362,6 +373,7 @@ impl RichText {
                             "underline" | "u" => current_style.underline = true,
                             "dim" => current_style.dim = true,
                             "strike" | "s" => current_style.strikethrough = true,
+                            "reverse" | "rev" => current_style.reverse = true,
                             "red" => current_style.fg = Some(Color::RED),
                             "green" => current_style.fg = Some(Color::GREEN),
                             "blue" => current_style.fg = Some(Color::BLUE),

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -29,6 +29,7 @@ pub struct Text {
     bold: bool,
     italic: bool,
     underline: bool,
+    reverse: bool,
     align: Alignment,
     /// CSS styling properties (id, classes)
     props: WidgetProps,
@@ -44,6 +45,7 @@ impl Text {
             bold: false,
             italic: false,
             underline: false,
+            reverse: false,
             align: Alignment::Left,
             props: WidgetProps::new(),
         }
@@ -122,6 +124,12 @@ impl Text {
         self
     }
 
+    /// Reverse video (swap foreground/background colors)
+    pub fn reverse(mut self) -> Self {
+        self.reverse = true;
+        self
+    }
+
     /// Set text alignment
     pub fn align(mut self, align: Alignment) -> Self {
         self.align = align;
@@ -177,6 +185,9 @@ impl Text {
         }
         if self.underline {
             style = style.underline();
+        }
+        if self.reverse {
+            style = style.reverse();
         }
 
         RichText::new().push(&self.content, style)

--- a/tests/snapshots/text_reverse.snap
+++ b/tests/snapshots/text_reverse.snap
@@ -1,0 +1,17 @@
+Normal text
+
+
+
+
+
+
+
+Reversed text
+
+
+
+
+
+
+
+Bold + Reversed

--- a/tests/widget_snapshots.rs
+++ b/tests/widget_snapshots.rs
@@ -64,6 +64,19 @@ fn test_text_alignment() {
     pilot.snapshot("text_alignment");
 }
 
+#[test]
+fn test_text_reverse() {
+    let view = vstack()
+        .child(Text::new("Normal text"))
+        .child(Text::new("Reversed text").reverse())
+        .child(Text::new("Bold + Reversed").bold().reverse());
+
+    let mut app = TestApp::new(view);
+    let mut pilot = Pilot::new(&mut app);
+
+    pilot.snapshot("text_reverse");
+}
+
 // =============================================================================
 // Stack Widget Tests
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add `REVERSE` modifier for text styling (swap foreground/background colors)
- Works with Cell, Text, RichText widgets

## Changes
| File | Description |
|------|-------------|
| `src/render/cell.rs` | Add REVERSE to Modifier bitflags, add reverse() method |
| `src/render/terminal.rs` | Emit Attribute::Reverse |
| `src/widget/richtext.rs` | Add reverse field/method to Style, markup support |
| `src/widget/text.rs` | Add reverse() method to Text |

## Usage
```rust
// Cell
Cell::new('X').reverse()

// Text widget
Text::new("Inverted").reverse()

// RichText markup
RichText::markup("[reverse]Inverted[/]")
```

Closes #51