### PR TITLE
feat(widget): add Justify text alignment

### DIFF
--- a/tests/snapshots/text_justify.snap
+++ b/tests/snapshots/text_justify.snap
@@ -1,0 +1,3 @@
+Hello        World        Test
+A       B      C      D      E
+SingleWord

--- a/tests/widget_snapshots.rs
+++ b/tests/widget_snapshots.rs
@@ -77,6 +77,20 @@ fn test_text_reverse() {
     pilot.snapshot("text_reverse");
 }
 
+#[test]
+fn test_text_justify() {
+    let config = TestConfig::with_size(30, 5);
+    let view = vstack()
+        .child(Text::new("Hello World Test").align(Alignment::Justify))
+        .child(Text::new("A B C D E").align(Alignment::Justify))
+        .child(Text::new("SingleWord").align(Alignment::Justify));
+
+    let mut app = TestApp::with_config(view, config);
+    let mut pilot = Pilot::new(&mut app);
+
+    pilot.snapshot("text_justify");
+}
+
 // =============================================================================
 // Stack Widget Tests
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add `Alignment::Justify` variant for text widget
- Implement `render_justified()` that distributes space evenly between words
- Falls back to left alignment for single words or overly long text

## Test plan
- [x] Unit tests for justify alignment behavior
- [x] Snapshot test for visual rendering verification
- [x] All existing text alignment tests pass

Closes #50