### PR TITLE
fix(ci): run only coverage on main branch push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
 
 concurrency:
@@ -35,7 +37,7 @@ jobs:
   fmt:
     name: Format
     needs: changes
-    if: needs.changes.outputs.code == 'true' && github.actor != 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -47,7 +49,7 @@ jobs:
   clippy:
     name: Clippy
     needs: changes
-    if: needs.changes.outputs.code == 'true' && github.actor != 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -62,6 +64,7 @@ jobs:
     needs: [changes, fmt, clippy]
     if: |
       always() &&
+      github.event_name == 'pull_request' &&
       needs.changes.outputs.code == 'true' &&
       (needs.fmt.result == 'success' || needs.fmt.result == 'skipped') &&
       (needs.clippy.result == 'success' || needs.clippy.result == 'skipped')
@@ -104,6 +107,7 @@ jobs:
     needs: [changes, fmt, clippy]
     if: |
       always() &&
+      github.event_name == 'pull_request' &&
       needs.changes.outputs.code == 'true' &&
       (needs.fmt.result == 'success' || needs.fmt.result == 'skipped') &&
       (needs.clippy.result == 'success' || needs.clippy.result == 'skipped')
@@ -116,6 +120,7 @@ jobs:
 
   typos:
     name: Typos
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add push trigger for main branch to establish Codecov baseline
- Skip fmt, clippy, test, msrv, typos on main push (only coverage runs)
- Fixes "unknown" coverage status on PRs by ensuring main has baseline

## Why
Previously CI only ran on `pull_request`, so main never had coverage uploaded.
This caused Codecov to show "unknown" because there was no baseline to compare against.