### PR TITLE
test(widget): improve test coverage for critical widgets

### DIFF
--- a/src/widget/datagrid.rs
+++ b/src/widget/datagrid.rs
@@ -1868,4 +1868,724 @@ mod tests {
         let grid = DataGrid::new().row_height(0);
         assert_eq!(grid.options.row_height, 1);
     }
+
+    // ==================== GridColors Tests ====================
+
+    #[test]
+    fn test_grid_colors_new() {
+        let colors = GridColors::new();
+        assert_eq!(colors.header_bg, Color::rgb(60, 60, 80));
+    }
+
+    #[test]
+    fn test_grid_colors_dark() {
+        let colors = GridColors::dark();
+        assert_eq!(colors.header_bg, Color::rgb(60, 60, 80));
+        assert_eq!(colors.header_fg, Color::WHITE);
+    }
+
+    #[test]
+    fn test_grid_colors_light() {
+        let colors = GridColors::light();
+        assert_eq!(colors.header_bg, Color::rgb(220, 220, 230));
+        assert_eq!(colors.header_fg, Color::BLACK);
+        assert_eq!(colors.row_bg, Color::rgb(255, 255, 255));
+    }
+
+    #[test]
+    fn test_grid_colors_debug_clone() {
+        let colors = GridColors::default();
+        let cloned = colors.clone();
+        assert_eq!(colors.header_bg, cloned.header_bg);
+        let _ = format!("{:?}", colors);
+    }
+
+    // ==================== GridOptions Tests ====================
+
+    #[test]
+    fn test_grid_options_new() {
+        let options = GridOptions::new();
+        assert!(options.show_header);
+        assert!(!options.show_row_numbers);
+        assert!(options.zebra);
+    }
+
+    #[test]
+    fn test_grid_options_debug_clone() {
+        let options = GridOptions::default();
+        let cloned = options.clone();
+        assert_eq!(options.show_header, cloned.show_header);
+        let _ = format!("{:?}", options);
+    }
+
+    // ==================== ColumnType Tests ====================
+
+    #[test]
+    fn test_column_type_default() {
+        assert_eq!(ColumnType::default(), ColumnType::Text);
+    }
+
+    #[test]
+    fn test_column_type_variants() {
+        let _text = ColumnType::Text;
+        let _number = ColumnType::Number;
+        let _date = ColumnType::Date;
+        let _bool = ColumnType::Boolean;
+        let _custom = ColumnType::Custom;
+    }
+
+    #[test]
+    fn test_column_type_debug_clone_eq() {
+        let col_type = ColumnType::Number;
+        let cloned = col_type;
+        assert_eq!(col_type, cloned);
+        let _ = format!("{:?}", col_type);
+    }
+
+    // ==================== SortDirection Tests ====================
+
+    #[test]
+    fn test_sort_direction_toggle() {
+        let asc = SortDirection::Ascending;
+        assert_eq!(asc.toggle(), SortDirection::Descending);
+
+        let desc = SortDirection::Descending;
+        assert_eq!(desc.toggle(), SortDirection::Ascending);
+    }
+
+    #[test]
+    fn test_sort_direction_icon() {
+        assert_eq!(SortDirection::Ascending.icon(), '▲');
+        assert_eq!(SortDirection::Descending.icon(), '▼');
+    }
+
+    #[test]
+    fn test_sort_direction_debug_clone_eq() {
+        let dir = SortDirection::Ascending;
+        let cloned = dir;
+        assert_eq!(dir, cloned);
+        let _ = format!("{:?}", dir);
+    }
+
+    // ==================== Alignment Tests ====================
+
+    #[test]
+    fn test_alignment_default() {
+        assert_eq!(Alignment::default(), Alignment::Left);
+    }
+
+    #[test]
+    fn test_alignment_variants() {
+        let _left = Alignment::Left;
+        let _center = Alignment::Center;
+        let _right = Alignment::Right;
+    }
+
+    // ==================== GridColumn Builder Tests ====================
+
+    #[test]
+    fn test_grid_column_col_type() {
+        let col = GridColumn::new("num", "Number").col_type(ColumnType::Number);
+        assert_eq!(col.col_type, ColumnType::Number);
+    }
+
+    #[test]
+    fn test_grid_column_min_max_width() {
+        let col = GridColumn::new("test", "Test").min_width(10).max_width(100);
+        assert_eq!(col.min_width, 10);
+        assert_eq!(col.max_width, 100);
+    }
+
+    #[test]
+    fn test_grid_column_editable() {
+        let col = GridColumn::new("test", "Test").editable(true);
+        assert!(col.editable);
+    }
+
+    #[test]
+    fn test_grid_column_align() {
+        let col = GridColumn::new("test", "Test").align(Alignment::Right);
+        assert_eq!(col.align, Alignment::Right);
+    }
+
+    #[test]
+    fn test_grid_column_right() {
+        let col = GridColumn::new("test", "Test").right();
+        assert_eq!(col.align, Alignment::Right);
+    }
+
+    #[test]
+    fn test_grid_column_center() {
+        let col = GridColumn::new("test", "Test").center();
+        assert_eq!(col.align, Alignment::Center);
+    }
+
+    // ==================== GridRow Tests ====================
+
+    #[test]
+    fn test_grid_row_default() {
+        let row = GridRow::default();
+        assert!(row.data.is_empty());
+        assert!(!row.selected);
+        assert!(!row.expanded);
+        assert!(row.children.is_empty());
+    }
+
+    #[test]
+    fn test_grid_row_debug_clone() {
+        let row = GridRow::new().cell("key", "value");
+        let cloned = row.clone();
+        assert_eq!(row.get("key"), cloned.get("key"));
+        let _ = format!("{:?}", row);
+    }
+
+    // ==================== DataGrid Builder Tests ====================
+
+    #[test]
+    fn test_datagrid_default() {
+        let grid = DataGrid::default();
+        assert!(grid.columns.is_empty());
+        assert!(grid.rows.is_empty());
+    }
+
+    #[test]
+    fn test_datagrid_colors() {
+        let grid = DataGrid::new().colors(GridColors::light());
+        assert_eq!(grid.colors.header_fg, Color::BLACK);
+    }
+
+    #[test]
+    fn test_datagrid_options() {
+        let options = GridOptions {
+            show_row_numbers: true,
+            ..Default::default()
+        };
+        let grid = DataGrid::new().options(options);
+        assert!(grid.options.show_row_numbers);
+    }
+
+    #[test]
+    fn test_datagrid_colors_mut() {
+        let mut grid = DataGrid::new();
+        grid.colors_mut().header_fg = Color::RED;
+        assert_eq!(grid.colors.header_fg, Color::RED);
+    }
+
+    #[test]
+    fn test_datagrid_options_mut() {
+        let mut grid = DataGrid::new();
+        grid.options_mut().show_row_numbers = true;
+        assert!(grid.options.show_row_numbers);
+    }
+
+    #[test]
+    fn test_datagrid_columns_vec() {
+        let cols = vec![GridColumn::new("a", "A"), GridColumn::new("b", "B")];
+        let grid = DataGrid::new().columns(cols);
+        assert_eq!(grid.columns.len(), 2);
+    }
+
+    #[test]
+    fn test_datagrid_data_2d() {
+        let grid = DataGrid::new()
+            .column(GridColumn::new("col1", "Col1"))
+            .column(GridColumn::new("col2", "Col2"))
+            .data(vec![
+                vec!["a1".into(), "b1".into()],
+                vec!["a2".into(), "b2".into()],
+            ]);
+        assert_eq!(grid.rows.len(), 2);
+        assert_eq!(grid.rows[0].get("col1"), Some("a1"));
+    }
+
+    #[test]
+    fn test_datagrid_header() {
+        let grid = DataGrid::new().header(false);
+        assert!(!grid.options.show_header);
+    }
+
+    #[test]
+    fn test_datagrid_row_numbers() {
+        let grid = DataGrid::new().row_numbers(true);
+        assert!(grid.options.show_row_numbers);
+    }
+
+    #[test]
+    fn test_datagrid_zebra() {
+        let grid = DataGrid::new().zebra(false);
+        assert!(!grid.options.zebra);
+    }
+
+    #[test]
+    fn test_datagrid_multi_select() {
+        let grid = DataGrid::new().multi_select(true);
+        assert!(grid.options.multi_select);
+    }
+
+    // ==================== Selection Tests ====================
+
+    #[test]
+    fn test_toggle_selection() {
+        let mut grid = DataGrid::new()
+            .multi_select(true)
+            .row(GridRow::new().cell("a", "1"))
+            .row(GridRow::new().cell("a", "2"));
+
+        assert!(!grid.rows[0].selected);
+        grid.toggle_selection();
+        assert!(grid.rows[0].selected);
+        grid.toggle_selection();
+        assert!(!grid.rows[0].selected);
+    }
+
+    #[test]
+    fn test_toggle_selection_without_multi_select() {
+        let mut grid = DataGrid::new()
+            .multi_select(false)
+            .row(GridRow::new().cell("a", "1"));
+
+        grid.toggle_selection();
+        // Should not toggle when multi_select is disabled
+        assert!(!grid.rows[0].selected);
+    }
+
+    #[test]
+    fn test_selected_rows() {
+        let mut grid = DataGrid::new()
+            .multi_select(true)
+            .row(GridRow::new().cell("a", "1"))
+            .row(GridRow::new().cell("a", "2"))
+            .row(GridRow::new().cell("a", "3"));
+
+        grid.rows[0].selected = true;
+        grid.rows[2].selected = true;
+
+        let selected = grid.selected_rows();
+        assert_eq!(selected.len(), 2);
+    }
+
+    // ==================== Navigation Tests ====================
+
+    #[test]
+    fn test_select_next_col() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A"))
+            .column(GridColumn::new("b", "B"))
+            .column(GridColumn::new("c", "C"));
+
+        assert_eq!(grid.selected_col, 0);
+        grid.select_next_col();
+        assert_eq!(grid.selected_col, 1);
+        grid.select_next_col();
+        assert_eq!(grid.selected_col, 2);
+        grid.select_next_col();
+        assert_eq!(grid.selected_col, 2); // Can't go past last
+    }
+
+    #[test]
+    fn test_select_prev_col() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A"))
+            .column(GridColumn::new("b", "B"));
+
+        grid.selected_col = 1;
+        grid.select_prev_col();
+        assert_eq!(grid.selected_col, 0);
+        grid.select_prev_col();
+        assert_eq!(grid.selected_col, 0); // Can't go before first
+    }
+
+    #[test]
+    fn test_page_up() {
+        let mut grid = DataGrid::new().column(GridColumn::new("a", "A"));
+
+        let rows: Vec<_> = (0..50)
+            .map(|i| GridRow::new().cell("a", i.to_string()))
+            .collect();
+        grid = grid.rows(rows);
+
+        grid.selected_row = 25;
+        grid.page_up(10);
+        assert_eq!(grid.selected_row, 15);
+
+        grid.page_up(20);
+        assert_eq!(grid.selected_row, 0); // Clamped to 0
+    }
+
+    #[test]
+    fn test_ensure_visible_with_height() {
+        let mut grid = DataGrid::new().column(GridColumn::new("a", "A"));
+
+        let rows: Vec<_> = (0..100)
+            .map(|i| GridRow::new().cell("a", i.to_string()))
+            .collect();
+        grid = grid.rows(rows);
+
+        grid.selected_row = 50;
+        grid.scroll_row = 0;
+        grid.ensure_visible_with_height(10);
+
+        // Scroll should adjust to show selected row
+        assert!(grid.scroll_row > 0);
+    }
+
+    #[test]
+    fn test_set_viewport_height() {
+        let mut grid = DataGrid::new().column(GridColumn::new("a", "A"));
+
+        let rows: Vec<_> = (0..50)
+            .map(|i| GridRow::new().cell("a", i.to_string()))
+            .collect();
+        grid = grid.rows(rows);
+
+        grid.selected_row = 30;
+        grid.scroll_row = 0;
+        grid.set_viewport_height(10);
+
+        assert!(grid.scroll_row > 0);
+    }
+
+    #[test]
+    fn test_scroll_info() {
+        let grid = DataGrid::new()
+            .column(GridColumn::new("a", "A"))
+            .row(GridRow::new().cell("a", "1"))
+            .row(GridRow::new().cell("a", "2"));
+
+        let (scroll, total, _viewport) = grid.scroll_info();
+        assert_eq!(scroll, 0);
+        assert_eq!(total, 2);
+    }
+
+    #[test]
+    fn test_visible_row_count() {
+        let grid = DataGrid::new()
+            .column(GridColumn::new("a", "A"))
+            .row(GridRow::new().cell("a", "1"))
+            .row(GridRow::new().cell("a", "2"));
+
+        assert_eq!(grid.visible_row_count(), 2);
+    }
+
+    // ==================== Sorting Edge Cases ====================
+
+    #[test]
+    fn test_sort_invalid_column() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A"))
+            .row(GridRow::new().cell("a", "1"));
+
+        // Sorting invalid column should be no-op
+        grid.sort(99);
+        assert!(grid.sort_column.is_none());
+    }
+
+    #[test]
+    fn test_sort_unsortable_column() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A").sortable(false))
+            .row(GridRow::new().cell("a", "1"));
+
+        grid.sort(0);
+        assert!(grid.sort_column.is_none());
+    }
+
+    #[test]
+    fn test_sort_toggle_direction() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A"))
+            .row(GridRow::new().cell("a", "B"))
+            .row(GridRow::new().cell("a", "A"));
+
+        grid.sort(0); // Ascending
+        assert_eq!(grid.sort_direction, SortDirection::Ascending);
+        assert_eq!(grid.rows[0].get("a"), Some("A"));
+
+        grid.sort(0); // Toggle to descending
+        assert_eq!(grid.sort_direction, SortDirection::Descending);
+        assert_eq!(grid.rows[0].get("a"), Some("B"));
+    }
+
+    #[test]
+    fn test_sort_number_column() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("num", "Number").col_type(ColumnType::Number))
+            .row(GridRow::new().cell("num", "10"))
+            .row(GridRow::new().cell("num", "2"))
+            .row(GridRow::new().cell("num", "100"));
+
+        grid.sort(0);
+
+        assert_eq!(grid.rows[0].get("num"), Some("2"));
+        assert_eq!(grid.rows[1].get("num"), Some("10"));
+        assert_eq!(grid.rows[2].get("num"), Some("100"));
+    }
+
+    #[test]
+    fn test_sort_cancels_edit() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A").editable(true))
+            .row(GridRow::new().cell("a", "B"))
+            .row(GridRow::new().cell("a", "A"));
+
+        grid.start_edit();
+        assert!(grid.is_editing());
+
+        grid.sort(0);
+        assert!(!grid.is_editing());
+    }
+
+    // ==================== Filter Tests ====================
+
+    #[test]
+    fn test_filter_specific_column() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A"))
+            .column(GridColumn::new("b", "B"))
+            .row(GridRow::new().cell("a", "Alice").cell("b", "Smith"))
+            .row(GridRow::new().cell("a", "Bob").cell("b", "Alice"));
+
+        grid.filter_column = Some(0);
+        grid.set_filter("alice");
+
+        // Should only match first row (column A)
+        assert_eq!(grid.filtered_count(), 1);
+    }
+
+    #[test]
+    fn test_filter_cancels_edit() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A").editable(true))
+            .row(GridRow::new().cell("a", "test"));
+
+        grid.start_edit();
+        assert!(grid.is_editing());
+
+        grid.set_filter("x");
+        assert!(!grid.is_editing());
+    }
+
+    // ==================== Edit Mode Tests ====================
+
+    #[test]
+    fn test_edit_delete_key() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A").editable(true))
+            .row(GridRow::new().cell("a", "ABC"));
+
+        grid.start_edit();
+        grid.handle_key(&Key::Home); // Move to start
+        grid.handle_key(&Key::Delete); // Delete 'A'
+
+        assert_eq!(grid.edit_buffer(), Some("BC"));
+    }
+
+    #[test]
+    fn test_edit_right_key() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A").editable(true))
+            .row(GridRow::new().cell("a", "AB"));
+
+        grid.start_edit();
+        grid.handle_key(&Key::Home);
+        assert_eq!(grid.edit_state.cursor, 0);
+
+        grid.handle_key(&Key::Right);
+        assert_eq!(grid.edit_state.cursor, 1);
+    }
+
+    #[test]
+    fn test_edit_start_out_of_bounds() {
+        let mut grid = DataGrid::new().column(GridColumn::new("a", "A").editable(true));
+
+        // No rows, can't edit
+        assert!(!grid.start_edit());
+    }
+
+    #[test]
+    fn test_commit_edit_invalid_state() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A").editable(true))
+            .row(GridRow::new().cell("a", "test"));
+
+        // Not editing, commit should fail
+        assert!(!grid.commit_edit());
+    }
+
+    #[test]
+    fn test_edit_add_new_cell() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A").editable(true))
+            .row(GridRow::new()); // Row without the cell
+
+        grid.start_edit();
+        grid.handle_key(&Key::Char('X'));
+        grid.commit_edit();
+
+        assert_eq!(grid.rows[0].get("a"), Some("X"));
+    }
+
+    // ==================== Key Handling Tests ====================
+
+    #[test]
+    fn test_handle_key_navigation() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A"))
+            .column(GridColumn::new("b", "B"))
+            .row(GridRow::new().cell("a", "1").cell("b", "2"))
+            .row(GridRow::new().cell("a", "3").cell("b", "4"));
+
+        // Vim keys
+        assert!(grid.handle_key(&Key::Char('j'))); // Down
+        assert_eq!(grid.selected_row, 1);
+
+        assert!(grid.handle_key(&Key::Char('k'))); // Up
+        assert_eq!(grid.selected_row, 0);
+
+        assert!(grid.handle_key(&Key::Char('l'))); // Right
+        assert_eq!(grid.selected_col, 1);
+
+        assert!(grid.handle_key(&Key::Char('h'))); // Left
+        assert_eq!(grid.selected_col, 0);
+
+        // Home/End
+        assert!(grid.handle_key(&Key::Char('g'))); // Home
+        assert_eq!(grid.selected_row, 0);
+
+        assert!(grid.handle_key(&Key::Char('G'))); // End
+        assert_eq!(grid.selected_row, 1);
+    }
+
+    #[test]
+    fn test_handle_key_enter_non_editable() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A").editable(false).sortable(true))
+            .row(GridRow::new().cell("a", "B"))
+            .row(GridRow::new().cell("a", "A"));
+
+        // Enter on non-editable should sort
+        grid.handle_key(&Key::Enter);
+        assert_eq!(grid.sort_column, Some(0));
+    }
+
+    #[test]
+    fn test_handle_key_space_multi_select() {
+        let mut grid = DataGrid::new()
+            .multi_select(true)
+            .column(GridColumn::new("a", "A"))
+            .row(GridRow::new().cell("a", "1"));
+
+        assert!(grid.handle_key(&Key::Char(' ')));
+        assert!(grid.rows[0].selected);
+    }
+
+    #[test]
+    fn test_handle_key_unhandled() {
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A"))
+            .row(GridRow::new().cell("a", "1"));
+
+        assert!(!grid.handle_key(&Key::Tab));
+    }
+
+    // ==================== Rendering Tests ====================
+
+    #[test]
+    fn test_render_small_area() {
+        let mut buffer = Buffer::new(5, 2);
+        let area = Rect::new(0, 0, 5, 2);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let grid = DataGrid::new()
+            .column(GridColumn::new("a", "A"))
+            .row(GridRow::new().cell("a", "test"));
+
+        grid.render(&mut ctx);
+        // Should not panic with small area
+    }
+
+    #[test]
+    fn test_render_with_row_numbers() {
+        let mut buffer = Buffer::new(80, 24);
+        let area = Rect::new(0, 0, 80, 24);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let grid = DataGrid::new()
+            .row_numbers(true)
+            .column(GridColumn::new("a", "A"))
+            .row(GridRow::new().cell("a", "test"));
+
+        grid.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_render_no_header() {
+        let mut buffer = Buffer::new(80, 24);
+        let area = Rect::new(0, 0, 80, 24);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let grid = DataGrid::new()
+            .header(false)
+            .column(GridColumn::new("a", "A"))
+            .row(GridRow::new().cell("a", "test"));
+
+        grid.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_render_non_virtual_scroll() {
+        let mut buffer = Buffer::new(80, 24);
+        let area = Rect::new(0, 0, 80, 24);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let grid = DataGrid::new()
+            .virtual_scroll(false)
+            .column(GridColumn::new("a", "A"))
+            .row(GridRow::new().cell("a", "test"));
+
+        grid.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_render_with_sorting() {
+        let mut buffer = Buffer::new(80, 24);
+        let area = Rect::new(0, 0, 80, 24);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let mut grid = DataGrid::new()
+            .column(GridColumn::new("a", "A"))
+            .row(GridRow::new().cell("a", "B"))
+            .row(GridRow::new().cell("a", "A"));
+
+        grid.sort(0);
+        grid.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_calculate_widths_empty() {
+        let grid = DataGrid::new();
+        let widths = grid.calculate_widths(80);
+        assert!(widths.is_empty());
+    }
+
+    // ==================== Helper Functions Tests ====================
+
+    #[test]
+    fn test_datagrid_helper() {
+        let grid = datagrid();
+        assert!(grid.columns.is_empty());
+    }
+
+    #[test]
+    fn test_grid_column_helper() {
+        let col = grid_column("key", "Title");
+        assert_eq!(col.key, "key");
+        assert_eq!(col.title, "Title");
+    }
+
+    #[test]
+    fn test_grid_row_helper() {
+        let row = grid_row();
+        assert!(row.data.is_empty());
+    }
 }

--- a/src/widget/dropzone.rs
+++ b/src/widget/dropzone.rs
@@ -435,4 +435,216 @@ mod tests {
         assert!(zone.can_drop());
         assert_eq!(zone.accepted_types(), &["file"]);
     }
+
+    #[test]
+    fn test_dropzone_accepts_all() {
+        let zone = DropZone::new("Drop anything")
+            .accepts(&["file"])
+            .accepts_all();
+
+        assert!(zone.accepts.is_empty());
+    }
+
+    #[test]
+    fn test_dropzone_colors() {
+        let zone = DropZone::new("Zone")
+            .border_color(Color::RED)
+            .hover_color(Color::BLUE);
+
+        assert_eq!(zone.border_color, Color::RED);
+        assert_eq!(zone.hover_color, Color::BLUE);
+    }
+
+    #[test]
+    fn test_dropzone_min_height() {
+        let zone = DropZone::new("Zone").min_height(5);
+        assert_eq!(zone.min_height, 5);
+    }
+
+    #[test]
+    fn test_dropzone_on_drop_handler() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let called = Rc::new(Cell::new(false));
+        let called_clone = called.clone();
+
+        let mut zone = DropZone::new("Zone").on_drop(move |_data| {
+            called_clone.set(true);
+            true
+        });
+
+        let data = DragData::text("test");
+        let result = Draggable::on_drop(&mut zone, data);
+
+        assert!(result);
+        assert!(called.get());
+    }
+
+    #[test]
+    fn test_dropzone_id() {
+        let zone1 = DropZone::new("Zone 1");
+        let zone2 = DropZone::new("Zone 2");
+
+        // IDs should be unique
+        assert_ne!(zone1.id(), zone2.id());
+    }
+
+    #[test]
+    fn test_dropzone_current_border_color() {
+        let mut zone = DropZone::new("Zone");
+
+        // Not hovered - use border_color
+        assert_eq!(zone.current_border_color(), zone.border_color);
+
+        // Hovered and can accept - use accept_color
+        zone.set_hovered(true, true);
+        assert_eq!(zone.current_border_color(), zone.accept_color);
+
+        // Hovered but cannot accept - use reject_color
+        zone.set_hovered(true, false);
+        assert_eq!(zone.current_border_color(), zone.reject_color);
+    }
+
+    #[test]
+    fn test_dropzone_border_chars() {
+        let solid = DropZone::new("Zone").style(DropZoneStyle::Solid);
+        let chars = solid.border_chars();
+        assert_eq!(chars.0, '┌');
+        assert_eq!(chars.4, '─');
+
+        let dashed = DropZone::new("Zone").style(DropZoneStyle::Dashed);
+        let chars = dashed.border_chars();
+        assert_eq!(chars.4, '╌');
+
+        let highlight = DropZone::new("Zone").style(DropZoneStyle::Highlight);
+        let chars = highlight.border_chars();
+        assert_eq!(chars.0, ' ');
+    }
+
+    #[test]
+    fn test_dropzone_drag_enter_leave() {
+        let mut zone = DropZone::new("Zone").accepts(&["file"]);
+
+        let data = DragData::text("test");
+        zone.on_drag_enter(&data);
+        assert!(zone.hovered);
+
+        zone.on_drag_leave();
+        assert!(!zone.hovered);
+        assert!(!zone.can_accept_current);
+    }
+
+    #[test]
+    fn test_dropzone_drop_bounds() {
+        let zone = DropZone::new("Zone");
+        let area = Rect::new(5, 5, 20, 10);
+        let bounds = zone.drop_bounds(area);
+
+        assert_eq!(bounds, area);
+    }
+
+    #[test]
+    fn test_dropzone_render() {
+        use crate::render::Buffer;
+
+        let mut buffer = Buffer::new(40, 10);
+        let area = Rect::new(0, 0, 40, 10);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let zone = DropZone::new("Drop files here");
+        zone.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_dropzone_render_hovered() {
+        use crate::render::Buffer;
+
+        let mut buffer = Buffer::new(40, 10);
+        let area = Rect::new(0, 0, 40, 10);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let mut zone = DropZone::new("Drop files here");
+        zone.set_hovered(true, true);
+        zone.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_dropzone_render_rejected() {
+        use crate::render::Buffer;
+
+        let mut buffer = Buffer::new(40, 10);
+        let area = Rect::new(0, 0, 40, 10);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let mut zone = DropZone::new("Drop files here");
+        zone.set_hovered(true, false);
+        zone.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_dropzone_render_styles() {
+        use crate::render::Buffer;
+
+        for style in [
+            DropZoneStyle::Solid,
+            DropZoneStyle::Dashed,
+            DropZoneStyle::Highlight,
+            DropZoneStyle::Minimal,
+        ] {
+            let mut buffer = Buffer::new(40, 10);
+            let area = Rect::new(0, 0, 40, 10);
+            let mut ctx = RenderContext::new(&mut buffer, area);
+
+            let zone = DropZone::new("Zone").style(style);
+            zone.render(&mut ctx);
+        }
+    }
+
+    #[test]
+    fn test_dropzone_render_small_area() {
+        use crate::render::Buffer;
+
+        let mut buffer = Buffer::new(5, 2);
+        let area = Rect::new(0, 0, 5, 2);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let zone = DropZone::new("This is a long placeholder text");
+        zone.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_dropzone_helper() {
+        let zone = drop_zone("Drop here");
+        assert_eq!(zone.placeholder, "Drop here");
+    }
+
+    #[test]
+    fn test_dropzone_style_default() {
+        assert_eq!(DropZoneStyle::default(), DropZoneStyle::Solid);
+    }
+
+    #[test]
+    fn test_dropzone_on_drop_no_handler() {
+        let mut zone = DropZone::new("Zone");
+        let data = DragData::text("test");
+
+        let result = Draggable::on_drop(&mut zone, data);
+        assert!(!result); // No handler, returns false
+    }
+
+    #[test]
+    fn test_dropzone_all_styles() {
+        let styles = [
+            DropZoneStyle::Solid,
+            DropZoneStyle::Dashed,
+            DropZoneStyle::Highlight,
+            DropZoneStyle::Minimal,
+        ];
+
+        for style in styles {
+            let zone = DropZone::new("Zone").style(style);
+            assert_eq!(zone.style, style);
+        }
+    }
 }

--- a/src/widget/heatmap.rs
+++ b/src/widget/heatmap.rs
@@ -606,4 +606,603 @@ mod tests {
         let hm = heatmap(data);
         assert_eq!(hm._rows, 1);
     }
+
+    // ==================== ColorScale Tests ====================
+
+    #[test]
+    fn test_color_scale_viridis() {
+        let scale = ColorScale::Viridis;
+        let low = scale.color_at(0.0);
+        let high = scale.color_at(1.0);
+
+        // Viridis starts purple-ish and ends yellow-ish
+        assert!(low.b > low.r); // Low end has more blue
+        assert!(high.g > high.b); // High end has more green
+    }
+
+    #[test]
+    fn test_color_scale_plasma() {
+        let scale = ColorScale::Plasma;
+        let low = scale.color_at(0.0);
+        let mid = scale.color_at(0.5);
+        let high = scale.color_at(1.0);
+
+        // Plasma goes from dark purple to bright yellow
+        assert!(low.r < 50); // Starts dark
+        assert!(high.r > 200); // Ends bright
+        assert!(mid.r > low.r && mid.r < high.r); // Monotonic increase
+    }
+
+    #[test]
+    fn test_color_scale_gray() {
+        let scale = ColorScale::Gray;
+        let black = scale.color_at(0.0);
+        let white = scale.color_at(1.0);
+        let mid = scale.color_at(0.5);
+
+        assert_eq!(black.r, 0);
+        assert_eq!(black.g, 0);
+        assert_eq!(black.b, 0);
+
+        assert_eq!(white.r, 255);
+        assert_eq!(white.g, 255);
+        assert_eq!(white.b, 255);
+
+        // Grayscale should have equal RGB
+        assert_eq!(mid.r, mid.g);
+        assert_eq!(mid.g, mid.b);
+    }
+
+    #[test]
+    fn test_color_scale_red_yellow_green() {
+        let scale = ColorScale::RedYellowGreen;
+        let red = scale.color_at(0.0);
+        let yellow = scale.color_at(0.5);
+        let green = scale.color_at(1.0);
+
+        // At 0.0: Red
+        assert_eq!(red.r, 255);
+        assert_eq!(red.g, 0);
+        assert_eq!(red.b, 0);
+
+        // At 0.5: Yellow
+        assert_eq!(yellow.r, 255);
+        assert_eq!(yellow.g, 255);
+        assert_eq!(yellow.b, 0);
+
+        // At 1.0: Green
+        assert_eq!(green.r, 0);
+        assert_eq!(green.g, 255);
+        assert_eq!(green.b, 0);
+    }
+
+    #[test]
+    fn test_color_scale_custom_returns_white() {
+        let scale = ColorScale::Custom;
+        let color = scale.color_at(0.5);
+        // Custom returns WHITE when used directly (override with custom_colors)
+        assert_eq!(color, Color::WHITE);
+    }
+
+    #[test]
+    fn test_color_scale_green_buckets() {
+        let scale = ColorScale::Green;
+
+        // Test each bucket
+        let empty = scale.color_at(0.0); // < 0.01
+        let low = scale.color_at(0.15); // 0.01-0.25
+        let med_low = scale.color_at(0.35); // 0.25-0.50
+        let med_high = scale.color_at(0.60); // 0.50-0.75
+        let high = scale.color_at(0.90); // >= 0.75
+
+        // Empty is darkest
+        assert_eq!(empty, Color::rgb(22, 27, 34));
+        // Low
+        assert_eq!(low, Color::rgb(14, 68, 41));
+        // Medium-low
+        assert_eq!(med_low, Color::rgb(0, 109, 50));
+        // Medium-high
+        assert_eq!(med_high, Color::rgb(38, 166, 65));
+        // High
+        assert_eq!(high, Color::rgb(57, 211, 83));
+    }
+
+    #[test]
+    fn test_color_scale_blue_red_gradient() {
+        let scale = ColorScale::BlueRed;
+
+        // Lower half: blue to white
+        let low = scale.color_at(0.25);
+        assert_eq!(low.b, 255); // Blue stays at 255
+        assert!(low.r > 0 && low.r < 255); // Red increases
+
+        // Upper half: white to red
+        let high = scale.color_at(0.75);
+        assert_eq!(high.r, 255); // Red stays at 255
+        assert!(high.b < 255 && high.b > 0); // Blue decreases
+    }
+
+    #[test]
+    fn test_color_scale_value_clamping() {
+        let scale = ColorScale::Gray;
+
+        // Values below 0 should clamp to 0
+        let below = scale.color_at(-1.0);
+        assert_eq!(below, Color::rgb(0, 0, 0));
+
+        // Values above 1 should clamp to 1
+        let above = scale.color_at(2.0);
+        assert_eq!(above, Color::rgb(255, 255, 255));
+    }
+
+    #[test]
+    fn test_color_scale_default() {
+        assert_eq!(ColorScale::default(), ColorScale::BlueRed);
+    }
+
+    #[test]
+    fn test_color_scale_debug_and_clone() {
+        let scale = ColorScale::Viridis;
+        let cloned = scale;
+        assert_eq!(scale, cloned);
+        let _ = format!("{:?}", scale);
+    }
+
+    // ==================== CellDisplay Tests ====================
+
+    #[test]
+    fn test_cell_display_default() {
+        assert_eq!(CellDisplay::default(), CellDisplay::Block);
+    }
+
+    #[test]
+    fn test_cell_display_debug_and_clone() {
+        let display = CellDisplay::HalfBlock;
+        let cloned = display;
+        assert_eq!(display, cloned);
+        let _ = format!("{:?}", display);
+    }
+
+    // ==================== HeatMap Builder Tests ====================
+
+    #[test]
+    fn test_heatmap_custom_colors() {
+        let hm = HeatMap::new(vec![vec![0.0, 1.0]]).custom_colors(Color::BLUE, Color::RED);
+
+        assert_eq!(hm.color_scale, ColorScale::Custom);
+        assert!(hm.custom_colors.is_some());
+
+        let (low, high) = hm.custom_colors.unwrap();
+        assert_eq!(low, Color::BLUE);
+        assert_eq!(high, Color::RED);
+    }
+
+    #[test]
+    fn test_heatmap_cell_display() {
+        let hm = HeatMap::new(vec![vec![0.5]]).cell_display(CellDisplay::HalfBlock);
+        assert_eq!(hm.cell_display, CellDisplay::HalfBlock);
+    }
+
+    #[test]
+    fn test_heatmap_cell_size() {
+        let hm = HeatMap::new(vec![vec![0.5]]).cell_size(5, 3);
+        assert_eq!(hm.cell_width, 5);
+        assert_eq!(hm.cell_height, 3);
+    }
+
+    #[test]
+    fn test_heatmap_cell_width() {
+        let hm = HeatMap::new(vec![vec![0.5]]).cell_width(8);
+        assert_eq!(hm.cell_width, 8);
+    }
+
+    #[test]
+    fn test_heatmap_cell_height() {
+        let hm = HeatMap::new(vec![vec![0.5]]).cell_height(4);
+        assert_eq!(hm.cell_height, 4);
+    }
+
+    #[test]
+    fn test_heatmap_show_values_increases_cell_width() {
+        let hm = HeatMap::new(vec![vec![0.5]])
+            .cell_width(2)
+            .show_values(true);
+
+        // show_values increases cell_width to at least 4
+        assert!(hm.cell_width >= 4);
+        assert!(hm.show_values);
+    }
+
+    #[test]
+    fn test_heatmap_show_values_keeps_larger_width() {
+        let hm = HeatMap::new(vec![vec![0.5]])
+            .cell_width(10)
+            .show_values(true);
+
+        // Should keep the larger width
+        assert_eq!(hm.cell_width, 10);
+    }
+
+    #[test]
+    fn test_heatmap_value_decimals() {
+        let hm = HeatMap::new(vec![vec![0.5]]).value_decimals(3);
+        assert_eq!(hm.value_decimals, 3);
+    }
+
+    #[test]
+    fn test_heatmap_title() {
+        let hm = HeatMap::new(vec![vec![0.5]]).title("My Heatmap");
+        assert_eq!(hm.title, Some("My Heatmap".to_string()));
+    }
+
+    #[test]
+    fn test_heatmap_show_legend() {
+        let hm = HeatMap::new(vec![vec![0.5]]).show_legend(true);
+        assert!(hm.show_legend);
+    }
+
+    #[test]
+    fn test_heatmap_highlight() {
+        let hm = HeatMap::new(vec![vec![0.5, 0.6], vec![0.7, 0.8]]).highlight(1, 0);
+        assert_eq!(hm.highlighted, Some((1, 0)));
+    }
+
+    // ==================== HeatMap Helper Functions ====================
+
+    #[test]
+    fn test_correlation_matrix() {
+        let data = vec![
+            vec![1.0, 0.5, -0.5],
+            vec![0.5, 1.0, 0.3],
+            vec![-0.5, 0.3, 1.0],
+        ];
+        let labels = vec!["A".into(), "B".into(), "C".into()];
+        let hm = HeatMap::correlation_matrix(&data, labels);
+
+        assert_eq!(hm.color_scale, ColorScale::BlueRed);
+        assert_eq!(hm.min_val, -1.0);
+        assert_eq!(hm.max_val, 1.0);
+        assert!(hm.row_labels.is_some());
+        assert!(hm.col_labels.is_some());
+        assert!(hm.show_values);
+    }
+
+    #[test]
+    fn test_contribution_map_helper() {
+        let contributions: Vec<u32> = (0..100).collect();
+        let hm = contribution_map(&contributions);
+        assert_eq!(hm.color_scale, ColorScale::Green);
+    }
+
+    // ==================== Normalization Tests ====================
+
+    #[test]
+    fn test_normalize_same_min_max() {
+        let hm = HeatMap::new(vec![vec![5.0, 5.0, 5.0]]);
+        // When min == max, normalize returns 0.5
+        assert_eq!(hm.normalize(5.0), 0.5);
+    }
+
+    #[test]
+    fn test_normalize_range() {
+        let hm = HeatMap::new(vec![vec![0.0, 100.0]]);
+        assert_eq!(hm.normalize(0.0), 0.0);
+        assert_eq!(hm.normalize(50.0), 0.5);
+        assert_eq!(hm.normalize(100.0), 1.0);
+        assert_eq!(hm.normalize(25.0), 0.25);
+    }
+
+    // ==================== Color For Value Tests ====================
+
+    #[test]
+    fn test_color_for_with_custom_colors() {
+        let hm = HeatMap::new(vec![vec![0.0, 1.0]])
+            .custom_colors(Color::rgb(0, 0, 0), Color::rgb(255, 255, 255));
+
+        let low_color = hm.color_for(0.0);
+        let high_color = hm.color_for(1.0);
+        let mid_color = hm.color_for(0.5);
+
+        assert_eq!(low_color, Color::rgb(0, 0, 0));
+        assert_eq!(high_color, Color::rgb(255, 255, 255));
+        // Mid should be approximately gray
+        assert!(mid_color.r > 100 && mid_color.r < 150);
+    }
+
+    #[test]
+    fn test_color_for_with_standard_scale() {
+        let hm = HeatMap::new(vec![vec![0.0, 1.0]]).color_scale(ColorScale::Gray);
+
+        let low = hm.color_for(0.0);
+        let high = hm.color_for(1.0);
+
+        assert_eq!(low, Color::rgb(0, 0, 0));
+        assert_eq!(high, Color::rgb(255, 255, 255));
+    }
+
+    // ==================== Render Cell Tests ====================
+
+    #[test]
+    fn test_render_cell_block() {
+        let hm = HeatMap::new(vec![vec![0.5]])
+            .cell_display(CellDisplay::Block)
+            .cell_width(3);
+
+        let cell = hm.render_cell(0.5);
+        assert_eq!(cell, "███");
+    }
+
+    #[test]
+    fn test_render_cell_half_block() {
+        let hm = HeatMap::new(vec![vec![0.5]])
+            .cell_display(CellDisplay::HalfBlock)
+            .cell_width(2);
+
+        let cell = hm.render_cell(0.5);
+        assert_eq!(cell, "▀▀");
+    }
+
+    #[test]
+    fn test_render_cell_value_display() {
+        let hm = HeatMap::new(vec![vec![0.5]])
+            .cell_display(CellDisplay::Value)
+            .cell_width(4)
+            .value_decimals(1);
+
+        let cell = hm.render_cell(0.5);
+        assert!(cell.contains("0.5"));
+    }
+
+    #[test]
+    fn test_render_cell_custom() {
+        let hm = HeatMap::new(vec![vec![0.5]])
+            .cell_display(CellDisplay::Custom)
+            .cell_width(2);
+
+        let cell = hm.render_cell(0.5);
+        assert_eq!(cell, "■■");
+    }
+
+    #[test]
+    fn test_render_cell_show_values_overrides_display() {
+        let hm = HeatMap::new(vec![vec![0.5]])
+            .cell_display(CellDisplay::Block)
+            .show_values(true)
+            .value_decimals(2);
+
+        let cell = hm.render_cell(0.5);
+        // show_values takes precedence over cell_display
+        assert!(cell.contains("0.50"));
+    }
+
+    // ==================== Edge Cases ====================
+
+    #[test]
+    fn test_heatmap_empty_data() {
+        let hm = HeatMap::new(vec![]);
+        assert_eq!(hm._rows, 0);
+        assert_eq!(hm.cols, 0);
+        // When empty, defaults apply
+        assert_eq!(hm.min_val, 0.0);
+        assert_eq!(hm.max_val, 1.0);
+    }
+
+    #[test]
+    fn test_heatmap_empty_rows() {
+        let hm = HeatMap::new(vec![vec![], vec![]]);
+        assert_eq!(hm._rows, 2);
+        assert_eq!(hm.cols, 0);
+    }
+
+    #[test]
+    fn test_from_flat_partial_data() {
+        // Data smaller than rows * cols
+        let data = vec![1.0, 2.0, 3.0];
+        let hm = HeatMap::from_flat(&data, 2, 3);
+        assert_eq!(hm._rows, 2);
+        assert_eq!(hm.data[0].len(), 3);
+        assert_eq!(hm.data[1].len(), 0); // Second row is empty since data ran out
+    }
+
+    #[test]
+    fn test_heatmap_negative_values() {
+        let hm = HeatMap::new(vec![vec![-10.0, 0.0, 10.0]]);
+        assert_eq!(hm.min_val, -10.0);
+        assert_eq!(hm.max_val, 10.0);
+        assert_eq!(hm.normalize(-10.0), 0.0);
+        assert_eq!(hm.normalize(0.0), 0.5);
+        assert_eq!(hm.normalize(10.0), 1.0);
+    }
+
+    // ==================== Rendering Tests ====================
+
+    #[test]
+    fn test_heatmap_render_basic() {
+        use crate::layout::Rect;
+        use crate::render::Buffer;
+
+        let hm = HeatMap::new(vec![vec![0.0, 0.5, 1.0]]).cell_width(1);
+
+        let mut buffer = Buffer::new(20, 5);
+        let rect = Rect::new(0, 0, 20, 5);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        hm.render(&mut ctx);
+        // Basic smoke test - just ensure no panic
+    }
+
+    #[test]
+    fn test_heatmap_render_with_title() {
+        use crate::layout::Rect;
+        use crate::render::Buffer;
+
+        let hm = HeatMap::new(vec![vec![0.5]]).title("Test Title");
+
+        let mut buffer = Buffer::new(20, 5);
+        let rect = Rect::new(0, 0, 20, 5);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        hm.render(&mut ctx);
+
+        // Check that first row contains title characters
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, 'T');
+        assert_eq!(buffer.get(1, 0).unwrap().symbol, 'e');
+        assert_eq!(buffer.get(2, 0).unwrap().symbol, 's');
+        assert_eq!(buffer.get(3, 0).unwrap().symbol, 't');
+    }
+
+    #[test]
+    fn test_heatmap_render_with_labels() {
+        use crate::layout::Rect;
+        use crate::render::Buffer;
+
+        let hm = HeatMap::new(vec![vec![0.5, 0.8], vec![0.2, 0.9]])
+            .row_labels(vec!["R1".into(), "R2".into()])
+            .col_labels(vec!["C1".into(), "C2".into()]);
+
+        let mut buffer = Buffer::new(30, 10);
+        let rect = Rect::new(0, 0, 30, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        hm.render(&mut ctx);
+
+        // Smoke test - render should complete without panic
+        // Labels are rendered somewhere in the buffer
+    }
+
+    #[test]
+    fn test_heatmap_render_with_legend() {
+        use crate::layout::Rect;
+        use crate::render::Buffer;
+
+        let hm = HeatMap::new(vec![vec![0.0, 1.0]]).show_legend(true);
+
+        let mut buffer = Buffer::new(40, 10);
+        let rect = Rect::new(0, 0, 40, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        hm.render(&mut ctx);
+
+        // Smoke test - legend should render without panic
+        // The legend contains "Low" and "High" labels somewhere in the buffer
+    }
+
+    #[test]
+    fn test_heatmap_render_with_values() {
+        use crate::layout::Rect;
+        use crate::render::Buffer;
+
+        let hm = HeatMap::new(vec![vec![0.5]])
+            .show_values(true)
+            .value_decimals(1);
+
+        let mut buffer = Buffer::new(20, 5);
+        let rect = Rect::new(0, 0, 20, 5);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        hm.render(&mut ctx);
+        // Smoke test
+    }
+
+    #[test]
+    fn test_heatmap_render_with_highlight() {
+        use crate::layout::Rect;
+        use crate::render::Buffer;
+
+        let hm = HeatMap::new(vec![vec![0.5, 0.8], vec![0.2, 0.9]]).highlight(0, 1);
+
+        let mut buffer = Buffer::new(20, 10);
+        let rect = Rect::new(0, 0, 20, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        hm.render(&mut ctx);
+        // Smoke test - highlight should apply bold
+    }
+
+    #[test]
+    fn test_heatmap_render_multiline_cells() {
+        use crate::layout::Rect;
+        use crate::render::Buffer;
+
+        let hm = HeatMap::new(vec![vec![0.5]]).cell_height(2);
+
+        let mut buffer = Buffer::new(20, 10);
+        let rect = Rect::new(0, 0, 20, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        hm.render(&mut ctx);
+        // Smoke test
+    }
+
+    #[test]
+    fn test_heatmap_clone() {
+        let hm = HeatMap::new(vec![vec![0.5]])
+            .title("Test")
+            .color_scale(ColorScale::Viridis);
+
+        let cloned = hm.clone();
+        assert_eq!(cloned.title, Some("Test".to_string()));
+        assert_eq!(cloned.color_scale, ColorScale::Viridis);
+    }
+
+    #[test]
+    fn test_heatmap_debug() {
+        let hm = HeatMap::new(vec![vec![0.5]]);
+        let debug = format!("{:?}", hm);
+        assert!(debug.contains("HeatMap"));
+    }
+
+    // ==================== Brightness Contrast Tests ====================
+
+    #[test]
+    fn test_render_value_brightness_contrast() {
+        use crate::layout::Rect;
+        use crate::render::Buffer;
+
+        // Test that high brightness cells get black text, low brightness get white
+        let hm = HeatMap::new(vec![vec![0.0, 1.0]])
+            .color_scale(ColorScale::Gray)
+            .show_values(true);
+
+        let mut buffer = Buffer::new(20, 5);
+        let rect = Rect::new(0, 0, 20, 5);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        hm.render(&mut ctx);
+        // This tests the brightness > 128 branch in render
+    }
+
+    // ==================== Label Truncation Tests ====================
+
+    #[test]
+    fn test_col_label_truncation() {
+        use crate::layout::Rect;
+        use crate::render::Buffer;
+
+        let hm = HeatMap::new(vec![vec![0.5]])
+            .cell_width(3)
+            .col_labels(vec!["VeryLongLabel".into()]);
+
+        let mut buffer = Buffer::new(30, 10);
+        let rect = Rect::new(0, 0, 30, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        hm.render(&mut ctx);
+        // Column label should be truncated to cell_width
+    }
+
+    #[test]
+    fn test_row_label_truncation() {
+        use crate::layout::Rect;
+        use crate::render::Buffer;
+
+        let hm = HeatMap::new(vec![vec![0.5]]).row_labels(vec!["VeryLongRowLabel".into()]);
+
+        let mut buffer = Buffer::new(30, 10);
+        let rect = Rect::new(0, 0, 30, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        hm.render(&mut ctx);
+        // Row label should be truncated to 6 chars
+    }
 }

--- a/src/widget/menu.rs
+++ b/src/widget/menu.rs
@@ -836,4 +836,390 @@ mod tests {
         bar.render(&mut ctx);
         // Smoke test
     }
+
+    #[test]
+    fn test_menu_item_checked() {
+        let item = MenuItem::new("Toggle").checked(true);
+        assert_eq!(item.checked, Some(true));
+
+        let item2 = MenuItem::new("Toggle2").checked(false);
+        assert_eq!(item2.checked, Some(false));
+    }
+
+    #[test]
+    fn test_menu_item_submenu() {
+        let item = MenuItem::new("Parent")
+            .submenu(vec![MenuItem::new("Child 1"), MenuItem::new("Child 2")]);
+        assert!(item.has_submenu());
+        assert_eq!(item.submenu.len(), 2);
+    }
+
+    #[test]
+    fn test_menu_item_has_submenu() {
+        let item1 = MenuItem::new("No Submenu");
+        assert!(!item1.has_submenu());
+
+        let item2 = MenuItem::new("With Submenu").submenu(vec![MenuItem::new("Child")]);
+        assert!(item2.has_submenu());
+    }
+
+    #[test]
+    fn test_menu_item_on_select_and_execute() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let called = Rc::new(Cell::new(false));
+        let called_clone = called.clone();
+
+        let item = MenuItem::new("Action").on_select(move || {
+            called_clone.set(true);
+        });
+
+        item.execute();
+        assert!(called.get());
+    }
+
+    #[test]
+    fn test_menu_item_execute_disabled() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let called = Rc::new(Cell::new(false));
+        let called_clone = called.clone();
+
+        let item = MenuItem::new("Disabled Action")
+            .disabled(true)
+            .on_select(move || {
+                called_clone.set(true);
+            });
+
+        item.execute();
+        assert!(!called.get()); // Should not be called
+    }
+
+    #[test]
+    fn test_menu_items() {
+        let m = Menu::new("Edit").items(vec![
+            MenuItem::new("Cut"),
+            MenuItem::new("Copy"),
+            MenuItem::new("Paste"),
+        ]);
+        assert_eq!(m.items.len(), 3);
+    }
+
+    #[test]
+    fn test_menu_bar_colors() {
+        let bar = MenuBar::new().bg(Color::BLACK).fg(Color::WHITE);
+        assert_eq!(bar.bg, Color::BLACK);
+        assert_eq!(bar.fg, Color::WHITE);
+    }
+
+    #[test]
+    fn test_menu_bar_toggle() {
+        let mut bar = MenuBar::new().menu(Menu::new("File").item(MenuItem::new("New")));
+
+        assert!(!bar.is_open());
+
+        bar.toggle();
+        assert!(bar.is_open());
+
+        bar.toggle();
+        assert!(!bar.is_open());
+    }
+
+    #[test]
+    fn test_menu_bar_prev_menu() {
+        let mut bar = MenuBar::new()
+            .menu(Menu::new("File"))
+            .menu(Menu::new("Edit"))
+            .menu(Menu::new("View"));
+
+        bar.selected_menu = 2;
+        bar.prev_menu();
+        assert_eq!(bar.selected_menu, 1);
+
+        bar.prev_menu();
+        assert_eq!(bar.selected_menu, 0);
+
+        // Wrap around
+        bar.prev_menu();
+        assert_eq!(bar.selected_menu, 2);
+    }
+
+    #[test]
+    fn test_menu_bar_next_prev_item() {
+        let mut bar = MenuBar::new().menu(
+            Menu::new("File")
+                .item(MenuItem::new("New"))
+                .item(MenuItem::new("Open"))
+                .item(MenuItem::new("Save")),
+        );
+
+        bar.open_menu(0);
+        assert_eq!(bar.selected_item, Some(0));
+
+        bar.next_item();
+        assert_eq!(bar.selected_item, Some(1));
+
+        bar.next_item();
+        assert_eq!(bar.selected_item, Some(2));
+
+        // Wrap around
+        bar.next_item();
+        assert_eq!(bar.selected_item, Some(0));
+
+        bar.prev_item();
+        assert_eq!(bar.selected_item, Some(2));
+    }
+
+    #[test]
+    fn test_menu_bar_skip_separators() {
+        let mut bar = MenuBar::new().menu(
+            Menu::new("File")
+                .item(MenuItem::new("New"))
+                .separator()
+                .item(MenuItem::new("Exit")),
+        );
+
+        bar.open_menu(0);
+        bar.next_item();
+        // Should skip separator and go to Exit
+        assert_eq!(bar.selected_item, Some(2));
+    }
+
+    #[test]
+    fn test_menu_bar_execute_selected() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let called = Rc::new(Cell::new(false));
+        let called_clone = called.clone();
+
+        let mut bar = MenuBar::new().menu(Menu::new("File").item(
+            MenuItem::new("Action").on_select(move || {
+                called_clone.set(true);
+            }),
+        ));
+
+        bar.open_menu(0);
+        let result = bar.execute_selected();
+        assert!(result);
+        assert!(called.get());
+        assert!(!bar.is_open()); // Menu should close after execution
+    }
+
+    #[test]
+    fn test_menu_bar_handle_key() {
+        let mut bar = MenuBar::new()
+            .menu(Menu::new("File").item(MenuItem::new("New")))
+            .menu(Menu::new("Edit").item(MenuItem::new("Copy")));
+
+        // Left/Right navigation
+        assert!(bar.handle_key(&Key::Right));
+        assert_eq!(bar.selected_menu, 1);
+
+        assert!(bar.handle_key(&Key::Left));
+        assert_eq!(bar.selected_menu, 0);
+
+        // Vim keys
+        assert!(bar.handle_key(&Key::Char('l')));
+        assert_eq!(bar.selected_menu, 1);
+
+        assert!(bar.handle_key(&Key::Char('h')));
+        assert_eq!(bar.selected_menu, 0);
+
+        // Enter to open
+        assert!(bar.handle_key(&Key::Enter));
+        assert!(bar.is_open());
+
+        // Up/Down when open
+        assert!(bar.handle_key(&Key::Down));
+        assert!(bar.handle_key(&Key::Char('j')));
+        assert!(bar.handle_key(&Key::Up));
+        assert!(bar.handle_key(&Key::Char('k')));
+
+        // Escape to close
+        assert!(bar.handle_key(&Key::Escape));
+        assert!(!bar.is_open());
+
+        // Space to toggle
+        assert!(bar.handle_key(&Key::Char(' ')));
+        assert!(bar.is_open());
+
+        // Unknown key
+        bar.close();
+        assert!(!bar.handle_key(&Key::Char('x')));
+    }
+
+    #[test]
+    fn test_menu_bar_default() {
+        let bar = MenuBar::default();
+        assert!(bar.menus.is_empty());
+        assert!(!bar.is_open());
+    }
+
+    #[test]
+    fn test_context_menu_navigation() {
+        let mut menu = ContextMenu::new()
+            .item(MenuItem::new("Cut"))
+            .item(MenuItem::new("Copy"))
+            .item(MenuItem::new("Paste"));
+
+        menu.show(10, 10);
+
+        // Navigate down
+        menu.handle_key(&Key::Down);
+        assert_eq!(menu.selected, 1);
+
+        menu.handle_key(&Key::Char('j'));
+        assert_eq!(menu.selected, 2);
+
+        // Navigate up
+        menu.handle_key(&Key::Up);
+        assert_eq!(menu.selected, 1);
+
+        menu.handle_key(&Key::Char('k'));
+        assert_eq!(menu.selected, 0);
+    }
+
+    #[test]
+    fn test_context_menu_boundary() {
+        let mut menu = ContextMenu::new()
+            .item(MenuItem::new("Item 1"))
+            .item(MenuItem::new("Item 2"));
+
+        menu.show(0, 0);
+
+        // Move down to last item
+        menu.handle_key(&Key::Down);
+        assert_eq!(menu.selected, 1);
+
+        // Should stay at boundary
+        menu.handle_key(&Key::Down);
+        assert_eq!(menu.selected, 1);
+
+        // Move up to first
+        menu.handle_key(&Key::Up);
+        assert_eq!(menu.selected, 0);
+
+        // Should stay at boundary
+        menu.handle_key(&Key::Up);
+        assert_eq!(menu.selected, 0);
+    }
+
+    #[test]
+    fn test_context_menu_execute() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let called = Rc::new(Cell::new(false));
+        let called_clone = called.clone();
+
+        let mut menu = ContextMenu::new().item(MenuItem::new("Action").on_select(move || {
+            called_clone.set(true);
+        }));
+
+        menu.show(0, 0);
+        let result = menu.handle_key(&Key::Enter);
+        assert!(result);
+        assert!(called.get());
+        assert!(!menu.is_visible());
+    }
+
+    #[test]
+    fn test_context_menu_escape() {
+        let mut menu = ContextMenu::new().item(MenuItem::new("Item"));
+
+        menu.show(0, 0);
+        assert!(menu.is_visible());
+
+        menu.handle_key(&Key::Escape);
+        assert!(!menu.is_visible());
+    }
+
+    #[test]
+    fn test_context_menu_render() {
+        let mut buffer = Buffer::new(40, 20);
+        let area = Rect::new(0, 0, 40, 20);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let mut menu = ContextMenu::new()
+            .item(MenuItem::new("Cut").shortcut("Ctrl+X"))
+            .item(MenuItem::new("Copy").shortcut("Ctrl+C"))
+            .item(MenuItem::separator())
+            .item(MenuItem::new("Paste").shortcut("Ctrl+V"));
+
+        menu.show(5, 5);
+        menu.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_menu_bar_render_open() {
+        let mut buffer = Buffer::new(80, 24);
+        let area = Rect::new(0, 0, 80, 24);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let mut bar = MenuBar::new().menu(
+            Menu::new("File")
+                .item(MenuItem::new("New").shortcut("Ctrl+N"))
+                .item(MenuItem::new("Open").shortcut("Ctrl+O"))
+                .separator()
+                .item(MenuItem::new("Exit")),
+        );
+
+        bar.open_menu(0);
+        bar.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_menu_bar_empty() {
+        let mut bar = MenuBar::new();
+
+        // Should not panic on empty menu bar
+        bar.next_menu();
+        bar.prev_menu();
+        bar.next_item();
+        bar.prev_item();
+        assert!(!bar.execute_selected());
+    }
+
+    #[test]
+    fn test_context_menu_separator() {
+        let menu = ContextMenu::new()
+            .item(MenuItem::new("Cut"))
+            .item(MenuItem::separator())
+            .item(MenuItem::new("Paste"));
+
+        assert_eq!(menu.items.len(), 3);
+        assert!(menu.items[1].separator);
+    }
+
+    #[test]
+    fn test_context_menu_default_colors() {
+        let menu = ContextMenu::new();
+        // Default colors are set
+        assert_eq!(menu.bg, Color::rgb(40, 40, 40));
+        assert_eq!(menu.fg, Color::WHITE);
+    }
+
+    #[test]
+    fn test_menu_bar_open_menu_with_items() {
+        let mut bar = MenuBar::new()
+            .menu(Menu::new("File").item(MenuItem::new("New")))
+            .menu(Menu::new("Empty"));
+
+        bar.open_menu(0);
+        assert_eq!(bar.selected_item, Some(0));
+
+        bar.open_menu(1);
+        assert_eq!(bar.selected_item, None); // Empty menu
+    }
+
+    #[test]
+    fn test_menu_bar_open_out_of_bounds() {
+        let mut bar = MenuBar::new().menu(Menu::new("File"));
+
+        bar.open_menu(10); // Out of bounds
+        assert!(!bar.is_open());
+    }
 }

--- a/src/widget/resizable.rs
+++ b/src/widget/resizable.rs
@@ -740,4 +740,596 @@ mod tests {
         assert_eq!(content.width, 18);
         assert_eq!(content.height, 8);
     }
+
+    // ==================== ResizeHandle Tests ====================
+
+    #[test]
+    fn test_resize_handle_all_constant() {
+        assert_eq!(ResizeHandle::ALL.len(), 8);
+        assert!(ResizeHandle::ALL.contains(&ResizeHandle::Top));
+        assert!(ResizeHandle::ALL.contains(&ResizeHandle::Bottom));
+        assert!(ResizeHandle::ALL.contains(&ResizeHandle::Left));
+        assert!(ResizeHandle::ALL.contains(&ResizeHandle::Right));
+        assert!(ResizeHandle::ALL.contains(&ResizeHandle::TopLeft));
+        assert!(ResizeHandle::ALL.contains(&ResizeHandle::TopRight));
+        assert!(ResizeHandle::ALL.contains(&ResizeHandle::BottomLeft));
+        assert!(ResizeHandle::ALL.contains(&ResizeHandle::BottomRight));
+    }
+
+    #[test]
+    fn test_resize_handle_edges_constant() {
+        assert_eq!(ResizeHandle::EDGES.len(), 4);
+        assert!(ResizeHandle::EDGES.contains(&ResizeHandle::Top));
+        assert!(ResizeHandle::EDGES.contains(&ResizeHandle::Bottom));
+        assert!(ResizeHandle::EDGES.contains(&ResizeHandle::Left));
+        assert!(ResizeHandle::EDGES.contains(&ResizeHandle::Right));
+        assert!(!ResizeHandle::EDGES.contains(&ResizeHandle::TopLeft));
+    }
+
+    #[test]
+    fn test_resize_handle_corners_constant() {
+        assert_eq!(ResizeHandle::CORNERS.len(), 4);
+        assert!(ResizeHandle::CORNERS.contains(&ResizeHandle::TopLeft));
+        assert!(ResizeHandle::CORNERS.contains(&ResizeHandle::TopRight));
+        assert!(ResizeHandle::CORNERS.contains(&ResizeHandle::BottomLeft));
+        assert!(ResizeHandle::CORNERS.contains(&ResizeHandle::BottomRight));
+        assert!(!ResizeHandle::CORNERS.contains(&ResizeHandle::Top));
+    }
+
+    #[test]
+    fn test_resize_handle_debug_clone_eq() {
+        let handle = ResizeHandle::TopLeft;
+        let cloned = handle;
+        assert_eq!(handle, cloned);
+        let _ = format!("{:?}", handle);
+    }
+
+    #[test]
+    fn test_resize_handle_hit_test_top() {
+        let area = Rect::new(0, 0, 20, 10);
+        // Top edge (middle section, excluding corners)
+        assert!(ResizeHandle::Top.hit_test(10, 0, area, 1));
+        assert!(ResizeHandle::Top.hit_test(5, 0, area, 1));
+        // Corner positions should not match top edge
+        assert!(!ResizeHandle::Top.hit_test(0, 0, area, 1));
+        assert!(!ResizeHandle::Top.hit_test(19, 0, area, 1));
+        // Wrong row
+        assert!(!ResizeHandle::Top.hit_test(10, 5, area, 1));
+    }
+
+    #[test]
+    fn test_resize_handle_hit_test_bottom() {
+        let area = Rect::new(0, 0, 20, 10);
+        // Bottom edge (middle section)
+        assert!(ResizeHandle::Bottom.hit_test(10, 9, area, 1));
+        // Corners should not match
+        assert!(!ResizeHandle::Bottom.hit_test(0, 9, area, 1));
+        assert!(!ResizeHandle::Bottom.hit_test(19, 9, area, 1));
+    }
+
+    #[test]
+    fn test_resize_handle_hit_test_left() {
+        let area = Rect::new(0, 0, 20, 10);
+        // Left edge (middle section)
+        assert!(ResizeHandle::Left.hit_test(0, 5, area, 1));
+        // Corners should not match
+        assert!(!ResizeHandle::Left.hit_test(0, 0, area, 1));
+        assert!(!ResizeHandle::Left.hit_test(0, 9, area, 1));
+    }
+
+    #[test]
+    fn test_resize_handle_hit_test_right() {
+        let area = Rect::new(0, 0, 20, 10);
+        // Right edge (middle section)
+        assert!(ResizeHandle::Right.hit_test(19, 5, area, 1));
+        // Corners should not match
+        assert!(!ResizeHandle::Right.hit_test(19, 0, area, 1));
+        assert!(!ResizeHandle::Right.hit_test(19, 9, area, 1));
+    }
+
+    #[test]
+    fn test_resize_handle_hit_test_top_left() {
+        let area = Rect::new(0, 0, 20, 10);
+        assert!(ResizeHandle::TopLeft.hit_test(0, 0, area, 1));
+        assert!(ResizeHandle::TopLeft.hit_test(1, 1, area, 1));
+        assert!(!ResizeHandle::TopLeft.hit_test(10, 5, area, 1));
+    }
+
+    #[test]
+    fn test_resize_handle_hit_test_top_right() {
+        let area = Rect::new(0, 0, 20, 10);
+        assert!(ResizeHandle::TopRight.hit_test(19, 0, area, 1));
+        assert!(ResizeHandle::TopRight.hit_test(18, 1, area, 1));
+        assert!(!ResizeHandle::TopRight.hit_test(10, 5, area, 1));
+    }
+
+    #[test]
+    fn test_resize_handle_hit_test_bottom_left() {
+        let area = Rect::new(0, 0, 20, 10);
+        assert!(ResizeHandle::BottomLeft.hit_test(0, 9, area, 1));
+        assert!(ResizeHandle::BottomLeft.hit_test(1, 8, area, 1));
+        assert!(!ResizeHandle::BottomLeft.hit_test(10, 5, area, 1));
+    }
+
+    // ==================== ResizeDirection Tests ====================
+
+    #[test]
+    fn test_resize_direction_none() {
+        let dir = ResizeDirection::NONE;
+        assert_eq!(dir.horizontal, 0);
+        assert_eq!(dir.vertical, 0);
+    }
+
+    #[test]
+    fn test_resize_direction_from_handle_all() {
+        let top = ResizeDirection::from_handle(ResizeHandle::Top);
+        assert_eq!(top.horizontal, 0);
+        assert_eq!(top.vertical, -1);
+
+        let bottom = ResizeDirection::from_handle(ResizeHandle::Bottom);
+        assert_eq!(bottom.horizontal, 0);
+        assert_eq!(bottom.vertical, 1);
+
+        let left = ResizeDirection::from_handle(ResizeHandle::Left);
+        assert_eq!(left.horizontal, -1);
+        assert_eq!(left.vertical, 0);
+
+        let right = ResizeDirection::from_handle(ResizeHandle::Right);
+        assert_eq!(right.horizontal, 1);
+        assert_eq!(right.vertical, 0);
+
+        let top_left = ResizeDirection::from_handle(ResizeHandle::TopLeft);
+        assert_eq!(top_left.horizontal, -1);
+        assert_eq!(top_left.vertical, -1);
+
+        let top_right = ResizeDirection::from_handle(ResizeHandle::TopRight);
+        assert_eq!(top_right.horizontal, 1);
+        assert_eq!(top_right.vertical, -1);
+
+        let bottom_left = ResizeDirection::from_handle(ResizeHandle::BottomLeft);
+        assert_eq!(bottom_left.horizontal, -1);
+        assert_eq!(bottom_left.vertical, 1);
+
+        let bottom_right = ResizeDirection::from_handle(ResizeHandle::BottomRight);
+        assert_eq!(bottom_right.horizontal, 1);
+        assert_eq!(bottom_right.vertical, 1);
+    }
+
+    #[test]
+    fn test_resize_direction_debug_clone_eq() {
+        let dir = ResizeDirection::NONE;
+        let cloned = dir;
+        assert_eq!(dir, cloned);
+        let _ = format!("{:?}", dir);
+    }
+
+    // ==================== ResizeStyle Tests ====================
+
+    #[test]
+    fn test_resize_style_default() {
+        assert_eq!(ResizeStyle::default(), ResizeStyle::Border);
+    }
+
+    #[test]
+    fn test_resize_style_debug_clone_eq() {
+        let style = ResizeStyle::Subtle;
+        let cloned = style;
+        assert_eq!(style, cloned);
+        let _ = format!("{:?}", style);
+    }
+
+    #[test]
+    fn test_resize_style_variants() {
+        let _border = ResizeStyle::Border;
+        let _subtle = ResizeStyle::Subtle;
+        let _hidden = ResizeStyle::Hidden;
+        let _dots = ResizeStyle::Dots;
+    }
+
+    // ==================== Builder Methods Tests ====================
+
+    #[test]
+    fn test_resizable_handle_color() {
+        let r = Resizable::new(20, 10).handle_color(Color::RED);
+        assert_eq!(r.handle_color, Color::RED);
+    }
+
+    #[test]
+    fn test_resizable_active_color() {
+        let r = Resizable::new(20, 10).active_color(Color::GREEN);
+        assert_eq!(r.active_color, Color::GREEN);
+    }
+
+    #[test]
+    fn test_resizable_custom_aspect_ratio() {
+        let r = Resizable::new(20, 10).aspect_ratio(4.0);
+        assert!(r.preserve_aspect);
+        assert!((r.aspect_ratio - 4.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_resizable_style_subtle() {
+        let r = Resizable::new(20, 10).style(ResizeStyle::Subtle);
+        assert_eq!(r.style, ResizeStyle::Subtle);
+    }
+
+    #[test]
+    fn test_resizable_style_hidden() {
+        let r = Resizable::new(20, 10).style(ResizeStyle::Hidden);
+        assert_eq!(r.style, ResizeStyle::Hidden);
+    }
+
+    #[test]
+    fn test_resizable_style_dots() {
+        let r = Resizable::new(20, 10).style(ResizeStyle::Dots);
+        assert_eq!(r.style, ResizeStyle::Dots);
+    }
+
+    // ==================== Callback Tests ====================
+
+    #[test]
+    fn test_resizable_on_resize_callback() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let called = Rc::new(Cell::new(false));
+        let width_received = Rc::new(Cell::new(0u16));
+        let height_received = Rc::new(Cell::new(0u16));
+
+        let called_clone = called.clone();
+        let width_clone = width_received.clone();
+        let height_clone = height_received.clone();
+
+        let mut r = Resizable::new(20, 10).on_resize(move |w, h| {
+            called_clone.set(true);
+            width_clone.set(w);
+            height_clone.set(h);
+        });
+
+        r.start_resize(ResizeHandle::BottomRight);
+        r.apply_delta(5, 3);
+
+        assert!(called.get());
+        assert_eq!(width_received.get(), 25);
+        assert_eq!(height_received.get(), 13);
+    }
+
+    // ==================== Keyboard Handling Tests ====================
+
+    #[test]
+    fn test_resizable_handle_key_not_focused() {
+        let mut r = Resizable::new(20, 10);
+        // Not focused by default
+        let handled = r.handle_key(&Key::Right);
+        assert!(!handled);
+        assert_eq!(r.size(), (20, 10)); // Size unchanged
+    }
+
+    #[test]
+    fn test_resizable_handle_key_right() {
+        let mut r = Resizable::new(20, 10);
+        r.state.focused = true;
+
+        let handled = r.handle_key(&Key::Right);
+        assert!(handled);
+        assert_eq!(r.size(), (21, 10));
+    }
+
+    #[test]
+    fn test_resizable_handle_key_left() {
+        let mut r = Resizable::new(20, 10);
+        r.state.focused = true;
+
+        let handled = r.handle_key(&Key::Left);
+        assert!(handled);
+        assert_eq!(r.size(), (19, 10));
+    }
+
+    #[test]
+    fn test_resizable_handle_key_down() {
+        let mut r = Resizable::new(20, 10);
+        r.state.focused = true;
+
+        let handled = r.handle_key(&Key::Down);
+        assert!(handled);
+        assert_eq!(r.size(), (20, 11));
+    }
+
+    #[test]
+    fn test_resizable_handle_key_up() {
+        let mut r = Resizable::new(20, 10);
+        r.state.focused = true;
+
+        let handled = r.handle_key(&Key::Up);
+        assert!(handled);
+        assert_eq!(r.size(), (20, 9));
+    }
+
+    #[test]
+    fn test_resizable_handle_key_unhandled() {
+        let mut r = Resizable::new(20, 10);
+        r.state.focused = true;
+
+        let handled = r.handle_key(&Key::Enter);
+        assert!(!handled);
+    }
+
+    #[test]
+    fn test_resizable_handle_key_without_handle() {
+        let mut r = Resizable::new(20, 10).handles(ResizeHandle::CORNERS);
+        r.state.focused = true;
+
+        // Right handle not in CORNERS
+        let handled = r.handle_key(&Key::Right);
+        assert!(!handled);
+        assert_eq!(r.size(), (20, 10));
+    }
+
+    // ==================== handle_at Tests ====================
+
+    #[test]
+    fn test_resizable_handle_at() {
+        let r = Resizable::new(20, 10);
+        let area = Rect::new(0, 0, 20, 10);
+
+        // Test corner detection
+        assert_eq!(r.handle_at(0, 0, area), Some(ResizeHandle::TopLeft));
+        assert_eq!(r.handle_at(19, 0, area), Some(ResizeHandle::TopRight));
+        assert_eq!(r.handle_at(0, 9, area), Some(ResizeHandle::BottomLeft));
+        assert_eq!(r.handle_at(19, 9, area), Some(ResizeHandle::BottomRight));
+
+        // Test center (no handle)
+        assert_eq!(r.handle_at(10, 5, area), None);
+    }
+
+    #[test]
+    fn test_resizable_set_hovered() {
+        let mut r = Resizable::new(20, 10);
+        assert_eq!(r.hovered_handle, None);
+
+        r.set_hovered(Some(ResizeHandle::TopLeft));
+        assert_eq!(r.hovered_handle, Some(ResizeHandle::TopLeft));
+
+        r.set_hovered(None);
+        assert_eq!(r.hovered_handle, None);
+    }
+
+    // ==================== Edge Cases ====================
+
+    #[test]
+    fn test_resizable_min_size_enforced() {
+        let r = Resizable::new(0, 0);
+        // Minimum is 1x1 even when created with 0x0
+        assert_eq!(r.size(), (1, 1));
+    }
+
+    #[test]
+    fn test_resizable_min_constraint_enforced() {
+        let mut r = Resizable::new(20, 10).min_size(10, 5);
+        r.set_size(1, 1);
+        assert_eq!(r.size(), (10, 5));
+    }
+
+    #[test]
+    fn test_resizable_max_only() {
+        let mut r = Resizable::new(20, 10).max_size(30, 0);
+        // max_height = 0 means unlimited
+        r.set_size(40, 100);
+        assert_eq!(r.size(), (30, 100));
+    }
+
+    #[test]
+    fn test_resizable_start_resize_invalid_handle() {
+        let mut r = Resizable::new(20, 10).handles(ResizeHandle::CORNERS);
+        r.start_resize(ResizeHandle::Top); // Top is not in CORNERS
+        assert!(!r.is_resizing());
+    }
+
+    #[test]
+    fn test_resizable_apply_delta_not_resizing() {
+        let mut r = Resizable::new(20, 10);
+        // Not in resizing state
+        r.apply_delta(10, 10);
+        // Size should not change
+        assert_eq!(r.size(), (20, 10));
+    }
+
+    #[test]
+    fn test_resizable_apply_delta_negative() {
+        let mut r = Resizable::new(20, 10);
+        r.start_resize(ResizeHandle::Left);
+        r.apply_delta(-5, 0);
+        // Left direction means -1, so delta -5 * -1 = +5
+        assert_eq!(r.size(), (25, 10));
+    }
+
+    #[test]
+    fn test_content_area_non_border_style() {
+        let r = Resizable::new(20, 10).style(ResizeStyle::Dots);
+        let area = Rect::new(5, 5, 20, 10);
+        let content = r.content_area(area);
+
+        // No border padding for Dots style
+        assert_eq!(content.x, 5);
+        assert_eq!(content.y, 5);
+        assert_eq!(content.width, 20);
+        assert_eq!(content.height, 10);
+    }
+
+    // ==================== Rendering Tests ====================
+
+    #[test]
+    fn test_resizable_render_border() {
+        use crate::render::Buffer;
+
+        let r = Resizable::new(10, 5).style(ResizeStyle::Border);
+        let mut buffer = Buffer::new(20, 10);
+        let rect = Rect::new(0, 0, 20, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        r.render(&mut ctx);
+
+        // Check border characters
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, '┌');
+        assert_eq!(buffer.get(9, 0).unwrap().symbol, '┐');
+        assert_eq!(buffer.get(0, 4).unwrap().symbol, '└');
+        assert_eq!(buffer.get(9, 4).unwrap().symbol, '┘');
+    }
+
+    #[test]
+    fn test_resizable_render_dots() {
+        use crate::render::Buffer;
+
+        let r = Resizable::new(10, 5).style(ResizeStyle::Dots);
+        let mut buffer = Buffer::new(20, 10);
+        let rect = Rect::new(0, 0, 20, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        r.render(&mut ctx);
+
+        // Check corner dots
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, '●');
+        assert_eq!(buffer.get(9, 0).unwrap().symbol, '●');
+        assert_eq!(buffer.get(0, 4).unwrap().symbol, '●');
+        assert_eq!(buffer.get(9, 4).unwrap().symbol, '●');
+    }
+
+    #[test]
+    fn test_resizable_render_hidden() {
+        use crate::render::Buffer;
+
+        let r = Resizable::new(10, 5).style(ResizeStyle::Hidden);
+        let mut buffer = Buffer::new(20, 10);
+        let rect = Rect::new(0, 0, 20, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        r.render(&mut ctx);
+
+        // Hidden style should not draw anything
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, ' ');
+    }
+
+    #[test]
+    fn test_resizable_render_subtle_not_hovered() {
+        use crate::render::Buffer;
+
+        let r = Resizable::new(10, 5).style(ResizeStyle::Subtle);
+        let mut buffer = Buffer::new(20, 10);
+        let rect = Rect::new(0, 0, 20, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        r.render(&mut ctx);
+
+        // Subtle style without hover should not draw border
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, ' ');
+    }
+
+    #[test]
+    fn test_resizable_render_subtle_hovered() {
+        use crate::render::Buffer;
+
+        let mut r = Resizable::new(10, 5).style(ResizeStyle::Subtle);
+        r.set_hovered(Some(ResizeHandle::TopLeft));
+
+        let mut buffer = Buffer::new(20, 10);
+        let rect = Rect::new(0, 0, 20, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        r.render(&mut ctx);
+
+        // Subtle style with hover should draw border
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, '┌');
+    }
+
+    #[test]
+    fn test_resizable_render_while_resizing() {
+        use crate::render::Buffer;
+
+        let mut r = Resizable::new(10, 5).style(ResizeStyle::Border);
+        r.start_resize(ResizeHandle::BottomRight);
+
+        let mut buffer = Buffer::new(20, 10);
+        let rect = Rect::new(0, 0, 20, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        r.render(&mut ctx);
+
+        // Should still render border with active color
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, '┌');
+    }
+
+    #[test]
+    fn test_resizable_render_with_hovered_corner() {
+        use crate::render::Buffer;
+
+        let mut r = Resizable::new(10, 5).style(ResizeStyle::Border);
+        r.set_hovered(Some(ResizeHandle::TopRight));
+
+        let mut buffer = Buffer::new(20, 10);
+        let rect = Rect::new(0, 0, 20, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        r.render(&mut ctx);
+
+        // Border should be rendered with highlighted corner
+        assert_eq!(buffer.get(9, 0).unwrap().symbol, '┐');
+    }
+
+    #[test]
+    fn test_resizable_render_hovered_bottom_corners() {
+        use crate::render::Buffer;
+
+        let mut r = Resizable::new(10, 5).style(ResizeStyle::Border);
+        r.set_hovered(Some(ResizeHandle::BottomLeft));
+
+        let mut buffer = Buffer::new(20, 10);
+        let rect = Rect::new(0, 0, 20, 10);
+        let mut ctx = RenderContext::new(&mut buffer, rect);
+
+        r.render(&mut ctx);
+        assert_eq!(buffer.get(0, 4).unwrap().symbol, '└');
+
+        // Test BottomRight
+        r.set_hovered(Some(ResizeHandle::BottomRight));
+        let mut buffer2 = Buffer::new(20, 10);
+        let mut ctx2 = RenderContext::new(&mut buffer2, rect);
+        r.render(&mut ctx2);
+        assert_eq!(buffer2.get(9, 4).unwrap().symbol, '┘');
+    }
+
+    // ==================== Helper Function Tests ====================
+
+    #[test]
+    fn test_resizable_helper_function() {
+        let r = resizable(30, 15);
+        assert_eq!(r.size(), (30, 15));
+    }
+
+    // ==================== Aspect Ratio Edge Cases ====================
+
+    #[test]
+    fn test_aspect_ratio_with_max_constraint() {
+        let mut r = Resizable::new(20, 10)
+            .preserve_aspect_ratio()
+            .max_size(50, 20);
+
+        r.set_size(60, 10);
+        // Width clamped to 50, height adjusted for 2:1 ratio
+        assert_eq!(r.width, 50);
+        // Height should be 25 for 2:1, but clamped to max 20
+        assert!(r.height <= 20);
+    }
+
+    #[test]
+    fn test_grid_snap_rounds() {
+        let mut r = Resizable::new(20, 10).snap_to_grid(10, 10);
+
+        // 23 rounds to 20 (23 + 5 = 28, 28/10 = 2, 2*10 = 20)
+        r.set_size(23, 14);
+        assert_eq!(r.size(), (20, 10));
+
+        // 27 rounds to 30
+        r.set_size(27, 16);
+        assert_eq!(r.size(), (30, 20));
+    }
 }

--- a/src/widget/sortable.rs
+++ b/src/widget/sortable.rs
@@ -638,4 +638,306 @@ mod tests {
         assert!(data.is_some());
         assert_eq!(data.unwrap().as_list_index(), Some(1));
     }
+
+    #[test]
+    fn test_sortable_list_on_reorder() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let called = Rc::new(Cell::new(false));
+        let called_clone = called.clone();
+
+        let mut list = SortableList::new(["A", "B", "C"]).on_reorder(move |from, to| {
+            called_clone.set(true);
+            assert!(from != to);
+        });
+
+        list.set_selected(Some(0));
+        list.move_down();
+
+        assert!(called.get());
+    }
+
+    #[test]
+    fn test_sortable_list_handles() {
+        let list = SortableList::new(["A"]).handles(false);
+        assert!(!list.show_handles);
+
+        let list2 = SortableList::new(["A"]).handles(true);
+        assert!(list2.show_handles);
+    }
+
+    #[test]
+    fn test_sortable_list_colors() {
+        let list = SortableList::new(["A"])
+            .item_color(Color::RED)
+            .selected_color(Color::BLUE);
+
+        assert_eq!(list.item_color, Color::RED);
+        assert_eq!(list.selected_color, Color::BLUE);
+    }
+
+    #[test]
+    fn test_sortable_list_items() {
+        let list = SortableList::new(["A", "B"]);
+        let items = list.items();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].label, "A");
+    }
+
+    #[test]
+    fn test_sortable_list_items_mut() {
+        let mut list = SortableList::new(["A", "B"]);
+        let items = list.items_mut();
+        items[0].label = "X".to_string();
+        assert_eq!(list.items()[0].label, "X");
+    }
+
+    #[test]
+    fn test_sortable_list_end_drag() {
+        let mut list = SortableList::new(["A", "B", "C"]);
+        list.set_selected(Some(0));
+        list.start_drag();
+        list.drop_target = Some(2);
+
+        list.end_drag();
+
+        assert!(!list.is_dragging());
+        // Item A moved from 0 to after B (index 1)
+        assert_eq!(list.items[0].label, "B");
+        assert_eq!(list.items[1].label, "A");
+    }
+
+    #[test]
+    fn test_sortable_list_update_drop_target() {
+        let mut list = SortableList::new(["A", "B", "C"]);
+        list.set_selected(Some(0));
+        list.start_drag();
+
+        list.update_drop_target(5, 0);
+
+        assert!(list.drop_target.is_some());
+    }
+
+    #[test]
+    fn test_sortable_list_remove_updates_selection() {
+        let mut list = SortableList::new(["A", "B", "C"]);
+        list.set_selected(Some(2)); // Select last item
+
+        list.remove(2); // Remove selected item
+
+        // Selection should move to new last item
+        assert_eq!(list.selected(), Some(1));
+    }
+
+    #[test]
+    fn test_sortable_list_remove_all() {
+        let mut list = SortableList::new(["A"]);
+        list.set_selected(Some(0));
+
+        list.remove(0);
+
+        assert!(list.items.is_empty());
+        assert_eq!(list.selected(), None);
+    }
+
+    #[test]
+    fn test_sortable_list_select_empty() {
+        let mut list = SortableList::new::<[&str; 0], &str>([]);
+
+        list.select_next();
+        assert!(list.selected().is_none());
+
+        list.select_prev();
+        assert!(list.selected().is_none());
+    }
+
+    #[test]
+    fn test_sortable_list_render() {
+        use crate::render::Buffer;
+
+        let mut buffer = Buffer::new(40, 10);
+        let area = Rect::new(0, 0, 40, 10);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let list = SortableList::new(["A", "B", "C"]);
+        list.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_sortable_list_render_with_selection() {
+        use crate::render::Buffer;
+
+        let mut buffer = Buffer::new(40, 10);
+        let area = Rect::new(0, 0, 40, 10);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let mut list = SortableList::new(["A", "B", "C"]);
+        list.set_selected(Some(1));
+        list.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_sortable_list_render_dragging() {
+        use crate::render::Buffer;
+
+        let mut buffer = Buffer::new(40, 10);
+        let area = Rect::new(0, 0, 40, 10);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let mut list = SortableList::new(["A", "B", "C"]);
+        list.set_selected(Some(1));
+        list.start_drag();
+        list.drop_target = Some(0);
+        list.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_sortable_list_handle_key() {
+        let mut list = SortableList::new(["A", "B", "C"]);
+
+        // j/k for navigation
+        list.handle_key(&KeyEvent::new(crate::event::Key::Char('j')));
+        assert_eq!(list.selected(), Some(0));
+
+        list.handle_key(&KeyEvent::new(crate::event::Key::Down));
+        assert_eq!(list.selected(), Some(1));
+
+        list.handle_key(&KeyEvent::new(crate::event::Key::Char('k')));
+        assert_eq!(list.selected(), Some(0));
+
+        list.handle_key(&KeyEvent::new(crate::event::Key::Up));
+        assert_eq!(list.selected(), Some(0)); // Already at top
+    }
+
+    #[test]
+    fn test_sortable_list_handle_key_move() {
+        let mut list = SortableList::new(["A", "B", "C"]);
+        list.set_selected(Some(0));
+
+        // Shift+J/K for moving items
+        let mut shift_j = KeyEvent::new(crate::event::Key::Down);
+        shift_j.shift = true;
+        list.handle_key(&shift_j);
+        assert_eq!(list.items[0].label, "B");
+        assert_eq!(list.items[1].label, "A");
+
+        let mut shift_k = KeyEvent::new(crate::event::Key::Up);
+        shift_k.shift = true;
+        list.handle_key(&shift_k);
+        assert_eq!(list.items[0].label, "A");
+        assert_eq!(list.items[1].label, "B");
+    }
+
+    #[test]
+    fn test_sortable_list_handle_mouse() {
+        let mut list = SortableList::new(["A", "B", "C"]);
+        let area = Rect::new(0, 0, 40, 10);
+
+        // Click to select
+        let event = MouseEvent::new(5, 1, MouseEventKind::Down(MouseButton::Left));
+
+        list.handle_mouse(&event, area);
+        assert_eq!(list.selected(), Some(1));
+    }
+
+    #[test]
+    fn test_sortable_list_can_drop() {
+        let list = SortableList::new(["A", "B", "C"]);
+        assert!(list.can_drop());
+    }
+
+    #[test]
+    fn test_sortable_list_accepted_types() {
+        let list = SortableList::new(["A", "B", "C"]);
+        let types = list.accepted_types();
+        assert!(types.contains(&"list_item"));
+    }
+
+    #[test]
+    fn test_sortable_list_drag_enter_leave() {
+        let mut list = SortableList::new(["A", "B", "C"]);
+
+        let data = DragData::list_item(1, "B");
+        list.on_drag_enter(&data);
+
+        list.on_drag_leave();
+    }
+
+    #[test]
+    fn test_sortable_list_helper() {
+        let list = sortable_list(["A", "B"]);
+        assert_eq!(list.items().len(), 2);
+    }
+
+    #[test]
+    fn test_sortable_item_new() {
+        let item = SortableItem::new("Test", 5);
+        assert_eq!(item.label, "Test");
+        assert_eq!(item.original_index, 5);
+        assert!(!item.selected);
+        assert!(!item.dragging);
+    }
+
+    #[test]
+    fn test_sortable_list_order_after_reorder() {
+        let mut list = SortableList::new(["A", "B", "C"]);
+        list.set_selected(Some(0));
+        list.move_down();
+
+        // After moving A from 0 to 1, order is [B, A, C]
+        // Original indices are [1, 0, 2]
+        let order = list.order();
+        assert_eq!(order, vec![1, 0, 2]);
+    }
+
+    #[test]
+    fn test_sortable_list_cancel_drag_out_of_bounds() {
+        let mut list = SortableList::new(["A"]);
+        list.set_selected(Some(0));
+        list.start_drag();
+
+        // Remove the item while dragging
+        list.items.clear();
+
+        // Should not panic
+        list.cancel_drag();
+        assert!(!list.is_dragging());
+    }
+
+    #[test]
+    fn test_sortable_list_end_drag_same_position() {
+        let mut list = SortableList::new(["A", "B", "C"]);
+        list.set_selected(Some(1));
+        list.start_drag();
+        list.drop_target = Some(1); // Same position
+
+        list.end_drag();
+
+        // Should not reorder
+        assert_eq!(list.items[0].label, "A");
+        assert_eq!(list.items[1].label, "B");
+    }
+
+    #[test]
+    fn test_sortable_list_remove_out_of_bounds() {
+        let mut list = SortableList::new(["A"]);
+        let removed = list.remove(10);
+        assert!(removed.is_none());
+    }
+
+    #[test]
+    fn test_sortable_list_move_at_boundary() {
+        let mut list = SortableList::new(["A", "B"]);
+
+        // Try to move up from first item
+        list.set_selected(Some(0));
+        list.move_up();
+        assert_eq!(list.items[0].label, "A"); // No change
+
+        // Try to move down from last item
+        list.set_selected(Some(1));
+        list.move_down();
+        assert_eq!(list.items[1].label, "B"); // No change
+    }
 }


### PR DESCRIPTION
## Summary

- Improve test coverage for 6 widgets with low coverage
- Add 250+ new tests total

### Coverage improvements:
| Widget | Before | After |
|--------|--------|-------|
| menu.rs | 32% | ~93% |
| dropzone.rs | 34% | ~95% |
| sortable.rs | 44% | ~87% |
| heatmap.rs | 47% | ~85% |
| resizable.rs | 48% | ~90% |
| datagrid.rs | 72% | ~90% |

### Tests added:
- **menu.rs**: MenuItem builders, MenuBar/ContextMenu navigation, styling, callbacks
- **dropzone.rs**: DragData handling, on_drop/on_drag_enter callbacks, rendering
- **sortable.rs**: SortableList operations, key/mouse handling, reordering
- **heatmap.rs**: ColorScale variants, CellDisplay, normalization, rendering
- **resizable.rs**: ResizeHandle/Direction constants, keyboard handling, rendering styles
- **datagrid.rs**: GridColors/Options, sorting, filtering, selection, editing

Closes #85

## Test plan
- [x] All existing tests pass
- [x] New tests pass
- [x] Pre-commit hooks pass (fmt, clippy, check)