### PR TITLE
feat(widget): add NumberInput, MultiSelect, and RangePicker widgets

### DIFF
--- a/src/widget/calendar.rs
+++ b/src/widget/calendar.rs
@@ -86,6 +86,49 @@ impl Date {
         let first = first_day_of_month(self.year, self.month);
         (first + self.day - 1) % 7
     }
+
+    /// Get previous day
+    pub fn prev_day(&self) -> Self {
+        if self.day > 1 {
+            Self::new(self.year, self.month, self.day - 1)
+        } else if self.month > 1 {
+            let prev_month = self.month - 1;
+            let days = days_in_month(self.year, prev_month);
+            Self::new(self.year, prev_month, days)
+        } else {
+            Self::new(self.year - 1, 12, 31)
+        }
+    }
+
+    /// Get next day
+    pub fn next_day(&self) -> Self {
+        let days = days_in_month(self.year, self.month);
+        if self.day < days {
+            Self::new(self.year, self.month, self.day + 1)
+        } else if self.month < 12 {
+            Self::new(self.year, self.month + 1, 1)
+        } else {
+            Self::new(self.year + 1, 1, 1)
+        }
+    }
+
+    /// Subtract n days from this date
+    pub fn subtract_days(&self, n: u32) -> Self {
+        let mut result = *self;
+        for _ in 0..n {
+            result = result.prev_day();
+        }
+        result
+    }
+
+    /// Add n days to this date
+    pub fn add_days(&self, n: u32) -> Self {
+        let mut result = *self;
+        for _ in 0..n {
+            result = result.next_day();
+        }
+        result
+    }
 }
 
 impl Default for Date {

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -214,7 +214,9 @@ mod masked_input;
 mod menu;
 mod mermaid;
 mod modal;
+mod multi_select;
 mod notification;
+mod number_input;
 mod option_list;
 mod pagination;
 mod positioned;
@@ -225,6 +227,7 @@ mod progress;
 #[cfg(feature = "qrcode")]
 mod qrcode;
 mod radio;
+mod range_picker;
 mod rating;
 mod resizable;
 mod richlog;
@@ -352,8 +355,12 @@ pub use mermaid::{
     NodeShape,
 };
 pub use modal::{modal, Modal, ModalButton, ModalButtonStyle};
+pub use multi_select::{multi_select, multi_select_from, MultiSelect, MultiSelectOption};
 pub use notification::{
     notification_center, Notification, NotificationCenter, NotificationLevel, NotificationPosition,
+};
+pub use number_input::{
+    currency_input, integer_input, number_input, percentage_input, NumberInput,
 };
 pub use option_list::{
     option_item, option_list, OptionEntry, OptionItem, OptionList,
@@ -370,6 +377,9 @@ pub use progress::{progress, Progress, ProgressStyle};
 #[cfg(feature = "qrcode")]
 pub use qrcode::{qrcode, qrcode_url, ErrorCorrection, QrCodeWidget, QrStyle};
 pub use radio::{radio_group, RadioGroup, RadioLayout, RadioStyle};
+pub use range_picker::{
+    analytics_range_picker, date_range_picker, range_picker, PresetRange, RangeFocus, RangePicker,
+};
 pub use rating::{rating, Rating, RatingSize, RatingStyle};
 pub use resizable::{resizable, Resizable, ResizeDirection, ResizeHandle, ResizeStyle};
 pub use richlog::{log_entry, richlog, LogEntry, LogLevel, RichLog};

--- a/src/widget/multi_select.rs
+++ b/src/widget/multi_select.rs
@@ -1,0 +1,1032 @@
+//! Multi-select widget for choosing multiple options from a list
+//!
+//! Provides a dropdown with:
+//! - Multiple selection with tag display
+//! - Fuzzy search filtering
+//! - Tag navigation and removal
+//! - Optional maximum selection limit
+
+use super::traits::{RenderContext, View, WidgetProps, WidgetState};
+use crate::event::Key;
+use crate::render::Cell;
+use crate::style::Color;
+use crate::utils::{fuzzy_match, FuzzyMatch};
+use crate::{impl_props_builders, impl_state_builders, impl_styled_view, impl_view_meta};
+
+/// An option in the multi-select widget
+#[derive(Debug, Clone)]
+pub struct MultiSelectOption {
+    /// Display label
+    pub label: String,
+    /// Value (can be same as label)
+    pub value: String,
+    /// Whether this option is disabled
+    pub disabled: bool,
+}
+
+impl MultiSelectOption {
+    /// Create a new option
+    pub fn new(label: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            value: value.into(),
+            disabled: false,
+        }
+    }
+
+    /// Create an option where label equals value
+    pub fn simple(label: impl Into<String>) -> Self {
+        let label = label.into();
+        Self {
+            value: label.clone(),
+            label,
+            disabled: false,
+        }
+    }
+
+    /// Set disabled state
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}
+
+/// A multi-select widget for choosing multiple options
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use revue::widget::{multi_select, MultiSelect, MultiSelectOption};
+///
+/// // Basic multi-select
+/// let select = multi_select()
+///     .option("Apple")
+///     .option("Banana")
+///     .option("Cherry");
+///
+/// // With pre-selected values
+/// let select = multi_select()
+///     .options(vec!["Red", "Green", "Blue"])
+///     .selected_indices(vec![0, 2]);  // Red and Blue selected
+///
+/// // From a list of items
+/// let fruits = vec!["Apple", "Banana", "Cherry", "Date"];
+/// let select = multi_select_from(fruits);
+/// ```
+#[derive(Debug, Clone)]
+pub struct MultiSelect {
+    /// Available options
+    options: Vec<MultiSelectOption>,
+    /// Selected option indices
+    selected: Vec<usize>,
+    /// Whether dropdown is open
+    open: bool,
+    /// Cursor position in dropdown
+    dropdown_cursor: usize,
+    /// Cursor position in tags (for navigation/deletion)
+    tag_cursor: Option<usize>,
+    /// Search query for filtering
+    query: String,
+    /// Filtered option indices
+    filtered: Vec<usize>,
+    /// Placeholder text
+    placeholder: String,
+    /// Maximum number of selections (None = unlimited)
+    max_selections: Option<usize>,
+    /// Width of the widget
+    width: Option<u16>,
+    /// Whether search is enabled
+    searchable: bool,
+    /// Highlight color for matched characters
+    highlight_fg: Option<Color>,
+    /// Selected tag background color
+    tag_bg: Option<Color>,
+    /// Widget state
+    state: WidgetState,
+    /// Widget props
+    props: WidgetProps,
+}
+
+impl MultiSelect {
+    /// Create a new multi-select widget
+    pub fn new() -> Self {
+        Self {
+            options: Vec::new(),
+            selected: Vec::new(),
+            open: false,
+            dropdown_cursor: 0,
+            tag_cursor: None,
+            query: String::new(),
+            filtered: Vec::new(),
+            placeholder: "Select...".to_string(),
+            max_selections: None,
+            width: None,
+            searchable: true,
+            highlight_fg: Some(Color::YELLOW),
+            tag_bg: Some(Color::rgb(60, 60, 140)),
+            state: WidgetState::new(),
+            props: WidgetProps::new(),
+        }
+    }
+
+    /// Set options from a vector of strings
+    pub fn options(mut self, options: Vec<impl Into<String>>) -> Self {
+        self.options = options
+            .into_iter()
+            .map(|o| MultiSelectOption::simple(o))
+            .collect();
+        self.reset_filter();
+        self
+    }
+
+    /// Set options from MultiSelectOption items
+    pub fn options_detailed(mut self, options: Vec<MultiSelectOption>) -> Self {
+        self.options = options;
+        self.reset_filter();
+        self
+    }
+
+    /// Add a single option
+    pub fn option(mut self, label: impl Into<String>) -> Self {
+        self.options.push(MultiSelectOption::simple(label));
+        self.reset_filter();
+        self
+    }
+
+    /// Add a detailed option
+    pub fn option_detailed(mut self, option: MultiSelectOption) -> Self {
+        self.options.push(option);
+        self.reset_filter();
+        self
+    }
+
+    /// Set pre-selected indices
+    pub fn selected_indices(mut self, indices: Vec<usize>) -> Self {
+        self.selected = indices
+            .into_iter()
+            .filter(|&i| i < self.options.len())
+            .collect();
+        self
+    }
+
+    /// Set pre-selected values
+    pub fn selected_values(mut self, values: Vec<impl AsRef<str>>) -> Self {
+        self.selected = values
+            .iter()
+            .filter_map(|v| self.options.iter().position(|opt| opt.value == v.as_ref()))
+            .collect();
+        self
+    }
+
+    /// Set placeholder text
+    pub fn placeholder(mut self, text: impl Into<String>) -> Self {
+        self.placeholder = text.into();
+        self
+    }
+
+    /// Set maximum number of selections
+    pub fn max_selections(mut self, max: usize) -> Self {
+        self.max_selections = Some(max);
+        self
+    }
+
+    /// Set widget width
+    pub fn width(mut self, width: u16) -> Self {
+        self.width = Some(width);
+        self
+    }
+
+    /// Enable or disable search
+    pub fn searchable(mut self, enable: bool) -> Self {
+        self.searchable = enable;
+        self
+    }
+
+    /// Set highlight color for matched characters
+    pub fn highlight_fg(mut self, color: Color) -> Self {
+        self.highlight_fg = Some(color);
+        self
+    }
+
+    /// Set tag background color
+    pub fn tag_bg(mut self, color: Color) -> Self {
+        self.tag_bg = Some(color);
+        self
+    }
+
+    // =========================================================================
+    // State queries
+    // =========================================================================
+
+    /// Check if dropdown is open
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Get selected indices
+    pub fn get_selected_indices(&self) -> &[usize] {
+        &self.selected
+    }
+
+    /// Get selected values
+    pub fn get_selected_values(&self) -> Vec<&str> {
+        self.selected
+            .iter()
+            .filter_map(|&i| self.options.get(i).map(|o| o.value.as_str()))
+            .collect()
+    }
+
+    /// Get selected labels
+    pub fn get_selected_labels(&self) -> Vec<&str> {
+        self.selected
+            .iter()
+            .filter_map(|&i| self.options.get(i).map(|o| o.label.as_str()))
+            .collect()
+    }
+
+    /// Get number of selected items
+    pub fn selection_count(&self) -> usize {
+        self.selected.len()
+    }
+
+    /// Check if an option is selected
+    pub fn is_selected(&self, index: usize) -> bool {
+        self.selected.contains(&index)
+    }
+
+    /// Check if can select more items
+    pub fn can_select_more(&self) -> bool {
+        match self.max_selections {
+            Some(max) => self.selected.len() < max,
+            None => true,
+        }
+    }
+
+    /// Get number of options
+    pub fn len(&self) -> usize {
+        self.options.len()
+    }
+
+    /// Check if there are no options
+    pub fn is_empty(&self) -> bool {
+        self.options.is_empty()
+    }
+
+    // =========================================================================
+    // Selection manipulation
+    // =========================================================================
+
+    /// Open the dropdown
+    pub fn open(&mut self) {
+        self.open = true;
+        self.tag_cursor = None;
+        self.reset_filter();
+    }
+
+    /// Close the dropdown
+    pub fn close(&mut self) {
+        self.open = false;
+        self.query.clear();
+        self.reset_filter();
+    }
+
+    /// Toggle dropdown
+    pub fn toggle(&mut self) {
+        if self.open {
+            self.close();
+        } else {
+            self.open();
+        }
+    }
+
+    /// Select an option by index
+    pub fn select_option(&mut self, index: usize) {
+        if index >= self.options.len() {
+            return;
+        }
+        if self.options[index].disabled {
+            return;
+        }
+        if !self.selected.contains(&index) && self.can_select_more() {
+            self.selected.push(index);
+        }
+    }
+
+    /// Deselect an option by index
+    pub fn deselect_option(&mut self, index: usize) {
+        self.selected.retain(|&i| i != index);
+    }
+
+    /// Toggle selection of an option
+    pub fn toggle_option(&mut self, index: usize) {
+        if self.is_selected(index) {
+            self.deselect_option(index);
+        } else {
+            self.select_option(index);
+        }
+    }
+
+    /// Clear all selections
+    pub fn clear_selection(&mut self) {
+        self.selected.clear();
+    }
+
+    /// Select all options
+    pub fn select_all(&mut self) {
+        self.selected = (0..self.options.len())
+            .filter(|&i| !self.options[i].disabled)
+            .collect();
+        if let Some(max) = self.max_selections {
+            self.selected.truncate(max);
+        }
+    }
+
+    /// Remove the last selected tag
+    pub fn remove_last_tag(&mut self) {
+        self.selected.pop();
+    }
+
+    /// Remove tag at cursor position
+    pub fn remove_tag_at_cursor(&mut self) {
+        if let Some(cursor) = self.tag_cursor {
+            if cursor < self.selected.len() {
+                self.selected.remove(cursor);
+                // Adjust cursor
+                if self.selected.is_empty() {
+                    self.tag_cursor = None;
+                } else if cursor >= self.selected.len() {
+                    self.tag_cursor = Some(self.selected.len() - 1);
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Navigation
+    // =========================================================================
+
+    /// Move dropdown cursor down
+    pub fn cursor_down(&mut self) {
+        if self.filtered.is_empty() {
+            return;
+        }
+        self.dropdown_cursor = (self.dropdown_cursor + 1) % self.filtered.len();
+    }
+
+    /// Move dropdown cursor up
+    pub fn cursor_up(&mut self) {
+        if self.filtered.is_empty() {
+            return;
+        }
+        self.dropdown_cursor = self
+            .dropdown_cursor
+            .checked_sub(1)
+            .unwrap_or(self.filtered.len() - 1);
+    }
+
+    /// Move tag cursor left
+    pub fn tag_cursor_left(&mut self) {
+        if self.selected.is_empty() {
+            return;
+        }
+        match self.tag_cursor {
+            None => self.tag_cursor = Some(self.selected.len() - 1),
+            Some(0) => {} // Already at start
+            Some(pos) => self.tag_cursor = Some(pos - 1),
+        }
+    }
+
+    /// Move tag cursor right
+    pub fn tag_cursor_right(&mut self) {
+        match self.tag_cursor {
+            None => {}
+            Some(pos) if pos >= self.selected.len() - 1 => self.tag_cursor = None,
+            Some(pos) => self.tag_cursor = Some(pos + 1),
+        }
+    }
+
+    /// Get current dropdown option index
+    pub fn current_option(&self) -> Option<usize> {
+        self.filtered.get(self.dropdown_cursor).copied()
+    }
+
+    // =========================================================================
+    // Search/Filter
+    // =========================================================================
+
+    /// Get current search query
+    pub fn query(&self) -> &str {
+        &self.query
+    }
+
+    /// Set search query
+    pub fn set_query(&mut self, query: impl Into<String>) {
+        self.query = query.into();
+        self.update_filter();
+    }
+
+    /// Clear search query
+    pub fn clear_query(&mut self) {
+        self.query.clear();
+        self.reset_filter();
+    }
+
+    /// Reset filter to show all options
+    fn reset_filter(&mut self) {
+        self.filtered = (0..self.options.len()).collect();
+        self.dropdown_cursor = 0;
+    }
+
+    /// Update filter based on query
+    fn update_filter(&mut self) {
+        if self.query.is_empty() {
+            self.reset_filter();
+            return;
+        }
+
+        let mut matches: Vec<(usize, i32)> = self
+            .options
+            .iter()
+            .enumerate()
+            .filter_map(|(i, opt)| fuzzy_match(&self.query, &opt.label).map(|m| (i, m.score)))
+            .collect();
+
+        matches.sort_by(|a, b| b.1.cmp(&a.1));
+        self.filtered = matches.into_iter().map(|(i, _)| i).collect();
+        self.dropdown_cursor = 0;
+    }
+
+    /// Get fuzzy match for an option
+    pub fn get_match(&self, text: &str) -> Option<FuzzyMatch> {
+        if self.query.is_empty() {
+            None
+        } else {
+            fuzzy_match(&self.query, text)
+        }
+    }
+
+    // =========================================================================
+    // Key handling
+    // =========================================================================
+
+    /// Handle key input, returns true if needs redraw
+    pub fn handle_key(&mut self, key: &Key) -> bool {
+        if self.state.disabled {
+            return false;
+        }
+
+        match key {
+            // Open/close/select
+            Key::Enter => {
+                if self.open {
+                    if let Some(idx) = self.current_option() {
+                        self.toggle_option(idx);
+                    }
+                } else {
+                    self.open();
+                }
+                true
+            }
+
+            Key::Escape => {
+                if self.open {
+                    self.close();
+                    true
+                } else if self.tag_cursor.is_some() {
+                    self.tag_cursor = None;
+                    true
+                } else {
+                    false
+                }
+            }
+
+            Key::Char(' ') if self.open && !self.searchable => {
+                if let Some(idx) = self.current_option() {
+                    self.toggle_option(idx);
+                }
+                true
+            }
+
+            // Dropdown navigation
+            Key::Down | Key::Char('j') if self.open => {
+                self.cursor_down();
+                true
+            }
+
+            Key::Up | Key::Char('k') if self.open => {
+                self.cursor_up();
+                true
+            }
+
+            // Tag navigation
+            Key::Left if !self.open => {
+                self.tag_cursor_left();
+                true
+            }
+
+            Key::Right if !self.open => {
+                self.tag_cursor_right();
+                true
+            }
+
+            // Delete tag
+            Key::Backspace if !self.open => {
+                if self.tag_cursor.is_some() {
+                    self.remove_tag_at_cursor();
+                } else if !self.selected.is_empty() {
+                    self.remove_last_tag();
+                }
+                true
+            }
+
+            Key::Backspace if self.open && self.searchable => {
+                self.query.pop();
+                self.update_filter();
+                true
+            }
+
+            Key::Delete if !self.open && self.tag_cursor.is_some() => {
+                self.remove_tag_at_cursor();
+                true
+            }
+
+            // Search typing
+            Key::Char(c) if self.open && self.searchable => {
+                self.query.push(*c);
+                self.update_filter();
+                true
+            }
+
+            // Select all
+            Key::Char('a') if !self.open => {
+                self.select_all();
+                true
+            }
+
+            // Clear selection
+            Key::Char('c') if !self.open => {
+                self.clear_selection();
+                true
+            }
+
+            _ => false,
+        }
+    }
+
+    // =========================================================================
+    // Display helpers
+    // =========================================================================
+
+    /// Calculate display width
+    fn display_width(&self, max_width: u16) -> u16 {
+        if let Some(w) = self.width {
+            return w.min(max_width);
+        }
+
+        let max_option_len = self
+            .options
+            .iter()
+            .map(|o| o.label.len())
+            .max()
+            .unwrap_or(self.placeholder.len());
+
+        ((max_option_len + 4) as u16).min(max_width)
+    }
+}
+
+impl Default for MultiSelect {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl View for MultiSelect {
+    fn render(&self, ctx: &mut RenderContext) {
+        let area = ctx.area;
+        if area.width < 5 || area.height < 1 {
+            return;
+        }
+
+        let (fg, bg) =
+            self.state
+                .resolve_colors_interactive(ctx.style, Color::WHITE, Color::rgb(50, 50, 50));
+
+        let width = self.display_width(area.width);
+
+        // Draw background for header row
+        for x in 0..width {
+            let mut cell = Cell::new(' ');
+            cell.fg = Some(fg);
+            cell.bg = Some(bg);
+            ctx.buffer.set(area.x + x, area.y, cell);
+        }
+
+        // Draw arrow
+        let arrow = if self.open { '▲' } else { '▼' };
+        ctx.draw_char(area.x + width - 1, area.y, arrow, fg);
+
+        // Draw tags or placeholder
+        let mut x = area.x;
+        let max_x = area.x + width - 2; // Leave room for arrow
+
+        if self.selected.is_empty() && !self.open {
+            // Draw placeholder
+            ctx.draw_text(x, area.y, &self.placeholder, Color::rgb(128, 128, 128));
+        } else {
+            // Draw tags
+            for (i, &opt_idx) in self.selected.iter().enumerate() {
+                if x >= max_x {
+                    break;
+                }
+
+                if let Some(opt) = self.options.get(opt_idx) {
+                    let label = &opt.label;
+                    let tag_len = (label.chars().count() + 3) as u16; // "[label] "
+
+                    if x + tag_len > max_x {
+                        // Draw overflow indicator
+                        ctx.draw_text(x, area.y, "...", Color::rgb(150, 150, 150));
+                        break;
+                    }
+
+                    let is_tag_selected = self.tag_cursor == Some(i);
+                    let tag_fg = if is_tag_selected {
+                        Color::WHITE
+                    } else {
+                        Color::rgb(200, 200, 200)
+                    };
+                    let tag_bg_color = if is_tag_selected {
+                        Color::rgb(100, 100, 200)
+                    } else {
+                        self.tag_bg.unwrap_or(Color::rgb(60, 60, 140))
+                    };
+
+                    // Draw tag with brackets
+                    ctx.draw_char_bg(x, area.y, '[', tag_fg, tag_bg_color);
+                    x += 1;
+
+                    for ch in label.chars() {
+                        if x >= max_x - 1 {
+                            break;
+                        }
+                        ctx.draw_char_bg(x, area.y, ch, tag_fg, tag_bg_color);
+                        x += 1;
+                    }
+
+                    ctx.draw_char_bg(x, area.y, ']', tag_fg, tag_bg_color);
+                    x += 1;
+
+                    // Space between tags
+                    if x < max_x {
+                        x += 1;
+                    }
+                }
+            }
+
+            // Draw search query if open
+            if self.open && self.searchable && !self.query.is_empty() {
+                let query_display = format!(" {}", self.query);
+                ctx.draw_text(x.min(max_x), area.y, &query_display, Color::CYAN);
+            }
+        }
+
+        // Draw dropdown if open
+        if self.open && area.height > 1 {
+            let max_visible = (area.height - 1) as usize;
+
+            for (row, &opt_idx) in self.filtered.iter().enumerate().take(max_visible) {
+                let y = area.y + 1 + row as u16;
+                let is_cursor = row == self.dropdown_cursor;
+                let is_selected = self.is_selected(opt_idx);
+
+                if let Some(opt) = self.options.get(opt_idx) {
+                    let (row_fg, row_bg) = if is_cursor {
+                        (Color::WHITE, Color::rgb(80, 80, 150))
+                    } else {
+                        (fg, bg)
+                    };
+
+                    // Draw row background
+                    for dx in 0..width {
+                        let mut cell = Cell::new(' ');
+                        cell.fg = Some(row_fg);
+                        cell.bg = Some(row_bg);
+                        ctx.buffer.set(area.x + dx, y, cell);
+                    }
+
+                    // Draw checkbox
+                    let checkbox_str = if is_selected { "[x]" } else { "[ ]" };
+                    ctx.draw_text_bg(area.x, y, checkbox_str, row_fg, row_bg);
+
+                    // Draw label with highlight
+                    let match_indices: Vec<usize> = self
+                        .get_match(&opt.label)
+                        .map(|m| m.indices)
+                        .unwrap_or_default();
+
+                    let label_x = area.x + 4;
+                    for (j, ch) in opt.label.chars().enumerate() {
+                        if label_x + j as u16 >= area.x + width {
+                            break;
+                        }
+
+                        let char_fg = if match_indices.contains(&j) {
+                            self.highlight_fg.unwrap_or(Color::YELLOW)
+                        } else if opt.disabled {
+                            Color::rgb(100, 100, 100)
+                        } else {
+                            row_fg
+                        };
+
+                        ctx.draw_char_bg(label_x + j as u16, y, ch, char_fg, row_bg);
+                    }
+                }
+            }
+        }
+    }
+
+    impl_view_meta!("MultiSelect");
+}
+
+impl_styled_view!(MultiSelect);
+impl_state_builders!(MultiSelect);
+impl_props_builders!(MultiSelect);
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+/// Create a basic multi-select widget
+///
+/// # Example
+/// ```rust,ignore
+/// let select = multi_select()
+///     .option("Apple")
+///     .option("Banana");
+/// ```
+pub fn multi_select() -> MultiSelect {
+    MultiSelect::new()
+}
+
+/// Create a multi-select from an iterable of strings
+///
+/// # Example
+/// ```rust,ignore
+/// let fruits = vec!["Apple", "Banana", "Cherry"];
+/// let select = multi_select_from(fruits);
+/// ```
+pub fn multi_select_from<I, S>(items: I) -> MultiSelect
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    MultiSelect::new().options(items.into_iter().map(|s| s.into()).collect())
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::Rect;
+    use crate::render::Buffer;
+
+    #[test]
+    fn test_multi_select_new() {
+        let select = MultiSelect::new();
+        assert!(select.is_empty());
+        assert!(!select.is_open());
+        assert_eq!(select.selection_count(), 0);
+    }
+
+    #[test]
+    fn test_multi_select_options() {
+        let select = multi_select()
+            .option("Apple")
+            .option("Banana")
+            .option("Cherry");
+
+        assert_eq!(select.len(), 3);
+        assert!(!select.is_selected(0));
+    }
+
+    #[test]
+    fn test_multi_select_selection() {
+        let mut select = multi_select().options(vec!["A", "B", "C"]);
+
+        select.select_option(0);
+        assert!(select.is_selected(0));
+        assert_eq!(select.selection_count(), 1);
+
+        select.select_option(2);
+        assert!(select.is_selected(2));
+        assert_eq!(select.selection_count(), 2);
+
+        select.deselect_option(0);
+        assert!(!select.is_selected(0));
+        assert_eq!(select.selection_count(), 1);
+    }
+
+    #[test]
+    fn test_multi_select_toggle() {
+        let mut select = multi_select().options(vec!["A", "B"]);
+
+        select.toggle_option(0);
+        assert!(select.is_selected(0));
+
+        select.toggle_option(0);
+        assert!(!select.is_selected(0));
+    }
+
+    #[test]
+    fn test_multi_select_max_selections() {
+        let mut select = multi_select()
+            .options(vec!["A", "B", "C"])
+            .max_selections(2);
+
+        select.select_option(0);
+        select.select_option(1);
+        assert!(select.can_select_more() == false);
+
+        select.select_option(2); // Should not add
+        assert!(!select.is_selected(2));
+        assert_eq!(select.selection_count(), 2);
+    }
+
+    #[test]
+    fn test_multi_select_get_values() {
+        let mut select = multi_select().options(vec!["Apple", "Banana", "Cherry"]);
+
+        select.select_option(0);
+        select.select_option(2);
+
+        let values = select.get_selected_values();
+        assert_eq!(values, vec!["Apple", "Cherry"]);
+    }
+
+    #[test]
+    fn test_multi_select_navigation() {
+        let mut select = multi_select().options(vec!["A", "B", "C"]);
+        select.open();
+
+        assert_eq!(select.dropdown_cursor, 0);
+
+        select.cursor_down();
+        assert_eq!(select.dropdown_cursor, 1);
+
+        select.cursor_down();
+        assert_eq!(select.dropdown_cursor, 2);
+
+        select.cursor_down(); // Wraps
+        assert_eq!(select.dropdown_cursor, 0);
+
+        select.cursor_up(); // Wraps backward
+        assert_eq!(select.dropdown_cursor, 2);
+    }
+
+    #[test]
+    fn test_multi_select_tag_navigation() {
+        let mut select = multi_select().options(vec!["A", "B", "C"]);
+        select.select_option(0);
+        select.select_option(1);
+        select.select_option(2);
+
+        assert!(select.tag_cursor.is_none());
+
+        select.tag_cursor_left();
+        assert_eq!(select.tag_cursor, Some(2));
+
+        select.tag_cursor_left();
+        assert_eq!(select.tag_cursor, Some(1));
+
+        select.tag_cursor_right();
+        assert_eq!(select.tag_cursor, Some(2));
+
+        select.tag_cursor_right();
+        assert!(select.tag_cursor.is_none());
+    }
+
+    #[test]
+    fn test_multi_select_remove_tag() {
+        let mut select = multi_select().options(vec!["A", "B", "C"]);
+        select.select_option(0);
+        select.select_option(1);
+        select.select_option(2);
+
+        select.tag_cursor = Some(1);
+        select.remove_tag_at_cursor();
+
+        assert_eq!(select.selection_count(), 2);
+        assert!(select.is_selected(0));
+        assert!(!select.is_selected(1));
+        assert!(select.is_selected(2));
+    }
+
+    #[test]
+    fn test_multi_select_search() {
+        let mut select = multi_select()
+            .options(vec!["Apple", "Apricot", "Banana", "Blueberry"])
+            .searchable(true);
+
+        select.open();
+        select.set_query("ap");
+
+        assert_eq!(select.filtered.len(), 2);
+        assert!(select.filtered.contains(&0)); // Apple
+        assert!(select.filtered.contains(&1)); // Apricot
+    }
+
+    #[test]
+    fn test_multi_select_key_handling() {
+        let mut select = multi_select().options(vec!["A", "B", "C"]);
+
+        // Open
+        select.handle_key(&Key::Enter);
+        assert!(select.is_open());
+
+        // Navigate
+        select.handle_key(&Key::Down);
+        assert_eq!(select.dropdown_cursor, 1);
+
+        // Select
+        select.handle_key(&Key::Enter);
+        assert!(select.is_selected(1));
+
+        // Close
+        select.handle_key(&Key::Escape);
+        assert!(!select.is_open());
+    }
+
+    #[test]
+    fn test_multi_select_disabled_option() {
+        let mut select = multi_select()
+            .option_detailed(MultiSelectOption::new("Disabled", "disabled").disabled(true));
+
+        select.select_option(0);
+        assert!(!select.is_selected(0)); // Can't select disabled
+    }
+
+    #[test]
+    fn test_multi_select_select_all() {
+        let mut select = multi_select().options(vec!["A", "B", "C"]);
+
+        select.select_all();
+        assert_eq!(select.selection_count(), 3);
+
+        select.clear_selection();
+        assert_eq!(select.selection_count(), 0);
+    }
+
+    #[test]
+    fn test_multi_select_pre_selected() {
+        let select = multi_select()
+            .options(vec!["A", "B", "C"])
+            .selected_indices(vec![0, 2]);
+
+        assert!(select.is_selected(0));
+        assert!(!select.is_selected(1));
+        assert!(select.is_selected(2));
+    }
+
+    #[test]
+    fn test_multi_select_from() {
+        let select = multi_select_from(vec!["X", "Y", "Z"]);
+        assert_eq!(select.len(), 3);
+    }
+
+    #[test]
+    fn test_multi_select_render() {
+        let mut buffer = Buffer::new(30, 5);
+        let area = Rect::new(0, 0, 30, 5);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let mut select = multi_select()
+            .options(vec!["Apple", "Banana"])
+            .focused(true);
+        select.select_option(0);
+
+        select.render(&mut ctx);
+
+        // Should show tag [Apple]
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, '[');
+    }
+
+    #[test]
+    fn test_multi_select_render_dropdown() {
+        let mut buffer = Buffer::new(30, 10);
+        let area = Rect::new(0, 0, 30, 10);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let mut select = multi_select()
+            .options(vec!["Apple", "Banana"])
+            .focused(true);
+        select.open();
+
+        select.render(&mut ctx);
+
+        // Should show checkbox on second row
+        assert_eq!(buffer.get(0, 1).unwrap().symbol, '[');
+    }
+}

--- a/src/widget/number_input.rs
+++ b/src/widget/number_input.rs
@@ -1,0 +1,859 @@
+//! Number input widget with increment/decrement controls
+//!
+//! Provides a numeric input field with:
+//! - Up/Down arrow key controls for increment/decrement
+//! - Direct numeric entry
+//! - Min/max value constraints
+//! - Configurable step size and precision
+//! - Optional prefix/suffix display (e.g., "$", "%")
+
+use super::traits::{RenderContext, View, WidgetProps, WidgetState};
+use crate::event::Key;
+use crate::render::Cell;
+use crate::style::Color;
+use crate::{impl_props_builders, impl_state_builders, impl_styled_view, impl_view_meta};
+
+/// A number input widget with increment/decrement controls
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use revue::widget::{number_input, NumberInput};
+///
+/// // Basic number input
+/// let input = number_input().value(42.0);
+///
+/// // With constraints
+/// let input = number_input()
+///     .value(50.0)
+///     .min(0.0)
+///     .max(100.0)
+///     .step(5.0);
+///
+/// // Currency input
+/// let price = number_input()
+///     .value(19.99)
+///     .prefix("$")
+///     .precision(2);
+///
+/// // Percentage input
+/// let percent = number_input()
+///     .value(75.0)
+///     .suffix("%")
+///     .min(0.0)
+///     .max(100.0);
+/// ```
+#[derive(Debug, Clone)]
+pub struct NumberInput {
+    /// Current numeric value
+    value: f64,
+    /// Minimum allowed value
+    min: Option<f64>,
+    /// Maximum allowed value
+    max: Option<f64>,
+    /// Increment/decrement step
+    step: f64,
+    /// Decimal precision for display
+    precision: u8,
+    /// Prefix to display before value (e.g., "$")
+    prefix: Option<String>,
+    /// Suffix to display after value (e.g., "%")
+    suffix: Option<String>,
+    /// Whether in direct editing mode
+    editing: bool,
+    /// Buffer for direct text input
+    input_buffer: String,
+    /// Cursor position in input buffer (character index)
+    cursor: usize,
+    /// Width of the input field (characters)
+    width: u16,
+    /// Whether to show +/- buttons
+    show_buttons: bool,
+    /// Widget state (focused, disabled, colors)
+    state: WidgetState,
+    /// Widget props (id, classes)
+    props: WidgetProps,
+}
+
+impl NumberInput {
+    /// Create a new number input widget
+    pub fn new() -> Self {
+        Self {
+            value: 0.0,
+            min: None,
+            max: None,
+            step: 1.0,
+            precision: 0,
+            prefix: None,
+            suffix: None,
+            editing: false,
+            input_buffer: String::new(),
+            cursor: 0,
+            width: 10,
+            show_buttons: true,
+            state: WidgetState::new(),
+            props: WidgetProps::new(),
+        }
+    }
+
+    /// Set the current value
+    pub fn value(mut self, value: f64) -> Self {
+        self.value = self.clamp_value(value);
+        self
+    }
+
+    /// Set minimum allowed value
+    pub fn min(mut self, min: f64) -> Self {
+        self.min = Some(min);
+        self.value = self.clamp_value(self.value);
+        self
+    }
+
+    /// Set maximum allowed value
+    pub fn max(mut self, max: f64) -> Self {
+        self.max = Some(max);
+        self.value = self.clamp_value(self.value);
+        self
+    }
+
+    /// Set the step size for increment/decrement
+    pub fn step(mut self, step: f64) -> Self {
+        self.step = step.abs();
+        self
+    }
+
+    /// Set decimal precision (number of decimal places to display)
+    pub fn precision(mut self, precision: u8) -> Self {
+        self.precision = precision;
+        self
+    }
+
+    /// Set prefix text (displayed before the value)
+    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = Some(prefix.into());
+        self
+    }
+
+    /// Set suffix text (displayed after the value)
+    pub fn suffix(mut self, suffix: impl Into<String>) -> Self {
+        self.suffix = Some(suffix.into());
+        self
+    }
+
+    /// Set the width of the input field
+    pub fn width(mut self, width: u16) -> Self {
+        self.width = width.max(5);
+        self
+    }
+
+    /// Show or hide the +/- buttons
+    pub fn show_buttons(mut self, show: bool) -> Self {
+        self.show_buttons = show;
+        self
+    }
+
+    // =========================================================================
+    // Value manipulation
+    // =========================================================================
+
+    /// Get the current value
+    pub fn get_value(&self) -> f64 {
+        self.value
+    }
+
+    /// Get the current value as an integer
+    pub fn get_int(&self) -> i64 {
+        self.value.round() as i64
+    }
+
+    /// Set the value (with clamping)
+    pub fn set_value(&mut self, value: f64) {
+        self.value = self.clamp_value(value);
+        self.editing = false;
+    }
+
+    /// Increment the value by step
+    pub fn increment(&mut self) {
+        self.set_value(self.value + self.step);
+    }
+
+    /// Decrement the value by step
+    pub fn decrement(&mut self) {
+        self.set_value(self.value - self.step);
+    }
+
+    /// Increment by large step (10x normal step)
+    pub fn increment_large(&mut self) {
+        self.set_value(self.value + self.step * 10.0);
+    }
+
+    /// Decrement by large step (10x normal step)
+    pub fn decrement_large(&mut self) {
+        self.set_value(self.value - self.step * 10.0);
+    }
+
+    /// Set to minimum value (if defined)
+    pub fn set_to_min(&mut self) {
+        if let Some(min) = self.min {
+            self.set_value(min);
+        }
+    }
+
+    /// Set to maximum value (if defined)
+    pub fn set_to_max(&mut self) {
+        if let Some(max) = self.max {
+            self.set_value(max);
+        }
+    }
+
+    /// Clamp value to min/max constraints
+    fn clamp_value(&self, value: f64) -> f64 {
+        let mut v = value;
+        if let Some(min) = self.min {
+            v = v.max(min);
+        }
+        if let Some(max) = self.max {
+            v = v.min(max);
+        }
+        v
+    }
+
+    // =========================================================================
+    // Display formatting
+    // =========================================================================
+
+    /// Format the current value for display
+    fn format_value(&self) -> String {
+        format!("{:.prec$}", self.value, prec = self.precision as usize)
+    }
+
+    /// Get the full display string (with prefix/suffix)
+    pub fn display_string(&self) -> String {
+        let value_str = if self.editing {
+            self.input_buffer.clone()
+        } else {
+            self.format_value()
+        };
+
+        let mut result = String::new();
+        if let Some(ref prefix) = self.prefix {
+            result.push_str(prefix);
+        }
+        result.push_str(&value_str);
+        if let Some(ref suffix) = self.suffix {
+            result.push_str(suffix);
+        }
+        result
+    }
+
+    // =========================================================================
+    // Editing mode
+    // =========================================================================
+
+    /// Enter direct editing mode
+    pub fn start_editing(&mut self) {
+        if !self.editing {
+            self.editing = true;
+            self.input_buffer = self.format_value();
+            self.cursor = self.input_buffer.chars().count();
+        }
+    }
+
+    /// Commit the edited value and exit editing mode
+    pub fn commit_edit(&mut self) {
+        if self.editing {
+            if let Ok(value) = self.input_buffer.parse::<f64>() {
+                self.value = self.clamp_value(value);
+            }
+            self.editing = false;
+            self.input_buffer.clear();
+        }
+    }
+
+    /// Cancel editing and restore original value
+    pub fn cancel_edit(&mut self) {
+        self.editing = false;
+        self.input_buffer.clear();
+    }
+
+    /// Check if in editing mode
+    pub fn is_editing(&self) -> bool {
+        self.editing
+    }
+
+    // =========================================================================
+    // UTF-8 safe buffer operations
+    // =========================================================================
+
+    fn char_to_byte_index(s: &str, char_idx: usize) -> usize {
+        s.char_indices()
+            .nth(char_idx)
+            .map(|(i, _)| i)
+            .unwrap_or(s.len())
+    }
+
+    fn buffer_char_count(&self) -> usize {
+        self.input_buffer.chars().count()
+    }
+
+    fn insert_char_at_cursor(&mut self, ch: char) {
+        let byte_idx = Self::char_to_byte_index(&self.input_buffer, self.cursor);
+        self.input_buffer.insert(byte_idx, ch);
+        self.cursor += 1;
+    }
+
+    fn delete_char_before_cursor(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+            let byte_idx = Self::char_to_byte_index(&self.input_buffer, self.cursor);
+            if let Some(ch) = self.input_buffer.chars().nth(self.cursor) {
+                self.input_buffer.drain(byte_idx..byte_idx + ch.len_utf8());
+            }
+        }
+    }
+
+    fn delete_char_at_cursor(&mut self) {
+        let char_count = self.buffer_char_count();
+        if self.cursor < char_count {
+            let byte_idx = Self::char_to_byte_index(&self.input_buffer, self.cursor);
+            if let Some(ch) = self.input_buffer.chars().nth(self.cursor) {
+                self.input_buffer.drain(byte_idx..byte_idx + ch.len_utf8());
+            }
+        }
+    }
+
+    // =========================================================================
+    // Key handling
+    // =========================================================================
+
+    /// Handle key input, returns true if value changed or needs redraw
+    pub fn handle_key(&mut self, key: &Key) -> bool {
+        if self.state.disabled {
+            return false;
+        }
+
+        match key {
+            // Increment/Decrement
+            Key::Up | Key::Char('k') => {
+                if self.editing {
+                    self.commit_edit();
+                }
+                self.increment();
+                true
+            }
+            Key::Down | Key::Char('j') => {
+                if self.editing {
+                    self.commit_edit();
+                }
+                self.decrement();
+                true
+            }
+
+            // Large increment/decrement
+            Key::PageUp => {
+                if self.editing {
+                    self.commit_edit();
+                }
+                self.increment_large();
+                true
+            }
+            Key::PageDown => {
+                if self.editing {
+                    self.commit_edit();
+                }
+                self.decrement_large();
+                true
+            }
+
+            // Min/Max
+            Key::Home => {
+                if self.editing {
+                    self.commit_edit();
+                }
+                self.set_to_min();
+                true
+            }
+            Key::End => {
+                if self.editing {
+                    self.commit_edit();
+                }
+                self.set_to_max();
+                true
+            }
+
+            // Enter editing mode or commit
+            Key::Enter => {
+                if self.editing {
+                    self.commit_edit();
+                } else {
+                    self.start_editing();
+                }
+                true
+            }
+
+            // Cancel editing
+            Key::Escape => {
+                if self.editing {
+                    self.cancel_edit();
+                    true
+                } else {
+                    false
+                }
+            }
+
+            // Direct numeric input
+            Key::Char(c) if c.is_ascii_digit() || *c == '.' || *c == '-' => {
+                if !self.editing {
+                    self.start_editing();
+                    self.input_buffer.clear();
+                    self.cursor = 0;
+                }
+
+                // Validate input
+                let valid = match c {
+                    '-' => self.cursor == 0 && !self.input_buffer.contains('-'),
+                    '.' => !self.input_buffer.contains('.'),
+                    _ => true,
+                };
+
+                if valid {
+                    self.insert_char_at_cursor(*c);
+                }
+                true
+            }
+
+            // Backspace in editing mode
+            Key::Backspace => {
+                if self.editing {
+                    self.delete_char_before_cursor();
+                    true
+                } else {
+                    false
+                }
+            }
+
+            // Delete in editing mode
+            Key::Delete => {
+                if self.editing {
+                    self.delete_char_at_cursor();
+                    true
+                } else {
+                    false
+                }
+            }
+
+            // Cursor movement in editing mode
+            Key::Left => {
+                if self.editing && self.cursor > 0 {
+                    self.cursor -= 1;
+                    true
+                } else {
+                    false
+                }
+            }
+            Key::Right => {
+                if self.editing && self.cursor < self.buffer_char_count() {
+                    self.cursor += 1;
+                    true
+                } else {
+                    false
+                }
+            }
+
+            _ => false,
+        }
+    }
+}
+
+impl Default for NumberInput {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl View for NumberInput {
+    fn render(&self, ctx: &mut RenderContext) {
+        let area = ctx.area;
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+
+        let (fg, bg) =
+            self.state
+                .resolve_colors_interactive(ctx.style, Color::WHITE, Color::rgb(60, 60, 60));
+
+        let mut x = area.x;
+
+        // Draw prefix
+        if let Some(ref prefix) = self.prefix {
+            ctx.draw_text(x, area.y, prefix, Color::rgb(150, 150, 150));
+            x += prefix.chars().count() as u16;
+        }
+
+        // Draw value (or input buffer when editing)
+        let value_str = if self.editing {
+            &self.input_buffer
+        } else {
+            &self.format_value()
+        };
+
+        for (i, ch) in value_str.chars().enumerate() {
+            if x >= area.x + area.width {
+                break;
+            }
+
+            let is_cursor_at_pos = self.editing && self.state.focused && i == self.cursor;
+
+            let mut cell = Cell::new(ch);
+            if is_cursor_at_pos {
+                cell.fg = Some(Color::BLACK);
+                cell.bg = Some(Color::WHITE);
+            } else {
+                cell.fg = Some(fg);
+                cell.bg = Some(bg);
+            }
+
+            ctx.buffer.set(x, area.y, cell);
+            x += 1;
+        }
+
+        // Draw cursor at end if editing and cursor is at end
+        if self.editing
+            && self.state.focused
+            && self.cursor >= value_str.chars().count()
+            && x < area.x + area.width
+        {
+            let mut cursor_cell = Cell::new(' ');
+            cursor_cell.fg = Some(Color::BLACK);
+            cursor_cell.bg = Some(Color::WHITE);
+            ctx.buffer.set(x, area.y, cursor_cell);
+            x += 1;
+        }
+
+        // Draw suffix
+        if let Some(ref suffix) = self.suffix {
+            ctx.draw_text(x, area.y, suffix, Color::rgb(150, 150, 150));
+            x += suffix.chars().count() as u16;
+        }
+
+        // Draw buttons if enabled and space available
+        if self.show_buttons && x + 4 <= area.x + area.width {
+            let button_x = area.x + area.width - 4;
+            let button_fg = if self.state.disabled {
+                Color::rgb(80, 80, 80)
+            } else {
+                Color::rgb(150, 150, 150)
+            };
+            ctx.draw_text(button_x, area.y, " -+", button_fg);
+        }
+    }
+
+    impl_view_meta!("NumberInput");
+}
+
+impl_styled_view!(NumberInput);
+impl_state_builders!(NumberInput);
+impl_props_builders!(NumberInput);
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+/// Create a basic number input widget
+///
+/// # Example
+/// ```rust,ignore
+/// let input = number_input().value(42.0);
+/// ```
+pub fn number_input() -> NumberInput {
+    NumberInput::new()
+}
+
+/// Create an integer-only number input (precision = 0, step = 1)
+///
+/// # Example
+/// ```rust,ignore
+/// let count = integer_input().value(10.0).min(0.0);
+/// ```
+pub fn integer_input() -> NumberInput {
+    NumberInput::new().precision(0).step(1.0)
+}
+
+/// Create a currency input with specified symbol
+///
+/// # Example
+/// ```rust,ignore
+/// let price = currency_input("$").value(19.99);
+/// let euro = currency_input("€").value(15.50);
+/// ```
+pub fn currency_input(symbol: &str) -> NumberInput {
+    NumberInput::new()
+        .precision(2)
+        .step(0.01)
+        .prefix(symbol)
+        .min(0.0)
+}
+
+/// Create a percentage input (0-100 range with % suffix)
+///
+/// # Example
+/// ```rust,ignore
+/// let percent = percentage_input().value(75.0);
+/// ```
+pub fn percentage_input() -> NumberInput {
+    NumberInput::new()
+        .precision(0)
+        .step(1.0)
+        .suffix("%")
+        .min(0.0)
+        .max(100.0)
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::Rect;
+    use crate::render::Buffer;
+
+    #[test]
+    fn test_number_input_new() {
+        let input = NumberInput::new();
+        assert_eq!(input.get_value(), 0.0);
+        assert!(!input.is_editing());
+    }
+
+    #[test]
+    fn test_number_input_value() {
+        let input = number_input().value(42.0);
+        assert_eq!(input.get_value(), 42.0);
+    }
+
+    #[test]
+    fn test_number_input_min_max() {
+        let input = number_input().value(150.0).min(0.0).max(100.0);
+        assert_eq!(input.get_value(), 100.0); // Clamped to max
+
+        let input = number_input().value(-50.0).min(0.0).max(100.0);
+        assert_eq!(input.get_value(), 0.0); // Clamped to min
+    }
+
+    #[test]
+    fn test_number_input_increment() {
+        let mut input = number_input().value(10.0).step(5.0);
+        input.increment();
+        assert_eq!(input.get_value(), 15.0);
+
+        input.decrement();
+        assert_eq!(input.get_value(), 10.0);
+    }
+
+    #[test]
+    fn test_number_input_increment_clamped() {
+        let mut input = number_input().value(95.0).step(10.0).max(100.0);
+        input.increment();
+        assert_eq!(input.get_value(), 100.0); // Clamped
+    }
+
+    #[test]
+    fn test_number_input_large_step() {
+        let mut input = number_input().value(50.0).step(1.0);
+        input.increment_large();
+        assert_eq!(input.get_value(), 60.0); // 10x step
+    }
+
+    #[test]
+    fn test_number_input_format() {
+        let input = number_input().value(42.123).precision(2);
+        assert_eq!(input.format_value(), "42.12");
+
+        let input = number_input().value(42.0).precision(0);
+        assert_eq!(input.format_value(), "42");
+    }
+
+    #[test]
+    fn test_number_input_display_string() {
+        let input = number_input().value(19.99).prefix("$").precision(2);
+        assert_eq!(input.display_string(), "$19.99");
+
+        let input = number_input().value(75.0).suffix("%").precision(0);
+        assert_eq!(input.display_string(), "75%");
+    }
+
+    #[test]
+    fn test_number_input_editing() {
+        let mut input = number_input().value(10.0);
+        input.state.focused = true;
+
+        input.start_editing();
+        assert!(input.is_editing());
+        assert_eq!(input.input_buffer, "10");
+
+        input.handle_key(&Key::Char('5'));
+        assert_eq!(input.input_buffer, "105");
+
+        input.commit_edit();
+        assert!(!input.is_editing());
+        assert_eq!(input.get_value(), 105.0);
+    }
+
+    #[test]
+    fn test_number_input_cancel_edit() {
+        let mut input = number_input().value(10.0);
+        input.state.focused = true;
+
+        input.start_editing();
+        input.handle_key(&Key::Char('9'));
+        input.handle_key(&Key::Char('9'));
+        assert_eq!(input.input_buffer, "1099");
+
+        input.cancel_edit();
+        assert!(!input.is_editing());
+        assert_eq!(input.get_value(), 10.0); // Original value preserved
+    }
+
+    #[test]
+    fn test_number_input_key_increment() {
+        let mut input = number_input().value(10.0).step(1.0);
+        input.state.focused = true;
+
+        input.handle_key(&Key::Up);
+        assert_eq!(input.get_value(), 11.0);
+
+        input.handle_key(&Key::Down);
+        assert_eq!(input.get_value(), 10.0);
+
+        input.handle_key(&Key::Char('k'));
+        assert_eq!(input.get_value(), 11.0);
+
+        input.handle_key(&Key::Char('j'));
+        assert_eq!(input.get_value(), 10.0);
+    }
+
+    #[test]
+    fn test_number_input_page_up_down() {
+        let mut input = number_input().value(50.0).step(1.0);
+        input.state.focused = true;
+
+        input.handle_key(&Key::PageUp);
+        assert_eq!(input.get_value(), 60.0);
+
+        input.handle_key(&Key::PageDown);
+        assert_eq!(input.get_value(), 50.0);
+    }
+
+    #[test]
+    fn test_number_input_home_end() {
+        let mut input = number_input().value(50.0).min(0.0).max(100.0);
+        input.state.focused = true;
+
+        input.handle_key(&Key::Home);
+        assert_eq!(input.get_value(), 0.0);
+
+        input.handle_key(&Key::End);
+        assert_eq!(input.get_value(), 100.0);
+    }
+
+    #[test]
+    fn test_number_input_disabled() {
+        let mut input = number_input().value(10.0).disabled(true);
+
+        let handled = input.handle_key(&Key::Up);
+        assert!(!handled);
+        assert_eq!(input.get_value(), 10.0); // Unchanged
+    }
+
+    #[test]
+    fn test_number_input_decimal_validation() {
+        let mut input = number_input().value(0.0).precision(2);
+        input.state.focused = true;
+        input.start_editing();
+        input.input_buffer.clear();
+        input.cursor = 0;
+
+        input.handle_key(&Key::Char('1'));
+        input.handle_key(&Key::Char('.'));
+        input.handle_key(&Key::Char('5'));
+        assert_eq!(input.input_buffer, "1.5");
+
+        // Second decimal should be ignored
+        input.handle_key(&Key::Char('.'));
+        assert_eq!(input.input_buffer, "1.5");
+    }
+
+    #[test]
+    fn test_number_input_negative() {
+        let mut input = number_input().value(0.0).min(-100.0);
+        input.state.focused = true;
+        input.start_editing();
+        input.input_buffer.clear();
+        input.cursor = 0;
+
+        input.handle_key(&Key::Char('-'));
+        input.handle_key(&Key::Char('5'));
+        assert_eq!(input.input_buffer, "-5");
+
+        // Second minus should be ignored
+        input.handle_key(&Key::Char('-'));
+        assert_eq!(input.input_buffer, "-5");
+
+        input.commit_edit();
+        assert_eq!(input.get_value(), -5.0);
+    }
+
+    #[test]
+    fn test_integer_input() {
+        let input = integer_input().value(42.7);
+        assert_eq!(input.format_value(), "43"); // Rounded
+        assert_eq!(input.get_int(), 43);
+    }
+
+    #[test]
+    fn test_currency_input() {
+        let input = currency_input("$").value(19.99);
+        assert_eq!(input.display_string(), "$19.99");
+        assert_eq!(input.get_value(), 19.99);
+    }
+
+    #[test]
+    fn test_percentage_input() {
+        let mut input = percentage_input().value(150.0);
+        assert_eq!(input.get_value(), 100.0); // Clamped to max
+        assert_eq!(input.display_string(), "100%");
+
+        input.set_value(-10.0);
+        assert_eq!(input.get_value(), 0.0); // Clamped to min
+    }
+
+    #[test]
+    fn test_number_input_render() {
+        let mut buffer = Buffer::new(20, 1);
+        let area = Rect::new(0, 0, 20, 1);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let input = number_input().value(42.0).precision(0).focused(true);
+        input.render(&mut ctx);
+
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, '4');
+        assert_eq!(buffer.get(1, 0).unwrap().symbol, '2');
+    }
+
+    #[test]
+    fn test_number_input_render_with_prefix_suffix() {
+        let mut buffer = Buffer::new(20, 1);
+        let area = Rect::new(0, 0, 20, 1);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let input = currency_input("$").value(9.99).focused(true);
+        input.render(&mut ctx);
+
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, '$');
+        assert_eq!(buffer.get(1, 0).unwrap().symbol, '9');
+        assert_eq!(buffer.get(2, 0).unwrap().symbol, '.');
+        assert_eq!(buffer.get(3, 0).unwrap().symbol, '9');
+        assert_eq!(buffer.get(4, 0).unwrap().symbol, '9');
+    }
+}

--- a/src/widget/range_picker.rs
+++ b/src/widget/range_picker.rs
@@ -1,0 +1,1190 @@
+//! Date/time range picker widget
+//!
+//! Provides a widget for selecting date ranges with:
+//! - Start and end date selection
+//! - Common preset ranges (Today, Last 7 Days, etc.)
+//! - Optional time selection
+//! - Validation to ensure end >= start
+
+use super::calendar::{days_in_month, Date, FirstDayOfWeek};
+use super::datetime_picker::{DateTime, Time};
+use super::traits::{RenderContext, View, WidgetProps, WidgetState};
+use crate::event::Key;
+use crate::render::{Cell, Modifier};
+use crate::style::Color;
+use crate::{impl_props_builders, impl_state_builders, impl_styled_view};
+use unicode_width::UnicodeWidthChar;
+
+/// Preset date ranges
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PresetRange {
+    /// Today only
+    Today,
+    /// Yesterday only
+    Yesterday,
+    /// Last 7 days including today
+    Last7Days,
+    /// Last 30 days including today
+    Last30Days,
+    /// Current week (Sunday/Monday to today)
+    ThisWeek,
+    /// Previous full week
+    LastWeek,
+    /// Current month
+    ThisMonth,
+    /// Previous full month
+    LastMonth,
+    /// This year
+    ThisYear,
+    /// Custom range (user selected)
+    Custom,
+}
+
+impl PresetRange {
+    /// Get display name
+    pub fn name(&self) -> &'static str {
+        match self {
+            PresetRange::Today => "Today",
+            PresetRange::Yesterday => "Yesterday",
+            PresetRange::Last7Days => "Last 7 Days",
+            PresetRange::Last30Days => "Last 30 Days",
+            PresetRange::ThisWeek => "This Week",
+            PresetRange::LastWeek => "Last Week",
+            PresetRange::ThisMonth => "This Month",
+            PresetRange::LastMonth => "Last Month",
+            PresetRange::ThisYear => "This Year",
+            PresetRange::Custom => "Custom",
+        }
+    }
+
+    /// Get all common presets
+    pub fn common() -> &'static [PresetRange] {
+        &[
+            PresetRange::Today,
+            PresetRange::Yesterday,
+            PresetRange::Last7Days,
+            PresetRange::Last30Days,
+            PresetRange::ThisWeek,
+            PresetRange::LastWeek,
+            PresetRange::ThisMonth,
+            PresetRange::LastMonth,
+        ]
+    }
+
+    /// Calculate the date range for this preset
+    pub fn calculate(&self, today: Date) -> (Date, Date) {
+        match self {
+            PresetRange::Today => (today, today),
+            PresetRange::Yesterday => {
+                let yesterday = today.prev_day();
+                (yesterday, yesterday)
+            }
+            PresetRange::Last7Days => {
+                let start = today.subtract_days(6);
+                (start, today)
+            }
+            PresetRange::Last30Days => {
+                let start = today.subtract_days(29);
+                (start, today)
+            }
+            PresetRange::ThisWeek => {
+                let weekday = today.weekday(); // 0 = Sunday
+                let start = today.subtract_days(weekday);
+                (start, today)
+            }
+            PresetRange::LastWeek => {
+                let weekday = today.weekday();
+                let this_week_start = today.subtract_days(weekday);
+                let last_week_end = this_week_start.prev_day();
+                let last_week_start = last_week_end.subtract_days(6);
+                (last_week_start, last_week_end)
+            }
+            PresetRange::ThisMonth => {
+                let start = Date::new(today.year, today.month, 1);
+                (start, today)
+            }
+            PresetRange::LastMonth => {
+                let (year, month) = if today.month == 1 {
+                    (today.year - 1, 12)
+                } else {
+                    (today.year, today.month - 1)
+                };
+                let start = Date::new(year, month, 1);
+                let end = Date::new(year, month, days_in_month(year, month));
+                (start, end)
+            }
+            PresetRange::ThisYear => {
+                let start = Date::new(today.year, 1, 1);
+                (start, today)
+            }
+            PresetRange::Custom => (today, today),
+        }
+    }
+}
+
+/// Which part of the range picker has focus
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RangeFocus {
+    /// Start date calendar
+    #[default]
+    Start,
+    /// End date calendar
+    End,
+    /// Preset list
+    Presets,
+}
+
+/// A date/time range picker widget
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use revue::widget::{range_picker, RangePicker, Date};
+///
+/// // Basic date range picker
+/// let picker = range_picker()
+///     .start_date(Date::new(2025, 1, 1))
+///     .end_date(Date::new(2025, 1, 31));
+///
+/// // With presets
+/// let picker = range_picker()
+///     .with_presets(true);
+///
+/// // Analytics-style range picker
+/// let picker = analytics_range_picker();
+/// ```
+pub struct RangePicker {
+    /// Start datetime
+    start: DateTime,
+    /// End datetime
+    end: DateTime,
+    /// Currently active preset
+    active_preset: Option<PresetRange>,
+    /// Available presets
+    presets: Vec<PresetRange>,
+    /// Cursor position in presets
+    preset_cursor: usize,
+    /// Current focus area
+    focus: RangeFocus,
+    /// First day of week
+    first_day: FirstDayOfWeek,
+    /// Show time selection
+    show_time: bool,
+    /// Calendar cursor day (for start)
+    start_cursor_day: u32,
+    /// Calendar cursor day (for end)
+    end_cursor_day: u32,
+    /// Minimum allowed date
+    min_date: Option<Date>,
+    /// Maximum allowed date
+    max_date: Option<Date>,
+    /// Show presets panel
+    show_presets: bool,
+    /// Colors
+    header_fg: Color,
+    selected_fg: Color,
+    selected_bg: Color,
+    range_bg: Color,
+    preset_fg: Color,
+    preset_selected_fg: Color,
+    preset_selected_bg: Color,
+    /// Widget state
+    state: WidgetState,
+    /// Widget props
+    props: WidgetProps,
+}
+
+impl RangePicker {
+    /// Create a new range picker
+    pub fn new() -> Self {
+        let today = Date::today();
+        Self {
+            start: DateTime::new(today, Time::new(0, 0, 0)),
+            end: DateTime::new(today, Time::new(23, 59, 59)),
+            active_preset: Some(PresetRange::Today),
+            presets: PresetRange::common().to_vec(),
+            preset_cursor: 0,
+            focus: RangeFocus::Start,
+            first_day: FirstDayOfWeek::Sunday,
+            show_time: false,
+            start_cursor_day: today.day,
+            end_cursor_day: today.day,
+            min_date: None,
+            max_date: None,
+            show_presets: true,
+            header_fg: Color::CYAN,
+            selected_fg: Color::BLACK,
+            selected_bg: Color::CYAN,
+            range_bg: Color::rgb(60, 100, 140),
+            preset_fg: Color::WHITE,
+            preset_selected_fg: Color::BLACK,
+            preset_selected_bg: Color::CYAN,
+            state: WidgetState::new(),
+            props: WidgetProps::new(),
+        }
+    }
+
+    /// Set start date
+    pub fn start_date(mut self, date: Date) -> Self {
+        self.start.date = date;
+        self.start_cursor_day = date.day;
+        self.active_preset = Some(PresetRange::Custom);
+        self
+    }
+
+    /// Set end date
+    pub fn end_date(mut self, date: Date) -> Self {
+        self.end.date = date;
+        self.end_cursor_day = date.day;
+        self.active_preset = Some(PresetRange::Custom);
+        self.swap_if_needed();
+        self
+    }
+
+    /// Set start time
+    pub fn start_time(mut self, time: Time) -> Self {
+        self.start.time = time;
+        self
+    }
+
+    /// Set end time
+    pub fn end_time(mut self, time: Time) -> Self {
+        self.end.time = time;
+        self
+    }
+
+    /// Set date range
+    pub fn range(mut self, start: Date, end: Date) -> Self {
+        self.start.date = start;
+        self.end.date = end;
+        self.start_cursor_day = start.day;
+        self.end_cursor_day = end.day;
+        self.active_preset = Some(PresetRange::Custom);
+        self.swap_if_needed();
+        self
+    }
+
+    /// Set first day of week
+    pub fn first_day(mut self, first: FirstDayOfWeek) -> Self {
+        self.first_day = first;
+        self
+    }
+
+    /// Show or hide time selection
+    pub fn show_time(mut self, show: bool) -> Self {
+        self.show_time = show;
+        self
+    }
+
+    /// Show or hide presets panel
+    pub fn with_presets(mut self, show: bool) -> Self {
+        self.show_presets = show;
+        self
+    }
+
+    /// Set available presets
+    pub fn presets(mut self, presets: Vec<PresetRange>) -> Self {
+        self.presets = presets;
+        self
+    }
+
+    /// Set minimum date constraint
+    pub fn min_date(mut self, date: Date) -> Self {
+        self.min_date = Some(date);
+        self
+    }
+
+    /// Set maximum date constraint
+    pub fn max_date(mut self, date: Date) -> Self {
+        self.max_date = Some(date);
+        self
+    }
+
+    /// Set range colors
+    pub fn range_color(mut self, color: Color) -> Self {
+        self.range_bg = color;
+        self
+    }
+
+    // =========================================================================
+    // Getters
+    // =========================================================================
+
+    /// Get the selected date range
+    pub fn get_range(&self) -> (Date, Date) {
+        (self.start.date, self.end.date)
+    }
+
+    /// Get the selected datetime range
+    pub fn get_datetime_range(&self) -> (DateTime, DateTime) {
+        (self.start, self.end)
+    }
+
+    /// Get start date
+    pub fn get_start(&self) -> Date {
+        self.start.date
+    }
+
+    /// Get end date
+    pub fn get_end(&self) -> Date {
+        self.end.date
+    }
+
+    /// Get active preset (if any)
+    pub fn get_active_preset(&self) -> Option<PresetRange> {
+        self.active_preset
+    }
+
+    /// Check if a date is within the selected range
+    pub fn is_in_range(&self, date: &Date) -> bool {
+        date >= &self.start.date && date <= &self.end.date
+    }
+
+    /// Get the current focus area
+    pub fn get_focus(&self) -> RangeFocus {
+        self.focus
+    }
+
+    // =========================================================================
+    // Setters
+    // =========================================================================
+
+    /// Set the start date
+    pub fn set_start(&mut self, date: Date) {
+        self.start.date = date;
+        self.start_cursor_day = date.day;
+        self.active_preset = Some(PresetRange::Custom);
+        self.swap_if_needed();
+    }
+
+    /// Set the end date
+    pub fn set_end(&mut self, date: Date) {
+        self.end.date = date;
+        self.end_cursor_day = date.day;
+        self.active_preset = Some(PresetRange::Custom);
+        self.swap_if_needed();
+    }
+
+    /// Apply a preset range
+    pub fn apply_preset(&mut self, preset: PresetRange) {
+        let today = Date::today();
+        let (start, end) = preset.calculate(today);
+        self.start.date = start;
+        self.end.date = end;
+        self.start_cursor_day = start.day;
+        self.end_cursor_day = end.day;
+        self.active_preset = Some(preset);
+    }
+
+    /// Ensure end >= start, swap if needed
+    fn swap_if_needed(&mut self) {
+        if self.end.date < self.start.date {
+            std::mem::swap(&mut self.start.date, &mut self.end.date);
+            std::mem::swap(&mut self.start_cursor_day, &mut self.end_cursor_day);
+        }
+    }
+
+    // =========================================================================
+    // Navigation
+    // =========================================================================
+
+    /// Move to next focus area
+    fn next_focus(&mut self) {
+        self.focus = match self.focus {
+            RangeFocus::Start => RangeFocus::End,
+            RangeFocus::End => {
+                if self.show_presets {
+                    RangeFocus::Presets
+                } else {
+                    RangeFocus::Start
+                }
+            }
+            RangeFocus::Presets => RangeFocus::Start,
+        };
+    }
+
+    /// Move to previous focus area
+    fn prev_focus(&mut self) {
+        self.focus = match self.focus {
+            RangeFocus::Start => {
+                if self.show_presets {
+                    RangeFocus::Presets
+                } else {
+                    RangeFocus::End
+                }
+            }
+            RangeFocus::End => RangeFocus::Start,
+            RangeFocus::Presets => RangeFocus::End,
+        };
+    }
+
+    /// Get mutable reference to current calendar date/cursor
+    fn current_date_mut(&mut self) -> (&mut Date, &mut u32) {
+        match self.focus {
+            RangeFocus::Start => (&mut self.start.date, &mut self.start_cursor_day),
+            RangeFocus::End | RangeFocus::Presets => (&mut self.end.date, &mut self.end_cursor_day),
+        }
+    }
+
+    /// Move cursor left (previous day)
+    fn move_day_left(&mut self) {
+        let (date, cursor) = self.current_date_mut();
+        if *cursor > 1 {
+            *cursor -= 1;
+        } else {
+            // Previous month
+            if date.month > 1 {
+                date.month -= 1;
+            } else {
+                date.month = 12;
+                date.year -= 1;
+            }
+            *cursor = days_in_month(date.year, date.month);
+        }
+    }
+
+    /// Move cursor right (next day)
+    fn move_day_right(&mut self) {
+        let (date, cursor) = self.current_date_mut();
+        let max_day = days_in_month(date.year, date.month);
+        if *cursor < max_day {
+            *cursor += 1;
+        } else {
+            // Next month
+            if date.month < 12 {
+                date.month += 1;
+            } else {
+                date.month = 1;
+                date.year += 1;
+            }
+            *cursor = 1;
+        }
+    }
+
+    /// Move cursor up (previous week)
+    fn move_week_up(&mut self) {
+        let (date, cursor) = self.current_date_mut();
+        if *cursor > 7 {
+            *cursor -= 7;
+        } else {
+            // Previous month
+            if date.month > 1 {
+                date.month -= 1;
+            } else {
+                date.month = 12;
+                date.year -= 1;
+            }
+            let max_day = days_in_month(date.year, date.month);
+            *cursor = max_day - (7 - *cursor);
+        }
+    }
+
+    /// Move cursor down (next week)
+    fn move_week_down(&mut self) {
+        let (date, cursor) = self.current_date_mut();
+        let max_day = days_in_month(date.year, date.month);
+        if *cursor + 7 <= max_day {
+            *cursor += 7;
+        } else {
+            let overflow = *cursor + 7 - max_day;
+            if date.month < 12 {
+                date.month += 1;
+            } else {
+                date.month = 1;
+                date.year += 1;
+            }
+            *cursor = overflow;
+        }
+    }
+
+    /// Go to previous month
+    fn prev_month(&mut self) {
+        let (date, cursor) = self.current_date_mut();
+        if date.month > 1 {
+            date.month -= 1;
+        } else {
+            date.month = 12;
+            date.year -= 1;
+        }
+        let max_day = days_in_month(date.year, date.month);
+        *cursor = (*cursor).min(max_day);
+    }
+
+    /// Go to next month
+    fn next_month(&mut self) {
+        let (date, cursor) = self.current_date_mut();
+        if date.month < 12 {
+            date.month += 1;
+        } else {
+            date.month = 1;
+            date.year += 1;
+        }
+        let max_day = days_in_month(date.year, date.month);
+        *cursor = (*cursor).min(max_day);
+    }
+
+    /// Go to previous year
+    fn prev_year(&mut self) {
+        let (date, cursor) = self.current_date_mut();
+        date.year -= 1;
+        let max_day = days_in_month(date.year, date.month);
+        *cursor = (*cursor).min(max_day);
+    }
+
+    /// Go to next year
+    fn next_year(&mut self) {
+        let (date, cursor) = self.current_date_mut();
+        date.year += 1;
+        let max_day = days_in_month(date.year, date.month);
+        *cursor = (*cursor).min(max_day);
+    }
+
+    /// Select current cursor position
+    fn select_date(&mut self) {
+        match self.focus {
+            RangeFocus::Start => {
+                self.start.date.day = self.start_cursor_day;
+                self.active_preset = Some(PresetRange::Custom);
+            }
+            RangeFocus::End => {
+                self.end.date.day = self.end_cursor_day;
+                self.active_preset = Some(PresetRange::Custom);
+            }
+            RangeFocus::Presets => {
+                if let Some(preset) = self.presets.get(self.preset_cursor) {
+                    self.apply_preset(*preset);
+                }
+            }
+        }
+        self.swap_if_needed();
+    }
+
+    /// Move preset cursor up
+    fn preset_up(&mut self) {
+        if !self.presets.is_empty() {
+            self.preset_cursor = self
+                .preset_cursor
+                .checked_sub(1)
+                .unwrap_or(self.presets.len() - 1);
+        }
+    }
+
+    /// Move preset cursor down
+    fn preset_down(&mut self) {
+        if !self.presets.is_empty() {
+            self.preset_cursor = (self.preset_cursor + 1) % self.presets.len();
+        }
+    }
+
+    // =========================================================================
+    // Key handling
+    // =========================================================================
+
+    /// Handle key input
+    pub fn handle_key(&mut self, key: &Key) -> bool {
+        if self.state.disabled {
+            return false;
+        }
+
+        match key {
+            // Switch focus areas
+            Key::Tab => {
+                self.next_focus();
+                true
+            }
+            Key::BackTab => {
+                self.prev_focus();
+                true
+            }
+
+            // Navigation
+            Key::Left | Key::Char('h') if self.focus != RangeFocus::Presets => {
+                self.move_day_left();
+                true
+            }
+            Key::Right | Key::Char('l') if self.focus != RangeFocus::Presets => {
+                self.move_day_right();
+                true
+            }
+            Key::Up | Key::Char('k') if self.focus != RangeFocus::Presets => {
+                self.move_week_up();
+                true
+            }
+            Key::Down | Key::Char('j') if self.focus != RangeFocus::Presets => {
+                self.move_week_down();
+                true
+            }
+
+            // Preset navigation
+            Key::Up | Key::Char('k') if self.focus == RangeFocus::Presets => {
+                self.preset_up();
+                true
+            }
+            Key::Down | Key::Char('j') if self.focus == RangeFocus::Presets => {
+                self.preset_down();
+                true
+            }
+
+            // Month/Year navigation
+            Key::Char('[') if self.focus != RangeFocus::Presets => {
+                self.prev_month();
+                true
+            }
+            Key::Char(']') if self.focus != RangeFocus::Presets => {
+                self.next_month();
+                true
+            }
+            Key::Char('{') if self.focus != RangeFocus::Presets => {
+                self.prev_year();
+                true
+            }
+            Key::Char('}') if self.focus != RangeFocus::Presets => {
+                self.next_year();
+                true
+            }
+
+            // Selection
+            Key::Enter | Key::Char(' ') => {
+                self.select_date();
+                true
+            }
+
+            _ => false,
+        }
+    }
+
+    // =========================================================================
+    // Rendering helpers
+    // =========================================================================
+
+    /// Get day of week for first day of month
+    fn first_weekday(&self, date: &Date) -> u32 {
+        let m = if date.month < 3 {
+            date.month as i32 + 12
+        } else {
+            date.month as i32
+        };
+        let y = if date.month < 3 {
+            date.year - 1
+        } else {
+            date.year
+        };
+        let k = y % 100;
+        let j = y / 100;
+        let h = (1 + (13 * (m + 1)) / 5 + k + k / 4 + j / 4 - 2 * j) % 7;
+        let h = ((h + 6) % 7 + 7) % 7;
+
+        match self.first_day {
+            FirstDayOfWeek::Sunday => h as u32,
+            FirstDayOfWeek::Monday => ((h + 6) % 7) as u32,
+        }
+    }
+
+    /// Render a calendar
+    #[allow(clippy::too_many_arguments)]
+    fn render_calendar(
+        &self,
+        ctx: &mut RenderContext,
+        x: u16,
+        y: u16,
+        date: &Date,
+        cursor_day: u32,
+        is_start: bool,
+        is_focused: bool,
+    ) {
+        let days = days_in_month(date.year, date.month);
+        let first_weekday = self.first_weekday(date);
+
+        // Header
+        let title = if is_start { "Start" } else { "End" };
+        let header = format!("{}: {} {}", title, month_name(date.month), date.year);
+        let header_color = if is_focused {
+            self.header_fg
+        } else {
+            Color::rgb(100, 100, 100)
+        };
+        self.draw_text(ctx, x, y, &header, header_color, true);
+
+        // Day headers
+        let day_headers = match self.first_day {
+            FirstDayOfWeek::Sunday => "Su Mo Tu We Th Fr Sa",
+            FirstDayOfWeek::Monday => "Mo Tu We Th Fr Sa Su",
+        };
+        self.draw_text(ctx, x, y + 1, day_headers, Color::rgb(150, 150, 150), false);
+
+        // Days
+        let mut row = 0u16;
+        let mut col = first_weekday as u16;
+
+        let selected_day = if is_start {
+            self.start.date.day
+        } else {
+            self.end.date.day
+        };
+
+        for day in 1..=days {
+            let day_x = x + col * 3;
+            let day_y = y + 2 + row;
+            let day_str = format!("{:2}", day);
+
+            let check_date = Date::new(date.year, date.month, day);
+            let in_range = self.is_in_range(&check_date);
+            let is_selected = day == selected_day;
+            let is_cursor = day == cursor_day && is_focused;
+
+            let (fg, bg, bold) = if is_cursor {
+                (Color::BLACK, Some(Color::WHITE), true)
+            } else if is_selected {
+                (self.selected_fg, Some(self.selected_bg), true)
+            } else if in_range {
+                (Color::WHITE, Some(self.range_bg), false)
+            } else {
+                (Color::WHITE, None, false)
+            };
+
+            if let Some(bg_color) = bg {
+                for i in 0..2 {
+                    let mut cell = Cell::new(' ');
+                    cell.bg = Some(bg_color);
+                    ctx.buffer.set(day_x + i, day_y, cell);
+                }
+            }
+            self.draw_text(ctx, day_x, day_y, &day_str, fg, bold);
+
+            col += 1;
+            if col > 6 {
+                col = 0;
+                row += 1;
+            }
+        }
+    }
+
+    /// Render presets list
+    fn render_presets(&self, ctx: &mut RenderContext, x: u16, y: u16, is_focused: bool) {
+        let title_color = if is_focused {
+            self.header_fg
+        } else {
+            Color::rgb(100, 100, 100)
+        };
+        self.draw_text(ctx, x, y, "Presets", title_color, true);
+
+        for (i, preset) in self.presets.iter().enumerate() {
+            let preset_y = y + 1 + i as u16;
+            let is_cursor = i == self.preset_cursor && is_focused;
+            let is_active = self.active_preset == Some(*preset);
+
+            let (fg, bg) = if is_cursor {
+                (self.preset_selected_fg, Some(self.preset_selected_bg))
+            } else if is_active {
+                (Color::CYAN, None)
+            } else {
+                (self.preset_fg, None)
+            };
+
+            let marker = if is_active { "● " } else { "  " };
+            let text = format!("{}{}", marker, preset.name());
+
+            if let Some(bg_color) = bg {
+                for dx in 0..16 {
+                    let mut cell = Cell::new(' ');
+                    cell.bg = Some(bg_color);
+                    ctx.buffer.set(x + dx, preset_y, cell);
+                }
+            }
+            self.draw_text(ctx, x, preset_y, &text, fg, is_cursor);
+        }
+    }
+
+    /// Draw text helper
+    fn draw_text(
+        &self,
+        ctx: &mut RenderContext,
+        x: u16,
+        y: u16,
+        text: &str,
+        color: Color,
+        bold: bool,
+    ) {
+        let mut offset = 0u16;
+        for ch in text.chars() {
+            let char_width = ch.width().unwrap_or(0) as u16;
+            if char_width == 0 {
+                continue;
+            }
+            let mut cell = Cell::new(ch);
+            cell.fg = Some(color);
+            if bold {
+                cell.modifier |= Modifier::BOLD;
+            }
+            ctx.buffer.set(x + offset, y, cell);
+            for i in 1..char_width {
+                ctx.buffer.set(x + offset + i, y, Cell::continuation());
+            }
+            offset += char_width;
+        }
+    }
+}
+
+impl Default for RangePicker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl View for RangePicker {
+    fn render(&self, ctx: &mut RenderContext) {
+        let area = ctx.area;
+        if area.width < 50 || area.height < 10 {
+            return;
+        }
+
+        let x = area.x;
+        let y = area.y;
+
+        // Render start calendar
+        let start_focused = self.focus == RangeFocus::Start;
+        self.render_calendar(
+            ctx,
+            x,
+            y,
+            &self.start.date,
+            self.start_cursor_day,
+            true,
+            start_focused,
+        );
+
+        // Render end calendar (next to start)
+        let end_x = x + 24;
+        let end_focused = self.focus == RangeFocus::End;
+        self.render_calendar(
+            ctx,
+            end_x,
+            y,
+            &self.end.date,
+            self.end_cursor_day,
+            false,
+            end_focused,
+        );
+
+        // Render presets if enabled
+        if self.show_presets {
+            let presets_x = end_x + 24;
+            let presets_focused = self.focus == RangeFocus::Presets;
+            self.render_presets(ctx, presets_x, y, presets_focused);
+        }
+
+        // Render selected range summary
+        let summary_y = y + 9;
+        let range_str = format!(
+            "Range: {}-{:02}-{:02} to {}-{:02}-{:02}",
+            self.start.date.year,
+            self.start.date.month,
+            self.start.date.day,
+            self.end.date.year,
+            self.end.date.month,
+            self.end.date.day,
+        );
+        self.draw_text(
+            ctx,
+            x,
+            summary_y,
+            &range_str,
+            Color::rgb(200, 200, 200),
+            false,
+        );
+
+        // Help text
+        let help = "Tab: switch | ←→↑↓: navigate | [/]: month | Enter: select";
+        self.draw_text(
+            ctx,
+            x,
+            summary_y + 1,
+            help,
+            Color::rgb(100, 100, 100),
+            false,
+        );
+    }
+}
+
+impl_styled_view!(RangePicker);
+impl_state_builders!(RangePicker);
+impl_props_builders!(RangePicker);
+
+/// Helper function to get month name
+fn month_name(month: u32) -> &'static str {
+    match month {
+        1 => "Jan",
+        2 => "Feb",
+        3 => "Mar",
+        4 => "Apr",
+        5 => "May",
+        6 => "Jun",
+        7 => "Jul",
+        8 => "Aug",
+        9 => "Sep",
+        10 => "Oct",
+        11 => "Nov",
+        12 => "Dec",
+        _ => "???",
+    }
+}
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+/// Create a basic range picker
+pub fn range_picker() -> RangePicker {
+    RangePicker::new()
+}
+
+/// Create a date-only range picker (no time)
+pub fn date_range_picker() -> RangePicker {
+    RangePicker::new().show_time(false)
+}
+
+/// Create an analytics-style range picker with common presets
+pub fn analytics_range_picker() -> RangePicker {
+    RangePicker::new().with_presets(true).presets(vec![
+        PresetRange::Today,
+        PresetRange::Yesterday,
+        PresetRange::Last7Days,
+        PresetRange::Last30Days,
+        PresetRange::ThisMonth,
+        PresetRange::LastMonth,
+        PresetRange::ThisYear,
+    ])
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::Rect;
+    use crate::render::Buffer;
+
+    #[test]
+    fn test_range_picker_new() {
+        let picker = RangePicker::new();
+        let (start, end) = picker.get_range();
+        assert_eq!(start, end); // Default is today-today
+    }
+
+    #[test]
+    fn test_range_picker_set_range() {
+        let picker = range_picker()
+            .start_date(Date::new(2025, 1, 1))
+            .end_date(Date::new(2025, 1, 31));
+
+        let (start, end) = picker.get_range();
+        assert_eq!(start, Date::new(2025, 1, 1));
+        assert_eq!(end, Date::new(2025, 1, 31));
+    }
+
+    #[test]
+    fn test_range_picker_swap() {
+        let picker = range_picker()
+            .start_date(Date::new(2025, 12, 31))
+            .end_date(Date::new(2025, 1, 1));
+
+        let (start, end) = picker.get_range();
+        assert!(start <= end);
+    }
+
+    #[test]
+    fn test_range_picker_is_in_range() {
+        let picker = range_picker()
+            .start_date(Date::new(2025, 1, 10))
+            .end_date(Date::new(2025, 1, 20));
+
+        assert!(picker.is_in_range(&Date::new(2025, 1, 15)));
+        assert!(picker.is_in_range(&Date::new(2025, 1, 10)));
+        assert!(picker.is_in_range(&Date::new(2025, 1, 20)));
+        assert!(!picker.is_in_range(&Date::new(2025, 1, 5)));
+        assert!(!picker.is_in_range(&Date::new(2025, 1, 25)));
+    }
+
+    #[test]
+    fn test_range_picker_focus_navigation() {
+        let mut picker = range_picker();
+
+        assert_eq!(picker.focus, RangeFocus::Start);
+
+        picker.handle_key(&Key::Tab);
+        assert_eq!(picker.focus, RangeFocus::End);
+
+        picker.handle_key(&Key::Tab);
+        assert_eq!(picker.focus, RangeFocus::Presets);
+
+        picker.handle_key(&Key::Tab);
+        assert_eq!(picker.focus, RangeFocus::Start);
+
+        picker.handle_key(&Key::BackTab);
+        assert_eq!(picker.focus, RangeFocus::Presets);
+    }
+
+    #[test]
+    fn test_range_picker_preset_apply() {
+        let mut picker = range_picker();
+        let today = Date::today();
+
+        picker.apply_preset(PresetRange::Today);
+        let (start, end) = picker.get_range();
+        assert_eq!(start, today);
+        assert_eq!(end, today);
+    }
+
+    #[test]
+    fn test_range_picker_preset_last7days() {
+        let today = Date::today();
+        let (start, end) = PresetRange::Last7Days.calculate(today);
+
+        assert_eq!(end, today);
+        // Start should be 6 days before today
+        let expected_start = today.subtract_days(6);
+        assert_eq!(start, expected_start);
+    }
+
+    #[test]
+    fn test_range_picker_preset_this_month() {
+        let today = Date::today();
+        let (start, end) = PresetRange::ThisMonth.calculate(today);
+
+        assert_eq!(start.day, 1);
+        assert_eq!(start.month, today.month);
+        assert_eq!(end, today);
+    }
+
+    #[test]
+    fn test_range_picker_key_navigation() {
+        let mut picker = range_picker().start_date(Date::new(2025, 6, 15));
+
+        picker.handle_key(&Key::Right);
+        assert_eq!(picker.start_cursor_day, 16);
+
+        picker.handle_key(&Key::Left);
+        assert_eq!(picker.start_cursor_day, 15);
+
+        picker.handle_key(&Key::Down);
+        assert_eq!(picker.start_cursor_day, 22);
+
+        picker.handle_key(&Key::Up);
+        assert_eq!(picker.start_cursor_day, 15);
+    }
+
+    #[test]
+    fn test_range_picker_month_navigation() {
+        let mut picker = range_picker().start_date(Date::new(2025, 6, 15));
+
+        picker.handle_key(&Key::Char(']'));
+        assert_eq!(picker.start.date.month, 7);
+
+        picker.handle_key(&Key::Char('['));
+        assert_eq!(picker.start.date.month, 6);
+    }
+
+    #[test]
+    fn test_range_picker_year_navigation() {
+        let mut picker = range_picker().start_date(Date::new(2025, 6, 15));
+
+        picker.handle_key(&Key::Char('}'));
+        assert_eq!(picker.start.date.year, 2026);
+
+        picker.handle_key(&Key::Char('{'));
+        assert_eq!(picker.start.date.year, 2025);
+    }
+
+    #[test]
+    fn test_range_picker_select() {
+        // Create a picker with a range that gives us room to select
+        let mut picker = range_picker()
+            .start_date(Date::new(2025, 1, 10))
+            .end_date(Date::new(2025, 1, 20));
+
+        assert_eq!(picker.start.date.day, 10);
+        assert_eq!(picker.start_cursor_day, 10);
+
+        // Navigate cursor to day 15
+        for _ in 0..5 {
+            picker.handle_key(&Key::Right);
+        }
+        assert_eq!(picker.start_cursor_day, 15);
+
+        // Select day 15
+        picker.handle_key(&Key::Enter);
+        assert_eq!(picker.start.date.day, 15);
+        assert_eq!(picker.end.date.day, 20); // End unchanged
+    }
+
+    #[test]
+    fn test_range_picker_preset_navigation() {
+        let mut picker = range_picker();
+        picker.focus = RangeFocus::Presets;
+
+        assert_eq!(picker.preset_cursor, 0);
+
+        picker.handle_key(&Key::Down);
+        assert_eq!(picker.preset_cursor, 1);
+
+        picker.handle_key(&Key::Up);
+        assert_eq!(picker.preset_cursor, 0);
+    }
+
+    #[test]
+    fn test_range_picker_preset_select() {
+        let mut picker = range_picker();
+        picker.focus = RangeFocus::Presets;
+        picker.preset_cursor = 2; // Last7Days
+
+        picker.handle_key(&Key::Enter);
+        assert_eq!(picker.active_preset, Some(PresetRange::Last7Days));
+    }
+
+    #[test]
+    fn test_range_picker_helper_functions() {
+        let _ = range_picker();
+        let _ = date_range_picker();
+        let _ = analytics_range_picker();
+    }
+
+    #[test]
+    fn test_range_picker_render() {
+        let mut buffer = Buffer::new(80, 15);
+        let area = Rect::new(0, 0, 80, 15);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let picker = range_picker()
+            .start_date(Date::new(2025, 1, 1))
+            .end_date(Date::new(2025, 1, 31))
+            .focused(true);
+
+        picker.render(&mut ctx);
+        // Verify rendering completed without panic
+    }
+
+    #[test]
+    fn test_preset_names() {
+        assert_eq!(PresetRange::Today.name(), "Today");
+        assert_eq!(PresetRange::Last7Days.name(), "Last 7 Days");
+        assert_eq!(PresetRange::Custom.name(), "Custom");
+    }
+
+    #[test]
+    fn test_preset_common() {
+        let common = PresetRange::common();
+        assert!(common.contains(&PresetRange::Today));
+        assert!(common.contains(&PresetRange::Last7Days));
+        assert!(!common.contains(&PresetRange::Custom));
+    }
+
+    #[test]
+    fn test_range_picker_disabled() {
+        let mut picker = range_picker().disabled(true);
+
+        let handled = picker.handle_key(&Key::Right);
+        assert!(!handled);
+    }
+}


### PR DESCRIPTION
## Summary
- **NumberInput** (#42): numeric input with increment/decrement controls, min/max constraints, precision settings, and prefix/suffix support
- **MultiSelect** (#43): dropdown for selecting multiple options with tag display, fuzzy search filtering, and keyboard navigation
- **RangePicker** (#44): date range selection with dual calendars, preset ranges (Today, Last 7 Days, etc.), and validation

## New Helper Functions
- `number_input()`, `integer_input()`, `currency_input()`, `percentage_input()`
- `multi_select()`, `multi_select_from()`
- `range_picker()`, `date_range_picker()`, `analytics_range_picker()`

## Additional Changes
- Added `Date` utility methods: `prev_day()`, `next_day()`, `subtract_days()`, `add_days()`
- Closed #45 (Time Picker already implemented as `time_picker()`)

## Test plan
- [x] NumberInput tests pass (21 tests)
- [x] MultiSelect tests pass (20 tests)
- [x] RangePicker tests pass (19 tests)
- [x] All existing tests pass
- [x] Clippy clean

Closes #42, Closes #43, Closes #44