### PR TITLE
feat(widget): add Callout widget for info highlight blocks

### DIFF
--- a/examples/callout.rs
+++ b/examples/callout.rs
@@ -1,0 +1,289 @@
+//! Callout Widget Demo - Demonstrates different callout types and variants
+//!
+//! Run with: cargo run --example callout
+
+use revue::prelude::*;
+use revue::widget::{Callout, CalloutVariant};
+
+/// Current view mode
+#[derive(Clone, Copy, PartialEq)]
+enum ViewTab {
+    Types,
+    Variants,
+    Collapsible,
+}
+
+impl ViewTab {
+    fn name(&self) -> &str {
+        match self {
+            ViewTab::Types => "Types",
+            ViewTab::Variants => "Variants",
+            ViewTab::Collapsible => "Collapsible",
+        }
+    }
+
+    fn all() -> &'static [ViewTab] {
+        &[ViewTab::Types, ViewTab::Variants, ViewTab::Collapsible]
+    }
+}
+
+/// Demo application state
+struct CalloutDemo {
+    /// Current tab
+    tab: ViewTab,
+    /// Collapsible callouts
+    note_callout: Callout,
+    tip_callout: Callout,
+    warning_callout: Callout,
+    /// Currently focused collapsible (0-2)
+    focused_idx: usize,
+}
+
+impl CalloutDemo {
+    fn new() -> Self {
+        Self {
+            tab: ViewTab::Types,
+            note_callout: Callout::note(
+                "This is a collapsible note.\nYou can hide or show the content.",
+            )
+            .collapsible(true)
+            .expanded(true),
+            tip_callout: Callout::tip(
+                "Pro tip: Use keyboard shortcuts!\nPress Space or Enter to toggle.",
+            )
+            .collapsible(true)
+            .expanded(false),
+            warning_callout: Callout::warning("Be careful with this action.\nIt cannot be undone.")
+                .collapsible(true)
+                .expanded(true),
+            focused_idx: 0,
+        }
+    }
+
+    fn handle_key(&mut self, key: &Key) -> bool {
+        // Tab switching
+        match key {
+            Key::Char('1') => {
+                self.tab = ViewTab::Types;
+                return true;
+            }
+            Key::Char('2') => {
+                self.tab = ViewTab::Variants;
+                return true;
+            }
+            Key::Char('3') => {
+                self.tab = ViewTab::Collapsible;
+                return true;
+            }
+            Key::Tab => {
+                let tabs = ViewTab::all();
+                let idx = tabs.iter().position(|&t| t == self.tab).unwrap_or(0);
+                self.tab = tabs[(idx + 1) % tabs.len()];
+                return true;
+            }
+            Key::BackTab => {
+                let tabs = ViewTab::all();
+                let idx = tabs.iter().position(|&t| t == self.tab).unwrap_or(0);
+                self.tab = tabs[(idx + tabs.len() - 1) % tabs.len()];
+                return true;
+            }
+            _ => {}
+        }
+
+        // Collapsible tab specific handling
+        if self.tab == ViewTab::Collapsible {
+            match key {
+                Key::Up | Key::Char('k') => {
+                    if self.focused_idx > 0 {
+                        self.focused_idx -= 1;
+                    }
+                    return true;
+                }
+                Key::Down | Key::Char('j') => {
+                    if self.focused_idx < 2 {
+                        self.focused_idx += 1;
+                    }
+                    return true;
+                }
+                Key::Enter | Key::Char(' ') => {
+                    match self.focused_idx {
+                        0 => self.note_callout.toggle(),
+                        1 => self.tip_callout.toggle(),
+                        2 => self.warning_callout.toggle(),
+                        _ => {}
+                    }
+                    return true;
+                }
+                Key::Left | Key::Char('h') => {
+                    match self.focused_idx {
+                        0 => self.note_callout.collapse(),
+                        1 => self.tip_callout.collapse(),
+                        2 => self.warning_callout.collapse(),
+                        _ => {}
+                    }
+                    return true;
+                }
+                Key::Right | Key::Char('l') => {
+                    match self.focused_idx {
+                        0 => self.note_callout.expand(),
+                        1 => self.tip_callout.expand(),
+                        2 => self.warning_callout.expand(),
+                        _ => {}
+                    }
+                    return true;
+                }
+                _ => {}
+            }
+        }
+
+        false
+    }
+
+    fn render_tabs(&self) -> impl View {
+        let mut tabs = hstack().gap(2);
+
+        for (i, tab) in ViewTab::all().iter().enumerate() {
+            let label = format!("[{}] {}", i + 1, tab.name());
+            let text = if *tab == self.tab {
+                Text::new(label).fg(Color::CYAN).bold()
+            } else {
+                Text::new(label).fg(Color::rgb(128, 128, 128))
+            };
+            tabs = tabs.child(text);
+        }
+
+        tabs
+    }
+
+    fn render_types_demo(&self) -> impl View {
+        vstack()
+            .gap(1)
+            .child(Text::new("All Callout Types:").bold())
+            .child(Text::new(""))
+            .child(Callout::note(
+                "This is a note callout for general information.",
+            ))
+            .child(Text::new(""))
+            .child(Callout::tip(
+                "This is a tip callout for helpful suggestions.",
+            ))
+            .child(Text::new(""))
+            .child(Callout::important(
+                "This is an important callout for key information.",
+            ))
+            .child(Text::new(""))
+            .child(Callout::warning(
+                "This is a warning callout for potential issues.",
+            ))
+            .child(Text::new(""))
+            .child(Callout::danger(
+                "This is a danger callout for critical warnings.",
+            ))
+            .child(Text::new(""))
+            .child(Callout::info(
+                "This is an info callout for supplementary details.",
+            ))
+    }
+
+    fn render_variants_demo(&self) -> impl View {
+        vstack()
+            .gap(1)
+            .child(Text::new("Callout Variants:").bold())
+            .child(Text::new(""))
+            .child(Text::new("Filled (default):").fg(Color::rgb(150, 150, 150)))
+            .child(
+                Callout::tip("Filled variant with background color.")
+                    .variant(CalloutVariant::Filled),
+            )
+            .child(Text::new(""))
+            .child(Text::new("Left Border:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                Callout::warning("Left border variant - minimal with accent.")
+                    .variant(CalloutVariant::LeftBorder),
+            )
+            .child(Text::new(""))
+            .child(Text::new("Minimal:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                Callout::info("Minimal variant - just icon and text.")
+                    .variant(CalloutVariant::Minimal),
+            )
+            .child(Text::new(""))
+            .child(Text::new("Custom Title and Icon:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                Callout::note("You can customize the title and icon.")
+                    .title("Custom Title")
+                    .custom_icon('*'),
+            )
+            .child(Text::new(""))
+            .child(Text::new("No Icon:").fg(Color::rgb(150, 150, 150)))
+            .child(Callout::important("Callout without icon.").icon(false))
+    }
+
+    fn render_collapsible_demo(&self) -> impl View {
+        let indicator = |idx: usize, expanded: bool| -> Text {
+            let arrow = if expanded { "[-]" } else { "[+]" };
+            if idx == self.focused_idx {
+                Text::new(format!(" > {}", arrow)).fg(Color::CYAN)
+            } else {
+                Text::new(format!("   {}", arrow)).fg(Color::rgb(100, 100, 100))
+            }
+        };
+
+        vstack()
+            .gap(1)
+            .child(Text::new("Collapsible Callouts:").bold())
+            .child(Text::new(
+                "(j/k or arrows: navigate, Space/Enter: toggle, h/l: collapse/expand)",
+            ))
+            .child(Text::new(""))
+            .child(indicator(0, self.note_callout.is_expanded()))
+            .child(self.note_callout.clone())
+            .child(Text::new(""))
+            .child(indicator(1, self.tip_callout.is_expanded()))
+            .child(self.tip_callout.clone())
+            .child(Text::new(""))
+            .child(indicator(2, self.warning_callout.is_expanded()))
+            .child(self.warning_callout.clone())
+    }
+}
+
+impl View for CalloutDemo {
+    fn render(&self, ctx: &mut RenderContext) {
+        let header = hstack()
+            .child(Text::new(" Callout Widget Demo ").fg(Color::CYAN).bold())
+            .child(Text::new(" | Tab/Shift+Tab or 1-3 to switch").fg(Color::rgb(100, 100, 100)));
+
+        let tabs = self.render_tabs();
+
+        let content = match self.tab {
+            ViewTab::Types => Border::rounded()
+                .title("Callout Types")
+                .child(self.render_types_demo()),
+            ViewTab::Variants => Border::rounded()
+                .title("Callout Variants")
+                .child(self.render_variants_demo()),
+            ViewTab::Collapsible => Border::rounded()
+                .title("Collapsible Callouts")
+                .child(self.render_collapsible_demo()),
+        };
+
+        let help =
+            Text::new("Press 'q' to quit | Tab: next | Shift+Tab: prev").fg(Color::rgb(80, 80, 80));
+
+        vstack()
+            .child(header)
+            .child(tabs)
+            .child(Text::new(""))
+            .child(content)
+            .child(Text::new(""))
+            .child(help)
+            .render(ctx);
+    }
+}
+
+fn main() -> Result<()> {
+    let mut app = App::builder().build();
+    let demo = CalloutDemo::new();
+
+    app.run_with_handler(demo, |key_event, demo| demo.handle_key(&key_event.key))
+}

--- a/src/widget/callout.rs
+++ b/src/widget/callout.rs
@@ -1,0 +1,911 @@
+//! Callout widget for highlighting important information blocks
+//!
+//! Provides consistent styling for notes, tips, warnings, and other important
+//! information in documentation and applications.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use revue::widget::{Callout, CalloutType, callout};
+//!
+//! // Basic note callout
+//! Callout::note("This is important information.");
+//!
+//! // Warning with title
+//! Callout::warning("Proceed with caution")
+//!     .title("Warning");
+//!
+//! // Collapsible tip
+//! callout("Click to expand details")
+//!     .callout_type(CalloutType::Tip)
+//!     .collapsible(true);
+//!
+//! // Custom icon
+//! Callout::info("Custom icon example")
+//!     .custom_icon('💡');
+//! ```
+
+use super::traits::{RenderContext, View, WidgetProps, WidgetState};
+use crate::event::Key;
+use crate::render::{Cell, Modifier};
+use crate::style::Color;
+use crate::{impl_props_builders, impl_state_builders, impl_styled_view};
+
+/// Callout type determines the styling and default icon
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CalloutType {
+    /// Informational note (blue) - general information
+    #[default]
+    Note,
+    /// Helpful tip (green) - suggestions and best practices
+    Tip,
+    /// Important notice (purple) - highlights key information
+    Important,
+    /// Warning message (yellow/orange) - potential issues
+    Warning,
+    /// Danger/caution (red) - critical warnings
+    Danger,
+    /// Info message (cyan) - supplementary information
+    Info,
+}
+
+impl CalloutType {
+    /// Get the default icon for this callout type
+    pub fn icon(&self) -> char {
+        match self {
+            CalloutType::Note => '📝',
+            CalloutType::Tip => '💡',
+            CalloutType::Important => '❗',
+            CalloutType::Warning => '⚠',
+            CalloutType::Danger => '🔴',
+            CalloutType::Info => 'ℹ',
+        }
+    }
+
+    /// Get the accent color for this callout type
+    pub fn accent_color(&self) -> Color {
+        match self {
+            CalloutType::Note => Color::rgb(59, 130, 246), // Blue
+            CalloutType::Tip => Color::rgb(34, 197, 94),   // Green
+            CalloutType::Important => Color::rgb(168, 85, 247), // Purple
+            CalloutType::Warning => Color::rgb(234, 179, 8), // Yellow
+            CalloutType::Danger => Color::rgb(239, 68, 68), // Red
+            CalloutType::Info => Color::rgb(6, 182, 212),  // Cyan
+        }
+    }
+
+    /// Get the background color for this callout type
+    pub fn bg_color(&self) -> Color {
+        match self {
+            CalloutType::Note => Color::rgb(23, 37, 53), // Dark blue
+            CalloutType::Tip => Color::rgb(20, 40, 28),  // Dark green
+            CalloutType::Important => Color::rgb(35, 25, 50), // Dark purple
+            CalloutType::Warning => Color::rgb(45, 38, 15), // Dark yellow
+            CalloutType::Danger => Color::rgb(50, 20, 20), // Dark red
+            CalloutType::Info => Color::rgb(15, 40, 45), // Dark cyan
+        }
+    }
+
+    /// Get the title text color for this callout type
+    pub fn title_color(&self) -> Color {
+        self.accent_color()
+    }
+
+    /// Get the default title for this callout type
+    pub fn default_title(&self) -> &'static str {
+        match self {
+            CalloutType::Note => "Note",
+            CalloutType::Tip => "Tip",
+            CalloutType::Important => "Important",
+            CalloutType::Warning => "Warning",
+            CalloutType::Danger => "Danger",
+            CalloutType::Info => "Info",
+        }
+    }
+}
+
+/// Visual variant for the callout
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CalloutVariant {
+    /// Filled background with accent border
+    #[default]
+    Filled,
+    /// Only left border accent, no background
+    LeftBorder,
+    /// Minimal style with just icon and text
+    Minimal,
+}
+
+/// A callout widget for highlighting important information
+///
+/// Provides predefined styles for notes, tips, warnings, and other
+/// important information blocks commonly used in documentation.
+#[derive(Clone)]
+pub struct Callout {
+    /// Main content text
+    content: String,
+    /// Optional title (defaults to type name)
+    title: Option<String>,
+    /// Callout type
+    callout_type: CalloutType,
+    /// Visual variant
+    variant: CalloutVariant,
+    /// Show icon
+    show_icon: bool,
+    /// Custom icon override
+    custom_icon: Option<char>,
+    /// Whether the callout is collapsible
+    collapsible: bool,
+    /// Whether the callout is expanded (when collapsible)
+    expanded: bool,
+    /// Icon when collapsed
+    collapsed_icon: char,
+    /// Icon when expanded
+    expanded_icon: char,
+    /// Widget state
+    state: WidgetState,
+    /// Widget properties
+    props: WidgetProps,
+}
+
+impl Callout {
+    /// Create a new callout with content
+    pub fn new(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            title: None,
+            callout_type: CalloutType::default(),
+            variant: CalloutVariant::default(),
+            show_icon: true,
+            custom_icon: None,
+            collapsible: false,
+            expanded: true,
+            collapsed_icon: '▶',
+            expanded_icon: '▼',
+            state: WidgetState::new(),
+            props: WidgetProps::new(),
+        }
+    }
+
+    /// Create a note callout
+    pub fn note(content: impl Into<String>) -> Self {
+        Self::new(content).callout_type(CalloutType::Note)
+    }
+
+    /// Create a tip callout
+    pub fn tip(content: impl Into<String>) -> Self {
+        Self::new(content).callout_type(CalloutType::Tip)
+    }
+
+    /// Create an important callout
+    pub fn important(content: impl Into<String>) -> Self {
+        Self::new(content).callout_type(CalloutType::Important)
+    }
+
+    /// Create a warning callout
+    pub fn warning(content: impl Into<String>) -> Self {
+        Self::new(content).callout_type(CalloutType::Warning)
+    }
+
+    /// Create a danger callout
+    pub fn danger(content: impl Into<String>) -> Self {
+        Self::new(content).callout_type(CalloutType::Danger)
+    }
+
+    /// Create an info callout
+    pub fn info(content: impl Into<String>) -> Self {
+        Self::new(content).callout_type(CalloutType::Info)
+    }
+
+    /// Set the callout type
+    pub fn callout_type(mut self, callout_type: CalloutType) -> Self {
+        self.callout_type = callout_type;
+        self
+    }
+
+    /// Set the title (overrides default type title)
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Set the visual variant
+    pub fn variant(mut self, variant: CalloutVariant) -> Self {
+        self.variant = variant;
+        self
+    }
+
+    /// Show/hide the icon
+    pub fn icon(mut self, show: bool) -> Self {
+        self.show_icon = show;
+        self
+    }
+
+    /// Set a custom icon
+    pub fn custom_icon(mut self, icon: char) -> Self {
+        self.custom_icon = Some(icon);
+        self.show_icon = true;
+        self
+    }
+
+    /// Make the callout collapsible
+    pub fn collapsible(mut self, collapsible: bool) -> Self {
+        self.collapsible = collapsible;
+        self
+    }
+
+    /// Set the expanded state (for collapsible callouts)
+    pub fn expanded(mut self, expanded: bool) -> Self {
+        self.expanded = expanded;
+        self
+    }
+
+    /// Set custom collapse/expand icons
+    pub fn collapse_icons(mut self, collapsed: char, expanded: char) -> Self {
+        self.collapsed_icon = collapsed;
+        self.expanded_icon = expanded;
+        self
+    }
+
+    /// Toggle expanded state
+    pub fn toggle(&mut self) {
+        if self.collapsible {
+            self.expanded = !self.expanded;
+        }
+    }
+
+    /// Expand the callout
+    pub fn expand(&mut self) {
+        self.expanded = true;
+    }
+
+    /// Collapse the callout
+    pub fn collapse(&mut self) {
+        self.expanded = false;
+    }
+
+    /// Check if expanded
+    pub fn is_expanded(&self) -> bool {
+        self.expanded
+    }
+
+    /// Check if collapsible
+    pub fn is_collapsible(&self) -> bool {
+        self.collapsible
+    }
+
+    /// Set expanded state mutably
+    pub fn set_expanded(&mut self, expanded: bool) {
+        self.expanded = expanded;
+    }
+
+    /// Get the icon to display
+    fn get_icon(&self) -> char {
+        self.custom_icon.unwrap_or_else(|| self.callout_type.icon())
+    }
+
+    /// Get the collapse icon based on state
+    fn collapse_icon(&self) -> char {
+        if self.expanded {
+            self.expanded_icon
+        } else {
+            self.collapsed_icon
+        }
+    }
+
+    /// Get the title to display
+    fn get_title(&self) -> &str {
+        self.title
+            .as_deref()
+            .unwrap_or_else(|| self.callout_type.default_title())
+    }
+
+    /// Calculate the height needed for this callout
+    pub fn height(&self) -> u16 {
+        if self.collapsible && !self.expanded {
+            return 1; // Just header
+        }
+
+        let content_lines = self.content.lines().count().max(1) as u16;
+
+        match self.variant {
+            CalloutVariant::Filled => {
+                // top border + title + content + bottom border
+                2 + content_lines + 1
+            }
+            CalloutVariant::LeftBorder => {
+                // title + content
+                1 + content_lines
+            }
+            CalloutVariant::Minimal => {
+                // title + content (no borders)
+                1 + content_lines
+            }
+        }
+    }
+
+    /// Handle keyboard input
+    ///
+    /// Returns `true` if the key was handled.
+    pub fn handle_key(&mut self, key: &Key) -> bool {
+        if !self.collapsible || self.state.disabled {
+            return false;
+        }
+
+        match key {
+            Key::Enter | Key::Char(' ') => {
+                self.toggle();
+                true
+            }
+            Key::Right | Key::Char('l') => {
+                self.expand();
+                true
+            }
+            Key::Left | Key::Char('h') => {
+                self.collapse();
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Default for Callout {
+    fn default() -> Self {
+        Self::new("Callout")
+    }
+}
+
+impl View for Callout {
+    crate::impl_view_meta!("Callout");
+
+    fn render(&self, ctx: &mut RenderContext) {
+        let area = ctx.area;
+        if area.width < 5 || area.height < 1 {
+            return;
+        }
+
+        let accent_color = self.callout_type.accent_color();
+        let bg_color = self.callout_type.bg_color();
+        let title_color = self.callout_type.title_color();
+
+        match self.variant {
+            CalloutVariant::Filled => {
+                self.render_filled(ctx, accent_color, bg_color, title_color);
+            }
+            CalloutVariant::LeftBorder => {
+                self.render_left_border(ctx, accent_color, title_color);
+            }
+            CalloutVariant::Minimal => {
+                self.render_minimal(ctx, accent_color, title_color);
+            }
+        }
+    }
+}
+
+impl Callout {
+    fn render_filled(
+        &self,
+        ctx: &mut RenderContext,
+        accent_color: Color,
+        bg_color: Color,
+        title_color: Color,
+    ) {
+        let area = ctx.area;
+
+        // Fill background
+        for y in area.y..area.y + area.height {
+            for x in area.x..area.x + area.width {
+                let mut cell = Cell::new(' ');
+                cell.bg = Some(bg_color);
+                ctx.buffer.set(x, y, cell);
+            }
+        }
+
+        // Draw left accent border
+        for y in area.y..area.y + area.height {
+            let mut cell = Cell::new('┃');
+            cell.fg = Some(accent_color);
+            cell.bg = Some(bg_color);
+            ctx.buffer.set(area.x, y, cell);
+        }
+
+        // Header line
+        let mut x = area.x + 2;
+        let y = area.y;
+
+        // Collapse icon (if collapsible)
+        if self.collapsible {
+            let mut icon_cell = Cell::new(self.collapse_icon());
+            icon_cell.fg = Some(title_color);
+            icon_cell.bg = Some(bg_color);
+            ctx.buffer.set(x, y, icon_cell);
+            x += 2;
+        }
+
+        // Type icon
+        if self.show_icon {
+            let icon = self.get_icon();
+            let mut icon_cell = Cell::new(icon);
+            icon_cell.fg = Some(accent_color);
+            icon_cell.bg = Some(bg_color);
+            ctx.buffer.set(x, y, icon_cell);
+            x += 2;
+        }
+
+        // Title
+        let title = self.get_title();
+        for ch in title.chars() {
+            if x >= area.x + area.width - 1 {
+                break;
+            }
+            let mut cell = Cell::new(ch);
+            cell.fg = Some(title_color);
+            cell.bg = Some(bg_color);
+            cell.modifier |= Modifier::BOLD;
+            ctx.buffer.set(x, y, cell);
+            x += 1;
+        }
+
+        // Content (if expanded or not collapsible)
+        if !self.collapsible || self.expanded {
+            let content_x = area.x + 2;
+            let content_width = area.width.saturating_sub(3);
+
+            for (i, line) in self.content.lines().enumerate() {
+                let line_y = area.y + 1 + i as u16;
+                if line_y >= area.y + area.height {
+                    break;
+                }
+
+                for (j, ch) in line.chars().enumerate() {
+                    if j as u16 >= content_width {
+                        break;
+                    }
+                    let mut cell = Cell::new(ch);
+                    cell.fg = Some(Color::rgb(200, 200, 200));
+                    cell.bg = Some(bg_color);
+                    ctx.buffer.set(content_x + j as u16, line_y, cell);
+                }
+            }
+        }
+    }
+
+    fn render_left_border(&self, ctx: &mut RenderContext, accent_color: Color, title_color: Color) {
+        let area = ctx.area;
+
+        // Draw left accent border
+        for y in area.y..area.y + area.height {
+            let mut cell = Cell::new('┃');
+            cell.fg = Some(accent_color);
+            ctx.buffer.set(area.x, y, cell);
+        }
+
+        // Header line
+        let mut x = area.x + 2;
+        let y = area.y;
+
+        // Collapse icon (if collapsible)
+        if self.collapsible {
+            let mut icon_cell = Cell::new(self.collapse_icon());
+            icon_cell.fg = Some(title_color);
+            ctx.buffer.set(x, y, icon_cell);
+            x += 2;
+        }
+
+        // Type icon
+        if self.show_icon {
+            let icon = self.get_icon();
+            let mut icon_cell = Cell::new(icon);
+            icon_cell.fg = Some(accent_color);
+            ctx.buffer.set(x, y, icon_cell);
+            x += 2;
+        }
+
+        // Title
+        let title = self.get_title();
+        for ch in title.chars() {
+            if x >= area.x + area.width {
+                break;
+            }
+            let mut cell = Cell::new(ch);
+            cell.fg = Some(title_color);
+            cell.modifier |= Modifier::BOLD;
+            ctx.buffer.set(x, y, cell);
+            x += 1;
+        }
+
+        // Content (if expanded or not collapsible)
+        if !self.collapsible || self.expanded {
+            let content_x = area.x + 2;
+            let content_width = area.width.saturating_sub(3);
+
+            for (i, line) in self.content.lines().enumerate() {
+                let line_y = area.y + 1 + i as u16;
+                if line_y >= area.y + area.height {
+                    break;
+                }
+
+                for (j, ch) in line.chars().enumerate() {
+                    if j as u16 >= content_width {
+                        break;
+                    }
+                    let mut cell = Cell::new(ch);
+                    cell.fg = Some(Color::rgb(180, 180, 180));
+                    ctx.buffer.set(content_x + j as u16, line_y, cell);
+                }
+            }
+        }
+    }
+
+    fn render_minimal(&self, ctx: &mut RenderContext, accent_color: Color, title_color: Color) {
+        let area = ctx.area;
+
+        // Header line
+        let mut x = area.x;
+        let y = area.y;
+
+        // Collapse icon (if collapsible)
+        if self.collapsible {
+            let mut icon_cell = Cell::new(self.collapse_icon());
+            icon_cell.fg = Some(title_color);
+            ctx.buffer.set(x, y, icon_cell);
+            x += 2;
+        }
+
+        // Type icon
+        if self.show_icon {
+            let icon = self.get_icon();
+            let mut icon_cell = Cell::new(icon);
+            icon_cell.fg = Some(accent_color);
+            ctx.buffer.set(x, y, icon_cell);
+            x += 2;
+        }
+
+        // Title
+        let title = self.get_title();
+        for ch in title.chars() {
+            if x >= area.x + area.width {
+                break;
+            }
+            let mut cell = Cell::new(ch);
+            cell.fg = Some(title_color);
+            cell.modifier |= Modifier::BOLD;
+            ctx.buffer.set(x, y, cell);
+            x += 1;
+        }
+
+        // Content (if expanded or not collapsible)
+        if !self.collapsible || self.expanded {
+            let content_x = if self.show_icon { area.x + 2 } else { area.x };
+            let content_width = area
+                .width
+                .saturating_sub(if self.show_icon { 2 } else { 0 });
+
+            for (i, line) in self.content.lines().enumerate() {
+                let line_y = area.y + 1 + i as u16;
+                if line_y >= area.y + area.height {
+                    break;
+                }
+
+                for (j, ch) in line.chars().enumerate() {
+                    if j as u16 >= content_width {
+                        break;
+                    }
+                    let mut cell = Cell::new(ch);
+                    cell.fg = Some(Color::rgb(180, 180, 180));
+                    ctx.buffer.set(content_x + j as u16, line_y, cell);
+                }
+            }
+        }
+    }
+}
+
+impl_styled_view!(Callout);
+impl_state_builders!(Callout);
+impl_props_builders!(Callout);
+
+/// Helper function to create a Callout
+pub fn callout(content: impl Into<String>) -> Callout {
+    Callout::new(content)
+}
+
+/// Helper function to create a note Callout
+pub fn note(content: impl Into<String>) -> Callout {
+    Callout::note(content)
+}
+
+/// Helper function to create a tip Callout
+pub fn tip(content: impl Into<String>) -> Callout {
+    Callout::tip(content)
+}
+
+/// Helper function to create an important Callout
+pub fn important(content: impl Into<String>) -> Callout {
+    Callout::important(content)
+}
+
+/// Helper function to create a warning Callout
+pub fn warning_callout(content: impl Into<String>) -> Callout {
+    Callout::warning(content)
+}
+
+/// Helper function to create a danger Callout
+pub fn danger(content: impl Into<String>) -> Callout {
+    Callout::danger(content)
+}
+
+/// Helper function to create an info Callout
+pub fn info_callout(content: impl Into<String>) -> Callout {
+    Callout::info(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::Rect;
+    use crate::render::Buffer;
+
+    #[test]
+    fn test_callout_new() {
+        let c = Callout::new("Test content");
+        assert_eq!(c.content, "Test content");
+        assert_eq!(c.callout_type, CalloutType::Note);
+        assert!(c.title.is_none());
+        assert!(!c.collapsible);
+        assert!(c.expanded);
+    }
+
+    #[test]
+    fn test_callout_type_helpers() {
+        assert_eq!(Callout::note("msg").callout_type, CalloutType::Note);
+        assert_eq!(Callout::tip("msg").callout_type, CalloutType::Tip);
+        assert_eq!(
+            Callout::important("msg").callout_type,
+            CalloutType::Important
+        );
+        assert_eq!(Callout::warning("msg").callout_type, CalloutType::Warning);
+        assert_eq!(Callout::danger("msg").callout_type, CalloutType::Danger);
+        assert_eq!(Callout::info("msg").callout_type, CalloutType::Info);
+    }
+
+    #[test]
+    fn test_callout_builders() {
+        let c = Callout::new("Content")
+            .title("Custom Title")
+            .callout_type(CalloutType::Warning)
+            .variant(CalloutVariant::LeftBorder)
+            .collapsible(true)
+            .expanded(false)
+            .icon(false);
+
+        assert_eq!(c.title, Some("Custom Title".to_string()));
+        assert_eq!(c.callout_type, CalloutType::Warning);
+        assert_eq!(c.variant, CalloutVariant::LeftBorder);
+        assert!(c.collapsible);
+        assert!(!c.expanded);
+        assert!(!c.show_icon);
+    }
+
+    #[test]
+    fn test_callout_toggle() {
+        let mut c = Callout::new("Test").collapsible(true);
+        assert!(c.is_expanded());
+
+        c.toggle();
+        assert!(!c.is_expanded());
+
+        c.toggle();
+        assert!(c.is_expanded());
+    }
+
+    #[test]
+    fn test_callout_toggle_not_collapsible() {
+        let mut c = Callout::new("Test").collapsible(false);
+        assert!(c.is_expanded());
+
+        c.toggle(); // Should not change
+        assert!(c.is_expanded());
+    }
+
+    #[test]
+    fn test_callout_expand_collapse() {
+        let mut c = Callout::new("Test").collapsible(true).expanded(false);
+
+        c.expand();
+        assert!(c.is_expanded());
+
+        c.collapse();
+        assert!(!c.is_expanded());
+    }
+
+    #[test]
+    fn test_callout_height() {
+        // Collapsed
+        let collapsed = Callout::new("Content").collapsible(true).expanded(false);
+        assert_eq!(collapsed.height(), 1);
+
+        // Filled with single line content
+        let filled = Callout::new("Single line").variant(CalloutVariant::Filled);
+        assert_eq!(filled.height(), 4); // border + title + content + border
+
+        // Filled with multi-line content
+        let multi = Callout::new("Line 1\nLine 2\nLine 3").variant(CalloutVariant::Filled);
+        assert_eq!(multi.height(), 6); // border + title + 3 content lines + border
+
+        // Left border variant
+        let left = Callout::new("Content").variant(CalloutVariant::LeftBorder);
+        assert_eq!(left.height(), 2); // title + content
+
+        // Minimal variant
+        let minimal = Callout::new("Content").variant(CalloutVariant::Minimal);
+        assert_eq!(minimal.height(), 2); // title + content
+    }
+
+    #[test]
+    fn test_callout_handle_key() {
+        let mut c = Callout::new("Test").collapsible(true);
+
+        assert!(c.handle_key(&Key::Enter));
+        assert!(!c.is_expanded());
+
+        assert!(c.handle_key(&Key::Char(' ')));
+        assert!(c.is_expanded());
+
+        assert!(c.handle_key(&Key::Left));
+        assert!(!c.is_expanded());
+
+        assert!(c.handle_key(&Key::Right));
+        assert!(c.is_expanded());
+
+        assert!(!c.handle_key(&Key::Up)); // Not handled
+    }
+
+    #[test]
+    fn test_callout_handle_key_not_collapsible() {
+        let mut c = Callout::new("Test").collapsible(false);
+
+        assert!(!c.handle_key(&Key::Enter));
+        assert!(c.is_expanded()); // Should not change
+    }
+
+    #[test]
+    fn test_callout_handle_key_disabled() {
+        let mut c = Callout::new("Test").collapsible(true).disabled(true);
+
+        assert!(!c.handle_key(&Key::Enter));
+        assert!(c.is_expanded());
+    }
+
+    #[test]
+    fn test_callout_type_icons() {
+        assert_eq!(CalloutType::Note.icon(), '📝');
+        assert_eq!(CalloutType::Tip.icon(), '💡');
+        assert_eq!(CalloutType::Important.icon(), '❗');
+        assert_eq!(CalloutType::Warning.icon(), '⚠');
+        assert_eq!(CalloutType::Danger.icon(), '🔴');
+        assert_eq!(CalloutType::Info.icon(), 'ℹ');
+    }
+
+    #[test]
+    fn test_callout_type_default_titles() {
+        assert_eq!(CalloutType::Note.default_title(), "Note");
+        assert_eq!(CalloutType::Tip.default_title(), "Tip");
+        assert_eq!(CalloutType::Important.default_title(), "Important");
+        assert_eq!(CalloutType::Warning.default_title(), "Warning");
+        assert_eq!(CalloutType::Danger.default_title(), "Danger");
+        assert_eq!(CalloutType::Info.default_title(), "Info");
+    }
+
+    #[test]
+    fn test_callout_custom_icon() {
+        let c = Callout::new("Test").custom_icon('★');
+        assert_eq!(c.get_icon(), '★');
+        assert!(c.show_icon);
+    }
+
+    #[test]
+    fn test_callout_get_title() {
+        let default_title = Callout::note("Test");
+        assert_eq!(default_title.get_title(), "Note");
+
+        let custom_title = Callout::note("Test").title("Custom");
+        assert_eq!(custom_title.get_title(), "Custom");
+    }
+
+    #[test]
+    fn test_callout_collapse_icons() {
+        let c = Callout::new("Test")
+            .collapsible(true)
+            .collapse_icons('+', '-');
+
+        assert_eq!(c.collapsed_icon, '+');
+        assert_eq!(c.expanded_icon, '-');
+        assert_eq!(c.collapse_icon(), '-'); // expanded by default
+    }
+
+    #[test]
+    fn test_callout_render_filled() {
+        let mut buffer = Buffer::new(50, 5);
+        let area = Rect::new(0, 0, 50, 5);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let c = Callout::note("Test content").variant(CalloutVariant::Filled);
+        c.render(&mut ctx);
+
+        // Check left accent border
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, '┃');
+    }
+
+    #[test]
+    fn test_callout_render_left_border() {
+        let mut buffer = Buffer::new(50, 3);
+        let area = Rect::new(0, 0, 50, 3);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let c = Callout::tip("Test").variant(CalloutVariant::LeftBorder);
+        c.render(&mut ctx);
+
+        // Check left accent border
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, '┃');
+    }
+
+    #[test]
+    fn test_callout_render_minimal() {
+        let mut buffer = Buffer::new(50, 3);
+        let area = Rect::new(0, 0, 50, 3);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let c = Callout::warning("Test").variant(CalloutVariant::Minimal);
+        c.render(&mut ctx);
+
+        // Check icon
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, '⚠');
+    }
+
+    #[test]
+    fn test_callout_render_collapsed() {
+        let mut buffer = Buffer::new(50, 5);
+        let area = Rect::new(0, 0, 50, 5);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let c = Callout::note("Hidden content")
+            .collapsible(true)
+            .expanded(false)
+            .variant(CalloutVariant::Filled);
+        c.render(&mut ctx);
+
+        // Only header should be rendered
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, '┃');
+    }
+
+    #[test]
+    fn test_callout_helpers() {
+        let c = callout("msg");
+        assert_eq!(c.content, "msg");
+
+        let n = note("note");
+        assert_eq!(n.callout_type, CalloutType::Note);
+
+        let t = tip("tip");
+        assert_eq!(t.callout_type, CalloutType::Tip);
+
+        let i = important("important");
+        assert_eq!(i.callout_type, CalloutType::Important);
+
+        let w = warning_callout("warning");
+        assert_eq!(w.callout_type, CalloutType::Warning);
+
+        let d = danger("danger");
+        assert_eq!(d.callout_type, CalloutType::Danger);
+
+        let info = info_callout("info");
+        assert_eq!(info.callout_type, CalloutType::Info);
+    }
+
+    #[test]
+    fn test_callout_default() {
+        let c = Callout::default();
+        assert_eq!(c.content, "Callout");
+    }
+}

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -56,6 +56,7 @@
 //! | [`Breadcrumb`] | Navigation trail | [`breadcrumb()`] |
 //! | [`Stepper`] | Step indicator | [`stepper()`] |
 //! | [`Alert`] | Persistent feedback | [`alert()`] |
+//! | [`Callout`] | Info highlight block | [`callout()`], [`note()`], [`tip()`] |
 //!
 //! ## Data Widgets
 //!
@@ -173,6 +174,7 @@ mod border;
 mod breadcrumb;
 mod button;
 mod calendar;
+mod callout;
 mod candlechart;
 mod canvas;
 mod chart;
@@ -276,6 +278,10 @@ pub use border::{border, Border, BorderType};
 pub use breadcrumb::{breadcrumb, crumb, Breadcrumb, BreadcrumbItem, SeparatorStyle};
 pub use button::{button, Button, ButtonVariant};
 pub use calendar::{calendar, Calendar, CalendarMode, Date, DateMarker, FirstDayOfWeek};
+pub use callout::{
+    callout, danger, important, info_callout, note, tip, warning_callout, Callout, CalloutType,
+    CalloutVariant,
+};
 pub use candlechart::{candle_chart, ohlc_chart, Candle, CandleChart, ChartStyle as CandleStyle};
 pub use canvas::{
     braille_canvas, canvas, BrailleCanvas, BrailleContext, BrailleGrid, Canvas, Circle,


### PR DESCRIPTION
## Summary

Add a Callout widget for highlighting important information blocks, commonly used in documentation and applications.

- Predefined types: Note, Tip, Important, Warning, Danger, Info
- Three visual variants: Filled, LeftBorder, Minimal
- Custom icon support
- Collapsible functionality with expand/collapse toggle
- Left border accent color by type
- Background color tinting

## Related Issue

Closes #39

## Test plan

- [x] Unit tests for all callout types and variants
- [x] Tests for collapsible functionality
- [x] Tests for keyboard handling
- [x] Render tests for all variants
- [x] Example: `cargo run --example callout`