### PR TITLE
docs: add missing widget docs and examples

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -407,6 +407,65 @@ progress()
     .label(format!("{}%", progress.get()))
 ```
 
+#### Alert
+
+```rust
+// Basic alerts by level
+info_alert("Operation completed")
+success_alert("File saved successfully")
+warning_alert("Connection unstable")
+error_alert("Failed to load data")
+
+// Alert variants
+alert("Custom message")
+    .level(AlertLevel::Warning)
+    .variant(AlertVariant::Filled)    // Filled background
+    .variant(AlertVariant::Outlined)  // Border only
+    .variant(AlertVariant::Minimal)   // Icon and text only
+    .dismissible(true)                // Can be dismissed
+    .icon(false)                      // Hide icon
+    .custom_icon('⚠')                 // Custom icon character
+    .title("Warning")                 // Add title
+```
+
+#### Callout
+
+```rust
+// Callout types for documentation-style highlights
+note("General information for the reader")
+tip("Helpful suggestion or best practice")
+important("Key information to remember")
+warning_callout("Potential issues to watch for")
+danger("Critical warning - proceed with caution")
+
+// Callout variants
+Callout::note("Content here")
+    .variant(CalloutVariant::Filled)      // Filled background
+    .variant(CalloutVariant::LeftBorder)  // Left accent border
+    .variant(CalloutVariant::Minimal)     // Icon and text only
+    .collapsible(true)                    // Can collapse/expand
+    .title("Custom Title")                // Override default title
+```
+
+#### StatusIndicator
+
+```rust
+// Status states
+online()                    // Green dot
+offline()                   // Gray dot
+busy_indicator()            // Red dot
+away_indicator()            // Yellow dot
+
+// Display styles
+status_indicator(Status::Online)
+    .indicator_style(StatusStyle::Dot)          // Just the dot
+    .indicator_style(StatusStyle::DotWithLabel) // Dot + "Online"
+    .indicator_style(StatusStyle::Badge)        // Colored badge
+    .size(StatusSize::Small)                    // sm/md/lg
+    .label("Available")                         // Custom label
+    .pulsing(true)                              // Animated pulse
+```
+
 ### Content Widgets
 
 #### Markdown

--- a/examples/alert.rs
+++ b/examples/alert.rs
@@ -1,0 +1,242 @@
+//! Alert Widget Demo - Demonstrates alert levels and variants
+//!
+//! Run with: cargo run --example alert
+
+use revue::prelude::*;
+use revue::widget::{
+    alert, error_alert, info_alert, success_alert, warning_alert, Alert, AlertLevel, AlertVariant,
+    Text,
+};
+
+/// Current view mode
+#[derive(Clone, Copy, PartialEq)]
+enum ViewTab {
+    Levels,
+    Variants,
+    Features,
+}
+
+impl ViewTab {
+    fn name(&self) -> &str {
+        match self {
+            ViewTab::Levels => "Levels",
+            ViewTab::Variants => "Variants",
+            ViewTab::Features => "Features",
+        }
+    }
+
+    fn all() -> &'static [ViewTab] {
+        &[ViewTab::Levels, ViewTab::Variants, ViewTab::Features]
+    }
+}
+
+/// Demo application state
+struct AlertDemo {
+    tab: ViewTab,
+    dismissed: [bool; 4],
+}
+
+impl AlertDemo {
+    fn new() -> Self {
+        Self {
+            tab: ViewTab::Levels,
+            dismissed: [false; 4],
+        }
+    }
+
+    fn handle_key(&mut self, key: &Key) -> bool {
+        match key {
+            Key::Char('1') => {
+                self.tab = ViewTab::Levels;
+                true
+            }
+            Key::Char('2') => {
+                self.tab = ViewTab::Variants;
+                true
+            }
+            Key::Char('3') => {
+                self.tab = ViewTab::Features;
+                true
+            }
+            Key::Char('r') => {
+                self.dismissed = [false; 4];
+                true
+            }
+            Key::Char('d') => {
+                // Dismiss next non-dismissed alert
+                for d in &mut self.dismissed {
+                    if !*d {
+                        *d = true;
+                        break;
+                    }
+                }
+                true
+            }
+            Key::Tab => {
+                let tabs = ViewTab::all();
+                let idx = tabs.iter().position(|&t| t == self.tab).unwrap_or(0);
+                self.tab = tabs[(idx + 1) % tabs.len()];
+                true
+            }
+            Key::BackTab => {
+                let tabs = ViewTab::all();
+                let idx = tabs.iter().position(|&t| t == self.tab).unwrap_or(0);
+                self.tab = tabs[(idx + tabs.len() - 1) % tabs.len()];
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn render_tabs(&self) -> impl View {
+        let mut tabs = hstack().gap(2);
+
+        for (i, tab) in ViewTab::all().iter().enumerate() {
+            let label = format!("[{}] {}", i + 1, tab.name());
+            let text = if *tab == self.tab {
+                Text::new(label).fg(Color::CYAN).bold()
+            } else {
+                Text::new(label).fg(Color::rgb(128, 128, 128))
+            };
+            tabs = tabs.child(text);
+        }
+
+        tabs
+    }
+
+    fn render_levels_demo(&self) -> impl View {
+        vstack()
+            .gap(1)
+            .child(Text::new("Alert Levels:").bold())
+            .child(Text::new(""))
+            .child(info_alert("This is an informational message."))
+            .child(Text::new(""))
+            .child(success_alert("Operation completed successfully!"))
+            .child(Text::new(""))
+            .child(warning_alert("Please review before continuing."))
+            .child(Text::new(""))
+            .child(error_alert("An error occurred. Please try again."))
+    }
+
+    fn render_variants_demo(&self) -> impl View {
+        vstack()
+            .gap(1)
+            .child(Text::new("Alert Variants:").bold())
+            .child(Text::new(""))
+            .child(Text::new("Filled (default):").fg(Color::rgb(150, 150, 150)))
+            .child(
+                alert("Filled variant with background color")
+                    .level(AlertLevel::Info)
+                    .variant(AlertVariant::Filled),
+            )
+            .child(Text::new(""))
+            .child(Text::new("Outlined:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                alert("Outlined variant with border")
+                    .level(AlertLevel::Success)
+                    .variant(AlertVariant::Outlined),
+            )
+            .child(Text::new(""))
+            .child(Text::new("Minimal:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                alert("Minimal variant - just icon and text")
+                    .level(AlertLevel::Error)
+                    .variant(AlertVariant::Minimal),
+            )
+    }
+
+    fn render_features_demo(&self) -> impl View {
+        let mut stack = vstack()
+            .gap(1)
+            .child(Text::new("Alert Features:").bold())
+            .child(Text::new(""))
+            .child(Text::new("With Title:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                Alert::new("Check your inbox for the confirmation link.")
+                    .level(AlertLevel::Info)
+                    .title("Email Sent"),
+            )
+            .child(Text::new(""))
+            .child(Text::new("Custom Icon:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                alert("Your changes have been saved to the cloud.")
+                    .level(AlertLevel::Success)
+                    .custom_icon('☁'),
+            )
+            .child(Text::new(""))
+            .child(Text::new("Without Icon:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                alert("Simple message without icon.")
+                    .level(AlertLevel::Info)
+                    .icon(false),
+            )
+            .child(Text::new(""))
+            .child(
+                Text::new("Dismissible Alerts (press 'd' to dismiss, 'r' to reset):")
+                    .fg(Color::rgb(150, 150, 150)),
+            );
+
+        if !self.dismissed[0] {
+            stack = stack.child(info_alert("First dismissible alert").dismissible(true));
+        }
+        if !self.dismissed[1] {
+            stack = stack.child(success_alert("Second dismissible alert").dismissible(true));
+        }
+        if !self.dismissed[2] {
+            stack = stack.child(warning_alert("Third dismissible alert").dismissible(true));
+        }
+        if !self.dismissed[3] {
+            stack = stack.child(error_alert("Fourth dismissible alert").dismissible(true));
+        }
+
+        if self.dismissed.iter().all(|&d| d) {
+            stack = stack.child(
+                Text::new("All alerts dismissed! Press 'r' to reset.")
+                    .fg(Color::rgb(100, 100, 100)),
+            );
+        }
+
+        stack
+    }
+}
+
+impl View for AlertDemo {
+    fn render(&self, ctx: &mut RenderContext) {
+        let header = hstack()
+            .child(Text::new(" Alert Widget Demo ").fg(Color::CYAN).bold())
+            .child(Text::new(" | Tab/1-3 to switch").fg(Color::rgb(100, 100, 100)));
+
+        let tabs = self.render_tabs();
+
+        let content = match self.tab {
+            ViewTab::Levels => Border::rounded()
+                .title("Alert Levels")
+                .child(self.render_levels_demo()),
+            ViewTab::Variants => Border::rounded()
+                .title("Alert Variants")
+                .child(self.render_variants_demo()),
+            ViewTab::Features => Border::rounded()
+                .title("Alert Features")
+                .child(self.render_features_demo()),
+        };
+
+        let help = Text::new("Press 'q' to quit | Tab: next | 'd': dismiss | 'r': reset")
+            .fg(Color::rgb(80, 80, 80));
+
+        vstack()
+            .child(header)
+            .child(tabs)
+            .child(Text::new(""))
+            .child(content)
+            .child(Text::new(""))
+            .child(help)
+            .render(ctx);
+    }
+}
+
+fn main() -> Result<()> {
+    let mut app = App::builder().build();
+    let demo = AlertDemo::new();
+
+    app.run_with_handler(demo, |key_event, demo| demo.handle_key(&key_event.key))
+}

--- a/examples/status_indicator.rs
+++ b/examples/status_indicator.rs
@@ -1,0 +1,306 @@
+//! StatusIndicator Widget Demo - Demonstrates status states and styles
+//!
+//! Run with: cargo run --example status_indicator
+
+use revue::prelude::*;
+use revue::widget::{
+    away_indicator, busy_indicator, offline, online, status_indicator, Status, StatusSize,
+    StatusStyle, Text,
+};
+
+/// Current view mode
+#[derive(Clone, Copy, PartialEq)]
+enum ViewTab {
+    States,
+    Styles,
+    Sizes,
+}
+
+impl ViewTab {
+    fn name(&self) -> &str {
+        match self {
+            ViewTab::States => "States",
+            ViewTab::Styles => "Styles",
+            ViewTab::Sizes => "Sizes",
+        }
+    }
+
+    fn all() -> &'static [ViewTab] {
+        &[ViewTab::States, ViewTab::Styles, ViewTab::Sizes]
+    }
+}
+
+/// Demo application state
+struct StatusIndicatorDemo {
+    tab: ViewTab,
+    pulsing: bool,
+}
+
+impl StatusIndicatorDemo {
+    fn new() -> Self {
+        Self {
+            tab: ViewTab::States,
+            pulsing: false,
+        }
+    }
+
+    fn handle_key(&mut self, key: &Key) -> bool {
+        match key {
+            Key::Char('1') => {
+                self.tab = ViewTab::States;
+                true
+            }
+            Key::Char('2') => {
+                self.tab = ViewTab::Styles;
+                true
+            }
+            Key::Char('3') => {
+                self.tab = ViewTab::Sizes;
+                true
+            }
+            Key::Char('p') => {
+                self.pulsing = !self.pulsing;
+                true
+            }
+            Key::Tab => {
+                let tabs = ViewTab::all();
+                let idx = tabs.iter().position(|&t| t == self.tab).unwrap_or(0);
+                self.tab = tabs[(idx + 1) % tabs.len()];
+                true
+            }
+            Key::BackTab => {
+                let tabs = ViewTab::all();
+                let idx = tabs.iter().position(|&t| t == self.tab).unwrap_or(0);
+                self.tab = tabs[(idx + tabs.len() - 1) % tabs.len()];
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn render_tabs(&self) -> impl View {
+        let mut tabs = hstack().gap(2);
+
+        for (i, tab) in ViewTab::all().iter().enumerate() {
+            let label = format!("[{}] {}", i + 1, tab.name());
+            let text = if *tab == self.tab {
+                Text::new(label).fg(Color::CYAN).bold()
+            } else {
+                Text::new(label).fg(Color::rgb(128, 128, 128))
+            };
+            tabs = tabs.child(text);
+        }
+
+        tabs
+    }
+
+    fn render_states_demo(&self) -> impl View {
+        vstack()
+            .gap(1)
+            .child(Text::new("Status States:").bold())
+            .child(Text::new(""))
+            .child(
+                hstack()
+                    .gap(2)
+                    .child(online().pulsing(self.pulsing))
+                    .child(Text::new("Online - User is available")),
+            )
+            .child(Text::new(""))
+            .child(
+                hstack()
+                    .gap(2)
+                    .child(offline())
+                    .child(Text::new("Offline - User is disconnected")),
+            )
+            .child(Text::new(""))
+            .child(
+                hstack()
+                    .gap(2)
+                    .child(busy_indicator().pulsing(self.pulsing))
+                    .child(Text::new("Busy - Do not disturb")),
+            )
+            .child(Text::new(""))
+            .child(
+                hstack()
+                    .gap(2)
+                    .child(away_indicator())
+                    .child(Text::new("Away - Temporarily unavailable")),
+            )
+            .child(Text::new(""))
+            .child(
+                hstack()
+                    .gap(2)
+                    .child(status_indicator(Status::Unknown))
+                    .child(Text::new("Unknown - Status not determined")),
+            )
+            .child(Text::new(""))
+            .child(
+                hstack()
+                    .gap(2)
+                    .child(status_indicator(Status::Error).pulsing(self.pulsing))
+                    .child(Text::new("Error - Connection issue")),
+            )
+            .child(Text::new(""))
+            .child(
+                Text::new(format!(
+                    "Press 'p' to toggle pulsing (currently: {})",
+                    if self.pulsing { "ON" } else { "OFF" }
+                ))
+                .fg(Color::rgb(100, 100, 100)),
+            )
+    }
+
+    fn render_styles_demo(&self) -> impl View {
+        vstack()
+            .gap(1)
+            .child(Text::new("Display Styles:").bold())
+            .child(Text::new(""))
+            .child(Text::new("Dot (default):").fg(Color::rgb(150, 150, 150)))
+            .child(
+                hstack()
+                    .gap(4)
+                    .child(online().indicator_style(StatusStyle::Dot))
+                    .child(busy_indicator().indicator_style(StatusStyle::Dot))
+                    .child(away_indicator().indicator_style(StatusStyle::Dot))
+                    .child(offline().indicator_style(StatusStyle::Dot)),
+            )
+            .child(Text::new(""))
+            .child(Text::new("Dot with Label:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                hstack()
+                    .gap(2)
+                    .child(online().indicator_style(StatusStyle::DotWithLabel))
+                    .child(busy_indicator().indicator_style(StatusStyle::DotWithLabel))
+                    .child(away_indicator().indicator_style(StatusStyle::DotWithLabel)),
+            )
+            .child(Text::new(""))
+            .child(Text::new("Label Only:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                hstack()
+                    .gap(2)
+                    .child(online().indicator_style(StatusStyle::LabelOnly))
+                    .child(busy_indicator().indicator_style(StatusStyle::LabelOnly))
+                    .child(offline().indicator_style(StatusStyle::LabelOnly)),
+            )
+            .child(Text::new(""))
+            .child(Text::new("Badge:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                hstack()
+                    .gap(2)
+                    .child(online().indicator_style(StatusStyle::Badge))
+                    .child(busy_indicator().indicator_style(StatusStyle::Badge))
+                    .child(away_indicator().indicator_style(StatusStyle::Badge)),
+            )
+            .child(Text::new(""))
+            .child(Text::new("Custom Label:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                hstack()
+                    .gap(2)
+                    .child(
+                        online()
+                            .indicator_style(StatusStyle::DotWithLabel)
+                            .label("Available"),
+                    )
+                    .child(
+                        busy_indicator()
+                            .indicator_style(StatusStyle::DotWithLabel)
+                            .label("In Meeting"),
+                    ),
+            )
+    }
+
+    fn render_sizes_demo(&self) -> impl View {
+        vstack()
+            .gap(1)
+            .child(Text::new("Size Variants:").bold())
+            .child(Text::new(""))
+            .child(Text::new("Small:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                hstack()
+                    .gap(2)
+                    .child(
+                        online()
+                            .size(StatusSize::Small)
+                            .indicator_style(StatusStyle::DotWithLabel),
+                    )
+                    .child(
+                        busy_indicator()
+                            .size(StatusSize::Small)
+                            .indicator_style(StatusStyle::Badge),
+                    ),
+            )
+            .child(Text::new(""))
+            .child(Text::new("Medium (default):").fg(Color::rgb(150, 150, 150)))
+            .child(
+                hstack()
+                    .gap(2)
+                    .child(
+                        online()
+                            .size(StatusSize::Medium)
+                            .indicator_style(StatusStyle::DotWithLabel),
+                    )
+                    .child(
+                        busy_indicator()
+                            .size(StatusSize::Medium)
+                            .indicator_style(StatusStyle::Badge),
+                    ),
+            )
+            .child(Text::new(""))
+            .child(Text::new("Large:").fg(Color::rgb(150, 150, 150)))
+            .child(
+                hstack()
+                    .gap(2)
+                    .child(
+                        online()
+                            .size(StatusSize::Large)
+                            .indicator_style(StatusStyle::DotWithLabel),
+                    )
+                    .child(
+                        busy_indicator()
+                            .size(StatusSize::Large)
+                            .indicator_style(StatusStyle::Badge),
+                    ),
+            )
+    }
+}
+
+impl View for StatusIndicatorDemo {
+    fn render(&self, ctx: &mut RenderContext) {
+        let header = hstack()
+            .child(Text::new(" StatusIndicator Demo ").fg(Color::CYAN).bold())
+            .child(Text::new(" | Tab/1-3 to switch").fg(Color::rgb(100, 100, 100)));
+
+        let tabs = self.render_tabs();
+
+        let content = match self.tab {
+            ViewTab::States => Border::rounded()
+                .title("Status States")
+                .child(self.render_states_demo()),
+            ViewTab::Styles => Border::rounded()
+                .title("Display Styles")
+                .child(self.render_styles_demo()),
+            ViewTab::Sizes => Border::rounded()
+                .title("Size Variants")
+                .child(self.render_sizes_demo()),
+        };
+
+        let help = Text::new("Press 'q' to quit | Tab: next | 'p': toggle pulse")
+            .fg(Color::rgb(80, 80, 80));
+
+        vstack()
+            .child(header)
+            .child(tabs)
+            .child(Text::new(""))
+            .child(content)
+            .child(Text::new(""))
+            .child(help)
+            .render(ctx);
+    }
+}
+
+fn main() -> Result<()> {
+    let mut app = App::builder().build();
+    let demo = StatusIndicatorDemo::new();
+
+    app.run_with_handler(demo, |key_event, demo| demo.handle_key(&key_event.key))
+}


### PR DESCRIPTION
## Summary
- Add Alert, Callout, StatusIndicator to docs/FEATURES.md
- Create examples/alert.rs with levels, variants, features demos
- Create examples/status_indicator.rs with states, styles, sizes demos

## Checklist
- [x] All examples compile
- [x] API references are correct
- [x] Clippy and fmt pass