### PR TITLE
feat: add IME, RTL/BiDi, and Sixel/iTerm2 image protocol support

### DIFF
--- a/src/event/ime.rs
+++ b/src/event/ime.rs
@@ -1,0 +1,844 @@
+//! IME (Input Method Editor) Composition Support
+//!
+//! Provides support for CJK and other complex input methods that require
+//! composition (multiple keystrokes forming a single character).
+//!
+//! # Features
+//!
+//! - Composition start/update/end events
+//! - Inline composition preview
+//! - Candidate selection support
+//! - Visual feedback (underline, highlight)
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use revue::event::ime::*;
+//!
+//! let mut ime = ImeState::new();
+//!
+//! // Handle composition events
+//! ime.on_composition(|event| {
+//!     match event {
+//!         CompositionEvent::Start => println!("Started composing"),
+//!         CompositionEvent::Update { text, cursor } => {
+//!             println!("Composing: {} (cursor at {})", text, cursor);
+//!         }
+//!         CompositionEvent::End { text } => {
+//!             println!("Committed: {:?}", text);
+//!         }
+//!     }
+//! });
+//!
+//! // Start composition
+//! ime.start_composition();
+//! ime.update_composition("か", 1);
+//! ime.update_composition("かん", 2);
+//! ime.commit("漢");
+//! ```
+
+use std::sync::Arc;
+
+// =============================================================================
+// Composition State
+// =============================================================================
+
+/// IME composition state
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CompositionState {
+    /// Not composing
+    #[default]
+    Idle,
+    /// Currently composing
+    Composing,
+    /// Selecting from candidates
+    Selecting,
+}
+
+/// Composition event
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompositionEvent {
+    /// Composition started
+    Start,
+    /// Composition text updated
+    Update {
+        /// Current composing text
+        text: String,
+        /// Cursor position within composition
+        cursor: usize,
+    },
+    /// Composition ended (committed or cancelled)
+    End {
+        /// Committed text (None if cancelled)
+        text: Option<String>,
+    },
+    /// Candidate list updated
+    CandidatesChanged {
+        /// List of candidates
+        candidates: Vec<String>,
+        /// Currently selected index
+        selected: usize,
+    },
+}
+
+// =============================================================================
+// Candidate
+// =============================================================================
+
+/// A candidate for selection during composition
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Candidate {
+    /// The candidate text
+    pub text: String,
+    /// Optional label (e.g., "1", "a")
+    pub label: Option<String>,
+    /// Optional annotation/description
+    pub annotation: Option<String>,
+}
+
+impl Candidate {
+    /// Create a new candidate
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            label: None,
+            annotation: None,
+        }
+    }
+
+    /// Set label
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    /// Set annotation
+    pub fn with_annotation(mut self, annotation: impl Into<String>) -> Self {
+        self.annotation = Some(annotation.into());
+        self
+    }
+}
+
+impl From<&str> for Candidate {
+    fn from(s: &str) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<String> for Candidate {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+// =============================================================================
+// Composition Style
+// =============================================================================
+
+/// Visual style for composition text
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CompositionStyle {
+    /// Underline the composing text
+    #[default]
+    Underline,
+    /// Highlight with background color
+    Highlight,
+    /// Use a different foreground color
+    Colored,
+    /// Combine underline and highlight
+    UnderlineHighlight,
+}
+
+/// Configuration for IME display
+#[derive(Debug, Clone)]
+pub struct ImeConfig {
+    /// Style for composing text
+    pub composition_style: CompositionStyle,
+    /// Show candidate window
+    pub show_candidates: bool,
+    /// Maximum candidates to display
+    pub max_candidates: usize,
+    /// Candidate window position relative to cursor
+    pub candidate_offset: (i16, i16),
+    /// Show composition inline (vs separate window)
+    pub inline_composition: bool,
+}
+
+impl Default for ImeConfig {
+    fn default() -> Self {
+        Self {
+            composition_style: CompositionStyle::Underline,
+            show_candidates: true,
+            max_candidates: 9,
+            candidate_offset: (0, 1),
+            inline_composition: true,
+        }
+    }
+}
+
+// =============================================================================
+// IME State
+// =============================================================================
+
+type CompositionCallback = Arc<dyn Fn(&CompositionEvent) + Send + Sync>;
+
+/// IME state manager
+pub struct ImeState {
+    /// Current composition state
+    state: CompositionState,
+    /// Current composing text
+    composing_text: String,
+    /// Cursor position within composition
+    cursor: usize,
+    /// Available candidates
+    candidates: Vec<Candidate>,
+    /// Selected candidate index
+    selected_candidate: usize,
+    /// Configuration
+    config: ImeConfig,
+    /// Composition event callbacks
+    callbacks: Vec<CompositionCallback>,
+    /// Whether IME is enabled
+    enabled: bool,
+}
+
+impl ImeState {
+    /// Create new IME state
+    pub fn new() -> Self {
+        Self {
+            state: CompositionState::Idle,
+            composing_text: String::new(),
+            cursor: 0,
+            candidates: Vec::new(),
+            selected_candidate: 0,
+            config: ImeConfig::default(),
+            callbacks: Vec::new(),
+            enabled: true,
+        }
+    }
+
+    /// Create with custom configuration
+    pub fn with_config(config: ImeConfig) -> Self {
+        Self {
+            config,
+            ..Self::new()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Configuration
+    // -------------------------------------------------------------------------
+
+    /// Get configuration
+    pub fn config(&self) -> &ImeConfig {
+        &self.config
+    }
+
+    /// Set configuration
+    pub fn set_config(&mut self, config: ImeConfig) {
+        self.config = config;
+    }
+
+    /// Enable IME
+    pub fn enable(&mut self) {
+        self.enabled = true;
+    }
+
+    /// Disable IME
+    pub fn disable(&mut self) {
+        self.enabled = false;
+        if self.state != CompositionState::Idle {
+            self.cancel();
+        }
+    }
+
+    /// Check if IME is enabled
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    // -------------------------------------------------------------------------
+    // State Queries
+    // -------------------------------------------------------------------------
+
+    /// Get current composition state
+    pub fn state(&self) -> CompositionState {
+        self.state
+    }
+
+    /// Check if currently composing
+    pub fn is_composing(&self) -> bool {
+        self.state != CompositionState::Idle
+    }
+
+    /// Get composing text
+    pub fn composing_text(&self) -> &str {
+        &self.composing_text
+    }
+
+    /// Get cursor position in composition
+    pub fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    /// Get candidates
+    pub fn candidates(&self) -> &[Candidate] {
+        &self.candidates
+    }
+
+    /// Get selected candidate index
+    pub fn selected_candidate(&self) -> usize {
+        self.selected_candidate
+    }
+
+    /// Get the currently selected candidate text
+    pub fn selected_text(&self) -> Option<&str> {
+        self.candidates
+            .get(self.selected_candidate)
+            .map(|c| c.text.as_str())
+    }
+
+    // -------------------------------------------------------------------------
+    // Composition Control
+    // -------------------------------------------------------------------------
+
+    /// Start composition
+    pub fn start_composition(&mut self) {
+        if !self.enabled {
+            return;
+        }
+
+        self.state = CompositionState::Composing;
+        self.composing_text.clear();
+        self.cursor = 0;
+        self.candidates.clear();
+        self.selected_candidate = 0;
+
+        self.emit(CompositionEvent::Start);
+    }
+
+    /// Update composition text
+    pub fn update_composition(&mut self, text: &str, cursor: usize) {
+        if self.state == CompositionState::Idle {
+            self.start_composition();
+        }
+
+        self.composing_text = text.to_string();
+        self.cursor = cursor.min(text.chars().count());
+
+        self.emit(CompositionEvent::Update {
+            text: self.composing_text.clone(),
+            cursor: self.cursor,
+        });
+    }
+
+    /// Set candidates
+    pub fn set_candidates(&mut self, candidates: Vec<Candidate>) {
+        self.candidates = candidates;
+        self.selected_candidate = 0;
+
+        if !self.candidates.is_empty() {
+            self.state = CompositionState::Selecting;
+        }
+
+        self.emit(CompositionEvent::CandidatesChanged {
+            candidates: self.candidates.iter().map(|c| c.text.clone()).collect(),
+            selected: self.selected_candidate,
+        });
+    }
+
+    /// Select next candidate
+    pub fn next_candidate(&mut self) {
+        if self.candidates.is_empty() {
+            return;
+        }
+
+        self.selected_candidate = (self.selected_candidate + 1) % self.candidates.len();
+
+        self.emit(CompositionEvent::CandidatesChanged {
+            candidates: self.candidates.iter().map(|c| c.text.clone()).collect(),
+            selected: self.selected_candidate,
+        });
+    }
+
+    /// Select previous candidate
+    pub fn prev_candidate(&mut self) {
+        if self.candidates.is_empty() {
+            return;
+        }
+
+        self.selected_candidate = if self.selected_candidate == 0 {
+            self.candidates.len() - 1
+        } else {
+            self.selected_candidate - 1
+        };
+
+        self.emit(CompositionEvent::CandidatesChanged {
+            candidates: self.candidates.iter().map(|c| c.text.clone()).collect(),
+            selected: self.selected_candidate,
+        });
+    }
+
+    /// Select candidate by index
+    pub fn select_candidate(&mut self, index: usize) {
+        if index < self.candidates.len() {
+            self.selected_candidate = index;
+
+            self.emit(CompositionEvent::CandidatesChanged {
+                candidates: self.candidates.iter().map(|c| c.text.clone()).collect(),
+                selected: self.selected_candidate,
+            });
+        }
+    }
+
+    /// Commit composition with current text or selected candidate
+    pub fn commit(&mut self, text: &str) -> Option<String> {
+        if self.state == CompositionState::Idle {
+            return None;
+        }
+
+        let committed = text.to_string();
+        self.reset_state();
+
+        self.emit(CompositionEvent::End {
+            text: Some(committed.clone()),
+        });
+
+        Some(committed)
+    }
+
+    /// Commit the currently selected candidate
+    pub fn commit_selected(&mut self) -> Option<String> {
+        if let Some(candidate) = self.candidates.get(self.selected_candidate) {
+            let text = candidate.text.clone();
+            self.commit(&text)
+        } else if !self.composing_text.is_empty() {
+            let text = self.composing_text.clone();
+            self.commit(&text)
+        } else {
+            None
+        }
+    }
+
+    /// Cancel composition
+    pub fn cancel(&mut self) {
+        if self.state == CompositionState::Idle {
+            return;
+        }
+
+        self.reset_state();
+
+        self.emit(CompositionEvent::End { text: None });
+    }
+
+    /// Handle backspace during composition
+    pub fn backspace(&mut self) -> bool {
+        if self.state == CompositionState::Idle || self.composing_text.is_empty() {
+            return false;
+        }
+
+        // Remove last character
+        let mut chars: Vec<char> = self.composing_text.chars().collect();
+        if self.cursor > 0 && self.cursor <= chars.len() {
+            chars.remove(self.cursor - 1);
+            self.composing_text = chars.into_iter().collect();
+            self.cursor = self.cursor.saturating_sub(1);
+
+            if self.composing_text.is_empty() {
+                self.cancel();
+            } else {
+                self.emit(CompositionEvent::Update {
+                    text: self.composing_text.clone(),
+                    cursor: self.cursor,
+                });
+            }
+
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Move cursor left within composition
+    pub fn move_cursor_left(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+            self.emit(CompositionEvent::Update {
+                text: self.composing_text.clone(),
+                cursor: self.cursor,
+            });
+        }
+    }
+
+    /// Move cursor right within composition
+    pub fn move_cursor_right(&mut self) {
+        let len = self.composing_text.chars().count();
+        if self.cursor < len {
+            self.cursor += 1;
+            self.emit(CompositionEvent::Update {
+                text: self.composing_text.clone(),
+                cursor: self.cursor,
+            });
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Callbacks
+    // -------------------------------------------------------------------------
+
+    /// Register composition event callback
+    pub fn on_composition<F>(&mut self, callback: F)
+    where
+        F: Fn(&CompositionEvent) + Send + Sync + 'static,
+    {
+        self.callbacks.push(Arc::new(callback));
+    }
+
+    /// Clear all callbacks
+    pub fn clear_callbacks(&mut self) {
+        self.callbacks.clear();
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    fn reset_state(&mut self) {
+        self.state = CompositionState::Idle;
+        self.composing_text.clear();
+        self.cursor = 0;
+        self.candidates.clear();
+        self.selected_candidate = 0;
+    }
+
+    fn emit(&self, event: CompositionEvent) {
+        for callback in &self.callbacks {
+            callback(&event);
+        }
+    }
+}
+
+impl Default for ImeState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// =============================================================================
+// Preedit String Builder
+// =============================================================================
+
+/// Builder for rendering preedit (composition) string with styling
+#[derive(Debug, Clone)]
+pub struct PreeditString {
+    /// Segments of the preedit string
+    segments: Vec<PreeditSegment>,
+}
+
+/// A segment of preedit text with styling
+#[derive(Debug, Clone)]
+pub struct PreeditSegment {
+    /// The text content
+    pub text: String,
+    /// Whether this segment is highlighted (selected)
+    pub highlighted: bool,
+    /// Whether this segment has the cursor
+    pub has_cursor: bool,
+    /// Cursor position within segment (if has_cursor)
+    pub cursor_pos: usize,
+}
+
+impl PreeditString {
+    /// Create new preedit string
+    pub fn new() -> Self {
+        Self {
+            segments: Vec::new(),
+        }
+    }
+
+    /// Create from IME state
+    pub fn from_ime(ime: &ImeState) -> Self {
+        let text = ime.composing_text();
+        let cursor = ime.cursor();
+
+        if text.is_empty() {
+            return Self::new();
+        }
+
+        // Split text at cursor position
+        let chars: Vec<char> = text.chars().collect();
+        let (before, after) = chars.split_at(cursor.min(chars.len()));
+
+        let mut preedit = Self::new();
+
+        if !before.is_empty() {
+            preedit.segments.push(PreeditSegment {
+                text: before.iter().collect(),
+                highlighted: false,
+                has_cursor: false,
+                cursor_pos: 0,
+            });
+        }
+
+        // Add cursor marker segment
+        preedit.segments.push(PreeditSegment {
+            text: String::new(),
+            highlighted: false,
+            has_cursor: true,
+            cursor_pos: 0,
+        });
+
+        if !after.is_empty() {
+            preedit.segments.push(PreeditSegment {
+                text: after.iter().collect(),
+                highlighted: false,
+                has_cursor: false,
+                cursor_pos: 0,
+            });
+        }
+
+        preedit
+    }
+
+    /// Add a segment
+    pub fn add_segment(&mut self, segment: PreeditSegment) {
+        self.segments.push(segment);
+    }
+
+    /// Get all segments
+    pub fn segments(&self) -> &[PreeditSegment] {
+        &self.segments
+    }
+
+    /// Get full text
+    pub fn text(&self) -> String {
+        self.segments.iter().map(|s| s.text.as_str()).collect()
+    }
+
+    /// Check if empty
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty() || self.text().is_empty()
+    }
+}
+
+impl Default for PreeditString {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn test_composition_state_default() {
+        let ime = ImeState::new();
+        assert_eq!(ime.state(), CompositionState::Idle);
+        assert!(!ime.is_composing());
+    }
+
+    #[test]
+    fn test_start_composition() {
+        let mut ime = ImeState::new();
+        ime.start_composition();
+
+        assert_eq!(ime.state(), CompositionState::Composing);
+        assert!(ime.is_composing());
+    }
+
+    #[test]
+    fn test_update_composition() {
+        let mut ime = ImeState::new();
+        ime.start_composition();
+        ime.update_composition("かん", 2);
+
+        assert_eq!(ime.composing_text(), "かん");
+        assert_eq!(ime.cursor(), 2);
+    }
+
+    #[test]
+    fn test_commit() {
+        let mut ime = ImeState::new();
+        ime.start_composition();
+        ime.update_composition("かん", 2);
+
+        let result = ime.commit("漢");
+
+        assert_eq!(result, Some("漢".to_string()));
+        assert!(!ime.is_composing());
+    }
+
+    #[test]
+    fn test_cancel() {
+        let mut ime = ImeState::new();
+        ime.start_composition();
+        ime.update_composition("test", 4);
+        ime.cancel();
+
+        assert!(!ime.is_composing());
+        assert!(ime.composing_text().is_empty());
+    }
+
+    #[test]
+    fn test_candidates() {
+        let mut ime = ImeState::new();
+        ime.start_composition();
+        ime.update_composition("kan", 3);
+
+        ime.set_candidates(vec![
+            Candidate::new("漢"),
+            Candidate::new("感"),
+            Candidate::new("間"),
+        ]);
+
+        assert_eq!(ime.candidates().len(), 3);
+        assert_eq!(ime.selected_candidate(), 0);
+        assert_eq!(ime.selected_text(), Some("漢"));
+    }
+
+    #[test]
+    fn test_candidate_navigation() {
+        let mut ime = ImeState::new();
+        ime.start_composition();
+        ime.set_candidates(vec![
+            Candidate::new("a"),
+            Candidate::new("b"),
+            Candidate::new("c"),
+        ]);
+
+        assert_eq!(ime.selected_candidate(), 0);
+
+        ime.next_candidate();
+        assert_eq!(ime.selected_candidate(), 1);
+
+        ime.next_candidate();
+        assert_eq!(ime.selected_candidate(), 2);
+
+        ime.next_candidate(); // Wraps around
+        assert_eq!(ime.selected_candidate(), 0);
+
+        ime.prev_candidate(); // Wraps around
+        assert_eq!(ime.selected_candidate(), 2);
+    }
+
+    #[test]
+    fn test_commit_selected() {
+        let mut ime = ImeState::new();
+        ime.start_composition();
+        ime.set_candidates(vec![Candidate::new("first"), Candidate::new("second")]);
+        ime.next_candidate();
+
+        let result = ime.commit_selected();
+        assert_eq!(result, Some("second".to_string()));
+    }
+
+    #[test]
+    fn test_backspace() {
+        let mut ime = ImeState::new();
+        ime.start_composition();
+        ime.update_composition("test", 4);
+
+        assert!(ime.backspace());
+        assert_eq!(ime.composing_text(), "tes");
+        assert_eq!(ime.cursor(), 3);
+    }
+
+    #[test]
+    fn test_backspace_cancels_empty() {
+        let mut ime = ImeState::new();
+        ime.start_composition();
+        ime.update_composition("a", 1);
+
+        ime.backspace();
+        assert!(!ime.is_composing());
+    }
+
+    #[test]
+    fn test_cursor_movement() {
+        let mut ime = ImeState::new();
+        ime.start_composition();
+        ime.update_composition("test", 4);
+
+        ime.move_cursor_left();
+        assert_eq!(ime.cursor(), 3);
+
+        ime.move_cursor_left();
+        ime.move_cursor_left();
+        ime.move_cursor_left();
+        assert_eq!(ime.cursor(), 0);
+
+        ime.move_cursor_left(); // Should not go below 0
+        assert_eq!(ime.cursor(), 0);
+
+        ime.move_cursor_right();
+        assert_eq!(ime.cursor(), 1);
+    }
+
+    #[test]
+    fn test_callback() {
+        let mut ime = ImeState::new();
+        let event_count = Arc::new(AtomicUsize::new(0));
+        let count_clone = Arc::clone(&event_count);
+
+        ime.on_composition(move |_| {
+            count_clone.fetch_add(1, Ordering::SeqCst);
+        });
+
+        ime.start_composition();
+        ime.update_composition("a", 1);
+        ime.commit("A");
+
+        assert_eq!(event_count.load(Ordering::SeqCst), 3); // start, update, end
+    }
+
+    #[test]
+    fn test_disabled_ime() {
+        let mut ime = ImeState::new();
+        ime.disable();
+
+        ime.start_composition();
+        assert!(!ime.is_composing());
+    }
+
+    #[test]
+    fn test_candidate_builder() {
+        let candidate = Candidate::new("漢")
+            .with_label("1")
+            .with_annotation("Chinese character");
+
+        assert_eq!(candidate.text, "漢");
+        assert_eq!(candidate.label, Some("1".to_string()));
+        assert_eq!(candidate.annotation, Some("Chinese character".to_string()));
+    }
+
+    #[test]
+    fn test_preedit_string() {
+        let mut ime = ImeState::new();
+        ime.start_composition();
+        ime.update_composition("hello", 2);
+
+        let preedit = PreeditString::from_ime(&ime);
+        assert!(!preedit.is_empty());
+        assert_eq!(preedit.text(), "hello");
+    }
+
+    #[test]
+    fn test_ime_config() {
+        let config = ImeConfig {
+            composition_style: CompositionStyle::Highlight,
+            show_candidates: false,
+            max_candidates: 5,
+            candidate_offset: (1, 2),
+            inline_composition: true,
+        };
+
+        let ime = ImeState::with_config(config.clone());
+        assert_eq!(ime.config().max_candidates, 5);
+    }
+}

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -5,6 +5,7 @@ pub mod drag;
 mod focus;
 pub mod gesture;
 mod handler;
+pub mod ime;
 mod keymap;
 mod reader;
 
@@ -23,6 +24,10 @@ pub use gesture::{
     PinchDirection, PinchGesture, SwipeDirection, SwipeGesture, TapGesture,
 };
 pub use handler::{EventContext, EventHandler, EventPhase, HandlerId};
+pub use ime::{
+    Candidate, CompositionEvent, CompositionState, CompositionStyle, ImeConfig, ImeState,
+    PreeditSegment, PreeditString,
+};
 pub use keymap::{Key, KeyBinding, KeyMap};
 pub use reader::EventReader;
 

--- a/src/render/image_protocol.rs
+++ b/src/render/image_protocol.rs
@@ -1,0 +1,904 @@
+//! Image protocol support for terminal graphics
+//!
+//! Supports multiple terminal image protocols:
+//! - Kitty graphics protocol (most capable, modern)
+//! - iTerm2 inline images (OSC 1337, macOS)
+//! - Sixel graphics (legacy, wide support)
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+/// Supported terminal image protocols
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum ImageProtocol {
+    /// Kitty graphics protocol (APC-based)
+    #[default]
+    Kitty,
+    /// iTerm2 inline images (OSC 1337)
+    Iterm2,
+    /// Sixel graphics protocol
+    Sixel,
+    /// No graphics support, use placeholder
+    None,
+}
+
+impl ImageProtocol {
+    /// Detect the best available protocol for the current terminal
+    pub fn detect() -> Self {
+        // Check for Kitty first (most capable)
+        if is_kitty_terminal() {
+            return ImageProtocol::Kitty;
+        }
+
+        // Check for iTerm2
+        if is_iterm2_terminal() {
+            return ImageProtocol::Iterm2;
+        }
+
+        // Check for Sixel support
+        if is_sixel_capable() {
+            return ImageProtocol::Sixel;
+        }
+
+        ImageProtocol::None
+    }
+
+    /// Check if this protocol is supported
+    pub fn is_supported(&self) -> bool {
+        !matches!(self, ImageProtocol::None)
+    }
+
+    /// Get protocol name
+    pub fn name(&self) -> &'static str {
+        match self {
+            ImageProtocol::Kitty => "Kitty",
+            ImageProtocol::Iterm2 => "iTerm2",
+            ImageProtocol::Sixel => "Sixel",
+            ImageProtocol::None => "None",
+        }
+    }
+}
+
+/// Check if running in Kitty terminal
+pub fn is_kitty_terminal() -> bool {
+    std::env::var("KITTY_WINDOW_ID").is_ok()
+        || std::env::var("TERM_PROGRAM")
+            .map(|v| v == "kitty")
+            .unwrap_or(false)
+}
+
+/// Check if running in iTerm2 terminal
+pub fn is_iterm2_terminal() -> bool {
+    std::env::var("TERM_PROGRAM")
+        .map(|v| v == "iTerm.app")
+        .unwrap_or(false)
+        || std::env::var("LC_TERMINAL")
+            .map(|v| v == "iTerm2")
+            .unwrap_or(false)
+}
+
+/// Check if terminal supports Sixel
+pub fn is_sixel_capable() -> bool {
+    // Check for known Sixel-capable terminals
+    if let Ok(term) = std::env::var("TERM") {
+        // mlterm, xterm with Sixel, foot, etc.
+        if term.contains("mlterm")
+            || term.contains("yaft")
+            || term.contains("foot")
+            || term.contains("contour")
+        {
+            return true;
+        }
+    }
+
+    // Check for VTE-based terminals with Sixel support
+    if std::env::var("VTE_VERSION").is_ok() {
+        if let Ok(colorterm) = std::env::var("COLORTERM") {
+            if colorterm == "truecolor" {
+                // Modern VTE may support Sixel
+                return true;
+            }
+        }
+    }
+
+    // xterm with Sixel support
+    if std::env::var("XTERM_VERSION").is_ok() {
+        return true;
+    }
+
+    false
+}
+
+/// Image encoder for terminal protocols
+#[derive(Clone, Debug)]
+pub struct ImageEncoder {
+    /// Target protocol
+    protocol: ImageProtocol,
+    /// Image data (raw pixels or encoded)
+    data: Vec<u8>,
+    /// Image width in pixels
+    width: u32,
+    /// Image height in pixels
+    height: u32,
+    /// Pixel format
+    format: PixelFormat,
+}
+
+/// Pixel format for image data
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PixelFormat {
+    /// Raw RGB pixels (3 bytes per pixel)
+    Rgb,
+    /// Raw RGBA pixels (4 bytes per pixel)
+    #[default]
+    Rgba,
+    /// PNG encoded data
+    Png,
+}
+
+impl ImageEncoder {
+    /// Create a new encoder with raw RGB data
+    pub fn from_rgb(data: Vec<u8>, width: u32, height: u32) -> Self {
+        Self {
+            protocol: ImageProtocol::detect(),
+            data,
+            width,
+            height,
+            format: PixelFormat::Rgb,
+        }
+    }
+
+    /// Create a new encoder with raw RGBA data
+    pub fn from_rgba(data: Vec<u8>, width: u32, height: u32) -> Self {
+        Self {
+            protocol: ImageProtocol::detect(),
+            data,
+            width,
+            height,
+            format: PixelFormat::Rgba,
+        }
+    }
+
+    /// Create a new encoder with PNG data
+    pub fn from_png(data: Vec<u8>, width: u32, height: u32) -> Self {
+        Self {
+            protocol: ImageProtocol::detect(),
+            data,
+            width,
+            height,
+            format: PixelFormat::Png,
+        }
+    }
+
+    /// Set the target protocol explicitly
+    pub fn protocol(mut self, protocol: ImageProtocol) -> Self {
+        self.protocol = protocol;
+        self
+    }
+
+    /// Get the target protocol
+    pub fn get_protocol(&self) -> ImageProtocol {
+        self.protocol
+    }
+
+    /// Encode the image for terminal display
+    pub fn encode(&self, cols: u16, rows: u16, image_id: u32) -> String {
+        match self.protocol {
+            ImageProtocol::Kitty => self.encode_kitty(cols, rows, image_id),
+            ImageProtocol::Iterm2 => self.encode_iterm2(cols, rows),
+            ImageProtocol::Sixel => self.encode_sixel(cols, rows),
+            ImageProtocol::None => String::new(),
+        }
+    }
+
+    /// Encode using Kitty graphics protocol
+    fn encode_kitty(&self, cols: u16, rows: u16, image_id: u32) -> String {
+        let mut output = String::new();
+
+        let format_code = match self.format {
+            PixelFormat::Png => 100,
+            PixelFormat::Rgb => 24,
+            PixelFormat::Rgba => 32,
+        };
+
+        // Encode data as base64
+        let encoded = BASE64.encode(&self.data);
+
+        // Split into chunks (max 4096 bytes per chunk)
+        let chunks: Vec<&str> = encoded
+            .as_bytes()
+            .chunks(4096)
+            .map(|c| std::str::from_utf8(c).unwrap_or(""))
+            .collect();
+
+        for (i, chunk) in chunks.iter().enumerate() {
+            let is_first = i == 0;
+            let is_last = i == chunks.len() - 1;
+            let more = if is_last { 0 } else { 1 };
+
+            if is_first {
+                // First chunk includes all parameters
+                output.push_str(&format!(
+                    "\x1b_Ga=T,f={},i={},c={},r={},m={};{}\x1b\\",
+                    format_code, image_id, cols, rows, more, chunk
+                ));
+            } else {
+                // Continuation chunks
+                output.push_str(&format!("\x1b_Gm={};{}\x1b\\", more, chunk));
+            }
+        }
+
+        output
+    }
+
+    /// Encode using iTerm2 inline image protocol (OSC 1337)
+    fn encode_iterm2(&self, cols: u16, rows: u16) -> String {
+        // Convert to PNG if not already
+        let png_data = match self.format {
+            PixelFormat::Png => self.data.clone(),
+            PixelFormat::Rgb | PixelFormat::Rgba => self.encode_to_png(),
+        };
+
+        // Base64 encode the image
+        let encoded = BASE64.encode(&png_data);
+
+        // Build the iTerm2 escape sequence
+        // Format: OSC 1337 ; File=[args]:base64data BEL
+        let args = format!(
+            "name={};size={};width={};height={};inline=1",
+            BASE64.encode("image"),
+            png_data.len(),
+            cols,
+            rows
+        );
+
+        format!("\x1b]1337;File={}:{}\x07", args, encoded)
+    }
+
+    /// Encode using Sixel graphics protocol
+    fn encode_sixel(&self, _cols: u16, _rows: u16) -> String {
+        // Convert to RGBA if needed
+        let rgba_data = self.to_rgba();
+
+        // Create a Sixel encoder
+        let sixel = SixelEncoder::new(self.width, self.height, &rgba_data);
+        sixel.encode()
+    }
+
+    /// Convert image data to PNG format
+    fn encode_to_png(&self) -> Vec<u8> {
+        use image::ImageEncoder;
+
+        let mut png_data = Vec::new();
+
+        // Use image crate to encode
+        let color_type = match self.format {
+            PixelFormat::Rgb => image::ExtendedColorType::Rgb8,
+            PixelFormat::Rgba => image::ExtendedColorType::Rgba8,
+            PixelFormat::Png => return self.data.clone(),
+        };
+
+        let _ = image::codecs::png::PngEncoder::new(&mut png_data).write_image(
+            &self.data,
+            self.width,
+            self.height,
+            color_type,
+        );
+
+        png_data
+    }
+
+    /// Convert to RGBA data
+    fn to_rgba(&self) -> Vec<u8> {
+        match self.format {
+            PixelFormat::Rgba => self.data.clone(),
+            PixelFormat::Rgb => {
+                // Convert RGB to RGBA
+                let mut rgba = Vec::with_capacity(self.data.len() / 3 * 4);
+                for chunk in self.data.chunks(3) {
+                    if chunk.len() == 3 {
+                        rgba.extend_from_slice(chunk);
+                        rgba.push(255); // Alpha
+                    }
+                }
+                rgba
+            }
+            PixelFormat::Png => {
+                // Decode PNG to RGBA
+                if let Ok(img) = image::load_from_memory(&self.data) {
+                    img.to_rgba8().into_raw()
+                } else {
+                    vec![0; (self.width * self.height * 4) as usize]
+                }
+            }
+        }
+    }
+}
+
+/// Sixel graphics encoder
+pub struct SixelEncoder<'a> {
+    width: u32,
+    height: u32,
+    data: &'a [u8],
+}
+
+impl<'a> SixelEncoder<'a> {
+    /// Create a new Sixel encoder
+    pub fn new(width: u32, height: u32, rgba_data: &'a [u8]) -> Self {
+        Self {
+            width,
+            height,
+            data: rgba_data,
+        }
+    }
+
+    /// Encode the image as Sixel
+    pub fn encode(&self) -> String {
+        let mut output = String::new();
+
+        // Build color palette (up to 256 colors)
+        let palette = self.build_palette();
+
+        // Start Sixel sequence
+        // DCS P1 ; P2 ; P3 q
+        // P1 = 0 (normal), P2 = 0 (default), P3 = 0 (don't set ratio)
+        output.push_str("\x1bPq");
+
+        // Set raster attributes: width x height
+        output.push_str(&format!("\"1;1;{};{}", self.width, self.height));
+
+        // Define color palette
+        for (idx, (r, g, b)) in palette.iter().enumerate() {
+            // #idx;2;r;g;b (2 = RGB percentage)
+            let r_pct = (*r as u32 * 100) / 255;
+            let g_pct = (*g as u32 * 100) / 255;
+            let b_pct = (*b as u32 * 100) / 255;
+            output.push_str(&format!("#{};2;{};{};{}", idx, r_pct, g_pct, b_pct));
+        }
+
+        // Encode pixel data
+        // Sixel encodes 6 vertical pixels at a time
+        for band in 0..self.height.div_ceil(6) {
+            let band_start = band * 6;
+
+            // For each color in palette
+            for (color_idx, _) in palette.iter().enumerate() {
+                let mut _run_start = 0;
+                let mut last_sixel: Option<u8> = None;
+                let mut run_length = 0;
+
+                // Select color
+                output.push('#');
+                output.push_str(&color_idx.to_string());
+
+                for x in 0..self.width {
+                    // Build sixel byte for this column
+                    let mut sixel_byte: u8 = 0;
+
+                    for bit in 0..6 {
+                        let y = band_start + bit;
+                        if y >= self.height {
+                            break;
+                        }
+
+                        let pixel_idx = ((y * self.width + x) * 4) as usize;
+                        if pixel_idx + 3 < self.data.len() {
+                            let r = self.data[pixel_idx];
+                            let g = self.data[pixel_idx + 1];
+                            let b = self.data[pixel_idx + 2];
+                            let a = self.data[pixel_idx + 3];
+
+                            // Check if this pixel matches current color
+                            if a > 127 {
+                                let (pr, pg, pb) = palette[color_idx];
+                                if Self::color_match(r, g, b, pr, pg, pb) {
+                                    sixel_byte |= 1 << bit;
+                                }
+                            }
+                        }
+                    }
+
+                    // Run-length encoding
+                    if Some(sixel_byte) == last_sixel {
+                        run_length += 1;
+                    } else {
+                        // Flush previous run
+                        if let Some(prev_sixel) = last_sixel {
+                            output.push_str(&Self::encode_run(prev_sixel, run_length));
+                        }
+                        last_sixel = Some(sixel_byte);
+                        _run_start = x;
+                        run_length = 1;
+                    }
+                }
+
+                // Flush final run
+                if let Some(prev_sixel) = last_sixel {
+                    output.push_str(&Self::encode_run(prev_sixel, run_length));
+                }
+
+                // Carriage return (same line, different color)
+                output.push('$');
+            }
+
+            // Line feed (next band)
+            output.push('-');
+        }
+
+        // End Sixel sequence
+        output.push_str("\x1b\\");
+
+        output
+    }
+
+    /// Build a color palette from the image
+    fn build_palette(&self) -> Vec<(u8, u8, u8)> {
+        use std::collections::HashMap;
+
+        let mut color_counts: HashMap<(u8, u8, u8), usize> = HashMap::new();
+
+        // Count color occurrences (quantize to reduce colors)
+        for pixel in self.data.chunks(4) {
+            if pixel.len() == 4 && pixel[3] > 127 {
+                // Quantize to reduce color space
+                let r = (pixel[0] / 32) * 32;
+                let g = (pixel[1] / 32) * 32;
+                let b = (pixel[2] / 32) * 32;
+                *color_counts.entry((r, g, b)).or_insert(0) += 1;
+            }
+        }
+
+        // Sort by frequency and take top 256
+        let mut colors: Vec<_> = color_counts.into_iter().collect();
+        colors.sort_by(|a, b| b.1.cmp(&a.1));
+
+        colors
+            .into_iter()
+            .take(256)
+            .map(|(color, _)| color)
+            .collect()
+    }
+
+    /// Check if two colors are close enough to match
+    fn color_match(r1: u8, g1: u8, b1: u8, r2: u8, g2: u8, b2: u8) -> bool {
+        let dr = (r1 as i32 - r2 as i32).abs();
+        let dg = (g1 as i32 - g2 as i32).abs();
+        let db = (b1 as i32 - b2 as i32).abs();
+        dr < 32 && dg < 32 && db < 32
+    }
+
+    /// Encode a run of sixel bytes
+    fn encode_run(sixel: u8, length: u32) -> String {
+        let sixel_char = (sixel + 63) as char;
+        if length == 1 {
+            sixel_char.to_string()
+        } else if length <= 3 {
+            std::iter::repeat_n(sixel_char, length as usize).collect()
+        } else {
+            format!("!{}{}", length, sixel_char)
+        }
+    }
+}
+
+/// iTerm2 specific image operations
+pub struct Iterm2Image;
+
+impl Iterm2Image {
+    /// Create an inline image escape sequence
+    pub fn inline_image(
+        data: &[u8],
+        width: Option<u16>,
+        height: Option<u16>,
+        preserve_aspect: bool,
+    ) -> String {
+        let encoded = BASE64.encode(data);
+        let filename = BASE64.encode("image.png");
+
+        let mut args = vec![format!("name={}", filename), format!("inline=1")];
+
+        if let Some(w) = width {
+            args.push(format!("width={}", w));
+        }
+        if let Some(h) = height {
+            args.push(format!("height={}", h));
+        }
+        if preserve_aspect {
+            args.push("preserveAspectRatio=1".to_string());
+        }
+
+        args.push(format!("size={}", data.len()));
+
+        format!("\x1b]1337;File={}:{}\x07", args.join(";"), encoded)
+    }
+
+    /// Create a cursor-positioned image (iTerm2 specific)
+    pub fn positioned_image(data: &[u8], x: u16, y: u16, width: u16, height: u16) -> String {
+        let encoded = BASE64.encode(data);
+        let filename = BASE64.encode("image.png");
+
+        format!(
+            "\x1b[{};{}H\x1b]1337;File=name={};width={};height={};inline=1;size={}:{}\x07",
+            y + 1,
+            x + 1,
+            filename,
+            width,
+            height,
+            data.len(),
+            encoded
+        )
+    }
+
+    /// Set custom cursor shape using an image
+    pub fn custom_cursor(_data: &[u8]) -> String {
+        // Note: iTerm2 doesn't support custom cursor images via escape sequences
+        // This is a placeholder for future compatibility
+        String::new()
+    }
+}
+
+/// Kitty specific image operations
+pub struct KittyImage;
+
+impl KittyImage {
+    /// Delete an image by ID
+    pub fn delete(image_id: u32) -> String {
+        format!("\x1b_Ga=d,i={}\x1b\\", image_id)
+    }
+
+    /// Delete all images
+    pub fn delete_all() -> String {
+        "\x1b_Ga=d\x1b\\".to_string()
+    }
+
+    /// Move/animate an image
+    pub fn move_image(image_id: u32, x: u16, y: u16) -> String {
+        format!("\x1b_Ga=p,i={},x={},y={}\x1b\\", image_id, x, y)
+    }
+
+    /// Create image with placement ID for animation
+    pub fn with_placement(
+        image_id: u32,
+        placement_id: u32,
+        data: &[u8],
+        cols: u16,
+        rows: u16,
+    ) -> String {
+        let encoded = BASE64.encode(data);
+        let chunks: Vec<&str> = encoded
+            .as_bytes()
+            .chunks(4096)
+            .map(|c| std::str::from_utf8(c).unwrap_or(""))
+            .collect();
+
+        let mut output = String::new();
+
+        for (i, chunk) in chunks.iter().enumerate() {
+            let is_first = i == 0;
+            let is_last = i == chunks.len() - 1;
+            let more = if is_last { 0 } else { 1 };
+
+            if is_first {
+                output.push_str(&format!(
+                    "\x1b_Ga=T,f=100,i={},p={},c={},r={},m={};{}\x1b\\",
+                    image_id, placement_id, cols, rows, more, chunk
+                ));
+            } else {
+                output.push_str(&format!("\x1b_Gm={};{}\x1b\\", more, chunk));
+            }
+        }
+
+        output
+    }
+
+    /// Query terminal for Kitty graphics support
+    pub fn query_support() -> String {
+        "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\".to_string()
+    }
+}
+
+/// Terminal capabilities for graphics
+#[derive(Clone, Debug, Default)]
+pub struct GraphicsCapabilities {
+    /// Best available protocol
+    pub protocol: ImageProtocol,
+    /// Maximum image width supported
+    pub max_width: Option<u32>,
+    /// Maximum image height supported
+    pub max_height: Option<u32>,
+    /// Number of colors supported (for Sixel)
+    pub color_depth: Option<u16>,
+    /// Whether animation is supported
+    pub animation: bool,
+}
+
+impl GraphicsCapabilities {
+    /// Detect graphics capabilities
+    pub fn detect() -> Self {
+        let protocol = ImageProtocol::detect();
+
+        let (max_width, max_height, animation) = match protocol {
+            ImageProtocol::Kitty => (None, None, true), // No practical limits
+            ImageProtocol::Iterm2 => (None, None, false), // No practical limits
+            ImageProtocol::Sixel => (Some(4096), Some(4096), false), // Varies by terminal
+            ImageProtocol::None => (None, None, false),
+        };
+
+        let color_depth = match protocol {
+            ImageProtocol::Sixel => Some(256),
+            _ => None,
+        };
+
+        Self {
+            protocol,
+            max_width,
+            max_height,
+            color_depth,
+            animation,
+        }
+    }
+
+    /// Check if any graphics protocol is supported
+    pub fn has_graphics(&self) -> bool {
+        self.protocol.is_supported()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =============================================================================
+    // ImageProtocol Tests
+    // =============================================================================
+
+    #[test]
+    fn test_image_protocol_default() {
+        assert_eq!(ImageProtocol::default(), ImageProtocol::Kitty);
+    }
+
+    #[test]
+    fn test_image_protocol_is_supported() {
+        assert!(ImageProtocol::Kitty.is_supported());
+        assert!(ImageProtocol::Iterm2.is_supported());
+        assert!(ImageProtocol::Sixel.is_supported());
+        assert!(!ImageProtocol::None.is_supported());
+    }
+
+    #[test]
+    fn test_image_protocol_name() {
+        assert_eq!(ImageProtocol::Kitty.name(), "Kitty");
+        assert_eq!(ImageProtocol::Iterm2.name(), "iTerm2");
+        assert_eq!(ImageProtocol::Sixel.name(), "Sixel");
+        assert_eq!(ImageProtocol::None.name(), "None");
+    }
+
+    // =============================================================================
+    // ImageEncoder Tests
+    // =============================================================================
+
+    #[test]
+    fn test_encoder_from_rgb() {
+        let data = vec![255, 0, 0, 0, 255, 0]; // 2 red/green pixels
+        let encoder = ImageEncoder::from_rgb(data, 2, 1);
+        assert_eq!(encoder.width, 2);
+        assert_eq!(encoder.height, 1);
+        assert_eq!(encoder.format, PixelFormat::Rgb);
+    }
+
+    #[test]
+    fn test_encoder_from_rgba() {
+        let data = vec![255, 0, 0, 255, 0, 255, 0, 255];
+        let encoder = ImageEncoder::from_rgba(data, 2, 1);
+        assert_eq!(encoder.width, 2);
+        assert_eq!(encoder.height, 1);
+        assert_eq!(encoder.format, PixelFormat::Rgba);
+    }
+
+    #[test]
+    fn test_encoder_set_protocol() {
+        let data = vec![0; 12];
+        let encoder = ImageEncoder::from_rgb(data, 2, 2).protocol(ImageProtocol::Sixel);
+        assert_eq!(encoder.get_protocol(), ImageProtocol::Sixel);
+    }
+
+    #[test]
+    fn test_encoder_kitty_output() {
+        let data = vec![0; 12];
+        let encoder = ImageEncoder::from_rgb(data, 2, 2).protocol(ImageProtocol::Kitty);
+        let output = encoder.encode(10, 5, 1);
+
+        assert!(output.starts_with("\x1b_G"));
+        assert!(output.ends_with("\x1b\\"));
+        assert!(output.contains("a=T"));
+        assert!(output.contains("f=24")); // RGB format
+    }
+
+    #[test]
+    fn test_encoder_iterm2_output() {
+        let data = vec![0; 12];
+        let encoder = ImageEncoder::from_rgb(data, 2, 2).protocol(ImageProtocol::Iterm2);
+        let output = encoder.encode(10, 5, 1);
+
+        assert!(output.starts_with("\x1b]1337;File="));
+        assert!(output.ends_with("\x07"));
+        assert!(output.contains("inline=1"));
+    }
+
+    #[test]
+    fn test_encoder_sixel_output() {
+        let data = vec![255, 0, 0, 255, 0, 255, 0, 255]; // 2 pixels
+        let encoder = ImageEncoder::from_rgba(data, 2, 1).protocol(ImageProtocol::Sixel);
+        let output = encoder.encode(10, 5, 1);
+
+        assert!(output.starts_with("\x1bPq"));
+        assert!(output.ends_with("\x1b\\"));
+    }
+
+    #[test]
+    fn test_encoder_none_output() {
+        let data = vec![0; 12];
+        let encoder = ImageEncoder::from_rgb(data, 2, 2).protocol(ImageProtocol::None);
+        let output = encoder.encode(10, 5, 1);
+        assert!(output.is_empty());
+    }
+
+    // =============================================================================
+    // Sixel Encoder Tests
+    // =============================================================================
+
+    #[test]
+    fn test_sixel_encode_run() {
+        assert_eq!(SixelEncoder::encode_run(0, 1), "?");
+        assert_eq!(SixelEncoder::encode_run(0, 3), "???");
+        assert_eq!(SixelEncoder::encode_run(0, 5), "!5?");
+    }
+
+    #[test]
+    fn test_sixel_color_match() {
+        assert!(SixelEncoder::color_match(100, 100, 100, 100, 100, 100));
+        assert!(SixelEncoder::color_match(100, 100, 100, 110, 110, 110));
+        assert!(!SixelEncoder::color_match(0, 0, 0, 255, 255, 255));
+    }
+
+    #[test]
+    fn test_sixel_encoder_basic() {
+        // Single red pixel
+        let data = vec![255, 0, 0, 255];
+        let encoder = SixelEncoder::new(1, 1, &data);
+        let output = encoder.encode();
+
+        assert!(output.starts_with("\x1bPq"));
+        assert!(output.ends_with("\x1b\\"));
+    }
+
+    // =============================================================================
+    // iTerm2 Image Tests
+    // =============================================================================
+
+    #[test]
+    fn test_iterm2_inline_image() {
+        let data = vec![0u8; 10];
+        let output = Iterm2Image::inline_image(&data, Some(10), Some(5), true);
+
+        assert!(output.starts_with("\x1b]1337;File="));
+        assert!(output.ends_with("\x07"));
+        assert!(output.contains("inline=1"));
+        assert!(output.contains("width=10"));
+        assert!(output.contains("height=5"));
+        assert!(output.contains("preserveAspectRatio=1"));
+    }
+
+    #[test]
+    fn test_iterm2_positioned_image() {
+        let data = vec![0u8; 10];
+        let output = Iterm2Image::positioned_image(&data, 5, 3, 10, 5);
+
+        assert!(output.contains("\x1b[4;6H")); // Cursor position (1-indexed)
+        assert!(output.contains("inline=1"));
+    }
+
+    // =============================================================================
+    // Kitty Image Tests
+    // =============================================================================
+
+    #[test]
+    fn test_kitty_delete() {
+        let output = KittyImage::delete(42);
+        assert!(output.contains("a=d"));
+        assert!(output.contains("i=42"));
+    }
+
+    #[test]
+    fn test_kitty_delete_all() {
+        let output = KittyImage::delete_all();
+        assert_eq!(output, "\x1b_Ga=d\x1b\\");
+    }
+
+    #[test]
+    fn test_kitty_move_image() {
+        let output = KittyImage::move_image(42, 10, 5);
+        assert!(output.contains("a=p"));
+        assert!(output.contains("i=42"));
+        assert!(output.contains("x=10"));
+        assert!(output.contains("y=5"));
+    }
+
+    #[test]
+    fn test_kitty_query_support() {
+        let output = KittyImage::query_support();
+        assert!(output.starts_with("\x1b_G"));
+        assert!(output.contains("a=q"));
+    }
+
+    // =============================================================================
+    // Graphics Capabilities Tests
+    // =============================================================================
+
+    #[test]
+    fn test_graphics_capabilities_default() {
+        let caps = GraphicsCapabilities::default();
+        assert_eq!(caps.protocol, ImageProtocol::Kitty);
+        assert!(!caps.animation);
+    }
+
+    // =============================================================================
+    // Terminal Detection Tests
+    // =============================================================================
+
+    #[test]
+    fn test_detection_functions() {
+        // These will return false in test environment (no terminal)
+        // Just verify they don't panic
+        let _ = is_kitty_terminal();
+        let _ = is_iterm2_terminal();
+        let _ = is_sixel_capable();
+    }
+
+    // =============================================================================
+    // Edge Cases
+    // =============================================================================
+
+    #[test]
+    fn test_encoder_empty_data() {
+        let encoder = ImageEncoder::from_rgb(vec![], 0, 0).protocol(ImageProtocol::Kitty);
+        let output = encoder.encode(10, 5, 1);
+        // Empty data produces empty output (no chunks to send)
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_encoder_large_image_chunking() {
+        // Create data larger than 4096 bytes to test chunking
+        let data = vec![0u8; 10000];
+        let encoder = ImageEncoder::from_rgb(data, 100, 100).protocol(ImageProtocol::Kitty);
+        let output = encoder.encode(10, 5, 1);
+
+        // Should have continuation markers
+        assert!(output.contains("m=1")); // More data coming
+        assert!(output.contains("m=0")); // Final chunk
+    }
+
+    #[test]
+    fn test_rgb_to_rgba_conversion() {
+        let rgb_data = vec![255, 0, 0, 0, 255, 0]; // 2 RGB pixels
+        let encoder = ImageEncoder::from_rgb(rgb_data, 2, 1);
+        let rgba = encoder.to_rgba();
+
+        assert_eq!(rgba.len(), 8); // 2 RGBA pixels
+        assert_eq!(rgba[3], 255); // Alpha added
+        assert_eq!(rgba[7], 255); // Alpha added
+    }
+
+    #[test]
+    fn test_sixel_palette_building() {
+        // Simple image with 2 colors
+        let data = vec![
+            255, 0, 0, 255, // Red
+            0, 255, 0, 255, // Green
+        ];
+        let encoder = SixelEncoder::new(2, 1, &data);
+        let palette = encoder.build_palette();
+
+        assert!(!palette.is_empty());
+        assert!(palette.len() <= 256);
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -10,12 +10,14 @@
 //! - **Buffer**: Double-buffered screen state
 //! - **Cell**: Individual terminal cell with character, colors, and modifiers
 //! - **Terminal**: High-level renderer that uses diff-based updates
+//! - **Image protocols**: Support for Kitty, iTerm2, and Sixel graphics
 
 pub mod backend;
 mod batch;
 mod buffer;
 mod cell;
 mod diff;
+pub mod image_protocol;
 mod terminal;
 
 pub use backend::{Backend, BackendCapabilities, CrosstermBackend};
@@ -23,4 +25,8 @@ pub use batch::{BatchStats, RenderBatch, RenderOp};
 pub use buffer::Buffer;
 pub use cell::{Cell, Modifier};
 pub use diff::{diff, Change};
+pub use image_protocol::{
+    GraphicsCapabilities, ImageEncoder, ImageProtocol, Iterm2Image, KittyImage, PixelFormat,
+    SixelEncoder,
+};
 pub use terminal::{stdout_terminal, Terminal};

--- a/src/text/bidi.rs
+++ b/src/text/bidi.rs
@@ -1,0 +1,1111 @@
+//! RTL (Right-to-Left) and BiDi (Bidirectional) text support
+//!
+//! Implements Unicode Bidirectional Algorithm (UAX #9) for proper handling
+//! of mixed-direction text, including Arabic, Hebrew, and other RTL scripts.
+
+use std::ops::Range;
+
+/// Text direction
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum TextDirection {
+    /// Left-to-right (default for Latin, CJK, etc.)
+    #[default]
+    Ltr,
+    /// Right-to-left (for Arabic, Hebrew, etc.)
+    Rtl,
+    /// Auto-detect from content
+    Auto,
+}
+
+impl TextDirection {
+    /// Returns true if this is RTL direction
+    pub fn is_rtl(&self) -> bool {
+        matches!(self, TextDirection::Rtl)
+    }
+
+    /// Returns true if this is LTR direction
+    pub fn is_ltr(&self) -> bool {
+        matches!(self, TextDirection::Ltr)
+    }
+
+    /// Returns true if direction should be auto-detected
+    pub fn is_auto(&self) -> bool {
+        matches!(self, TextDirection::Auto)
+    }
+
+    /// Resolve auto direction based on text content
+    pub fn resolve(&self, text: &str) -> ResolvedDirection {
+        match self {
+            TextDirection::Ltr => ResolvedDirection::Ltr,
+            TextDirection::Rtl => ResolvedDirection::Rtl,
+            TextDirection::Auto => detect_direction(text),
+        }
+    }
+}
+
+/// Resolved (non-auto) text direction
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum ResolvedDirection {
+    /// Left-to-right
+    #[default]
+    Ltr,
+    /// Right-to-left
+    Rtl,
+}
+
+impl ResolvedDirection {
+    /// Returns true if this is RTL
+    pub fn is_rtl(&self) -> bool {
+        matches!(self, ResolvedDirection::Rtl)
+    }
+
+    /// Returns true if this is LTR
+    pub fn is_ltr(&self) -> bool {
+        matches!(self, ResolvedDirection::Ltr)
+    }
+
+    /// Get the opposite direction
+    pub fn opposite(&self) -> Self {
+        match self {
+            ResolvedDirection::Ltr => ResolvedDirection::Rtl,
+            ResolvedDirection::Rtl => ResolvedDirection::Ltr,
+        }
+    }
+}
+
+/// BiDi character class (simplified from UAX #9)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BidiClass {
+    /// Strong left-to-right (L)
+    L,
+    /// Strong right-to-left (R) - Hebrew
+    R,
+    /// Strong right-to-left Arabic (AL)
+    AL,
+    /// European number (EN)
+    EN,
+    /// European number separator (ES)
+    ES,
+    /// European number terminator (ET)
+    ET,
+    /// Arabic number (AN)
+    AN,
+    /// Common number separator (CS)
+    CS,
+    /// Nonspacing mark (NSM)
+    NSM,
+    /// Boundary neutral (BN)
+    BN,
+    /// Paragraph separator (B)
+    B,
+    /// Segment separator (S)
+    S,
+    /// Whitespace (WS)
+    WS,
+    /// Other neutrals (ON)
+    ON,
+    /// Left-to-right embedding (LRE)
+    LRE,
+    /// Left-to-right override (LRO)
+    LRO,
+    /// Right-to-left embedding (RLE)
+    RLE,
+    /// Right-to-left override (RLO)
+    RLO,
+    /// Pop directional formatting (PDF)
+    PDF,
+    /// Left-to-right isolate (LRI)
+    LRI,
+    /// Right-to-left isolate (RLI)
+    RLI,
+    /// First strong isolate (FSI)
+    FSI,
+    /// Pop directional isolate (PDI)
+    PDI,
+}
+
+impl BidiClass {
+    /// Get the BiDi class of a character
+    pub fn of(c: char) -> Self {
+        let code = c as u32;
+
+        // Check for explicit directional formatting characters
+        match c {
+            '\u{202A}' => return BidiClass::LRE,
+            '\u{202B}' => return BidiClass::RLE,
+            '\u{202C}' => return BidiClass::PDF,
+            '\u{202D}' => return BidiClass::LRO,
+            '\u{202E}' => return BidiClass::RLO,
+            '\u{2066}' => return BidiClass::LRI,
+            '\u{2067}' => return BidiClass::RLI,
+            '\u{2068}' => return BidiClass::FSI,
+            '\u{2069}' => return BidiClass::PDI,
+            _ => {}
+        }
+
+        // Arabic block (0600-06FF) and Arabic Supplement (0750-077F)
+        if (0x0600..=0x06FF).contains(&code) || (0x0750..=0x077F).contains(&code) {
+            // Arabic numbers
+            if (0x0660..=0x0669).contains(&code) || (0x06F0..=0x06F9).contains(&code) {
+                return BidiClass::AN;
+            }
+            return BidiClass::AL;
+        }
+
+        // Arabic Extended-A (08A0-08FF)
+        if (0x08A0..=0x08FF).contains(&code) {
+            return BidiClass::AL;
+        }
+
+        // Arabic Presentation Forms-A (FB50-FDFF) and B (FE70-FEFF)
+        if (0xFB50..=0xFDFF).contains(&code) || (0xFE70..=0xFEFF).contains(&code) {
+            return BidiClass::AL;
+        }
+
+        // Hebrew block (0590-05FF)
+        if (0x0590..=0x05FF).contains(&code) {
+            return BidiClass::R;
+        }
+
+        // Other RTL scripts
+        if (0x07C0..=0x07FF).contains(&code)     // NKo
+            || (0x0800..=0x089F).contains(&code) // Samaritan, Mandaic
+            || (0x10800..=0x10FFF).contains(&code) // Phoenician, etc.
+            || (0x1E800..=0x1EFFF).contains(&code)
+        // Mende Kikakui, etc.
+        {
+            return BidiClass::R;
+        }
+
+        // European numbers (ASCII digits)
+        if c.is_ascii_digit() {
+            return BidiClass::EN;
+        }
+
+        // Number separators
+        if matches!(c, '+' | '-') {
+            return BidiClass::ES;
+        }
+
+        // Number terminators
+        if matches!(c, '#' | '$' | '%' | '°' | '€' | '£' | '¥') {
+            return BidiClass::ET;
+        }
+
+        // Common separators
+        if matches!(c, ',' | '.' | ':') {
+            return BidiClass::CS;
+        }
+
+        // Paragraph separator
+        if matches!(c, '\n' | '\r' | '\u{0085}' | '\u{2029}') {
+            return BidiClass::B;
+        }
+
+        // Segment separator
+        if matches!(c, '\t' | '\u{001F}' | '\u{001E}' | '\u{000B}') {
+            return BidiClass::S;
+        }
+
+        // Whitespace
+        if c.is_whitespace() {
+            return BidiClass::WS;
+        }
+
+        // Common punctuation and symbols are neutral
+        if c.is_ascii_punctuation() || matches!(c, '(' | ')' | '[' | ']' | '{' | '}' | '"' | '\'') {
+            return BidiClass::ON;
+        }
+
+        // Default to strong L for Latin and most other scripts
+        BidiClass::L
+    }
+
+    /// Check if this is a strong type
+    pub fn is_strong(&self) -> bool {
+        matches!(self, BidiClass::L | BidiClass::R | BidiClass::AL)
+    }
+
+    /// Check if this is a strong RTL type
+    pub fn is_strong_rtl(&self) -> bool {
+        matches!(self, BidiClass::R | BidiClass::AL)
+    }
+
+    /// Check if this is a weak type
+    pub fn is_weak(&self) -> bool {
+        matches!(
+            self,
+            BidiClass::EN
+                | BidiClass::ES
+                | BidiClass::ET
+                | BidiClass::AN
+                | BidiClass::CS
+                | BidiClass::NSM
+                | BidiClass::BN
+        )
+    }
+
+    /// Check if this is a neutral type
+    pub fn is_neutral(&self) -> bool {
+        matches!(
+            self,
+            BidiClass::B | BidiClass::S | BidiClass::WS | BidiClass::ON
+        )
+    }
+}
+
+/// A segment of text with a single direction
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BidiRun {
+    /// The text content of this run
+    pub text: String,
+    /// Character range in original text
+    pub range: Range<usize>,
+    /// The embedding level (even = LTR, odd = RTL)
+    pub level: u8,
+    /// The resolved direction of this run
+    pub direction: ResolvedDirection,
+}
+
+impl BidiRun {
+    /// Create a new BiDi run
+    pub fn new(text: String, range: Range<usize>, level: u8) -> Self {
+        let direction = if level.is_multiple_of(2) {
+            ResolvedDirection::Ltr
+        } else {
+            ResolvedDirection::Rtl
+        };
+        Self {
+            text,
+            range,
+            level,
+            direction,
+        }
+    }
+
+    /// Get the length of this run in characters
+    pub fn char_count(&self) -> usize {
+        self.text.chars().count()
+    }
+}
+
+/// Result of BiDi analysis
+#[derive(Clone, Debug)]
+pub struct BidiInfo {
+    /// The original text
+    pub text: String,
+    /// The base/paragraph direction
+    pub base_direction: ResolvedDirection,
+    /// The BiDi runs (segments with uniform direction)
+    pub runs: Vec<BidiRun>,
+    /// Visual ordering of runs (indices into runs)
+    pub visual_order: Vec<usize>,
+}
+
+impl BidiInfo {
+    /// Analyze text for BiDi properties
+    pub fn new(text: &str, direction: TextDirection) -> Self {
+        let base_direction = direction.resolve(text);
+        let runs = compute_runs(text, base_direction);
+        let visual_order = compute_visual_order(&runs);
+
+        Self {
+            text: text.to_string(),
+            base_direction,
+            runs,
+            visual_order,
+        }
+    }
+
+    /// Get the text reordered for visual display
+    pub fn visual_text(&self) -> String {
+        let mut result = String::with_capacity(self.text.len());
+
+        for &run_idx in &self.visual_order {
+            let run = &self.runs[run_idx];
+            if run.direction.is_rtl() {
+                // Reverse the characters for RTL runs
+                result.extend(run.text.chars().rev());
+            } else {
+                result.push_str(&run.text);
+            }
+        }
+
+        result
+    }
+
+    /// Convert a logical (storage) position to visual (display) position
+    pub fn logical_to_visual(&self, logical_pos: usize) -> usize {
+        let mut visual_pos = 0;
+
+        for &run_idx in &self.visual_order {
+            let run = &self.runs[run_idx];
+
+            if run.range.contains(&logical_pos) {
+                // Found the run containing our position
+                let offset_in_run = logical_pos - run.range.start;
+                if run.direction.is_rtl() {
+                    // In RTL run, position is from the end
+                    visual_pos += run.char_count() - 1 - offset_in_run;
+                } else {
+                    visual_pos += offset_in_run;
+                }
+                return visual_pos;
+            }
+
+            visual_pos += run.char_count();
+        }
+
+        visual_pos
+    }
+
+    /// Convert a visual (display) position to logical (storage) position
+    pub fn visual_to_logical(&self, visual_pos: usize) -> usize {
+        let mut pos = 0;
+
+        for &run_idx in &self.visual_order {
+            let run = &self.runs[run_idx];
+            let run_len = run.char_count();
+
+            if pos + run_len > visual_pos {
+                // Found the run containing our position
+                let offset_in_run = visual_pos - pos;
+                if run.direction.is_rtl() {
+                    // In RTL run, position is from the end
+                    return run.range.start + (run_len - 1 - offset_in_run);
+                } else {
+                    return run.range.start + offset_in_run;
+                }
+            }
+
+            pos += run_len;
+        }
+
+        self.text.chars().count()
+    }
+
+    /// Get cursor movement direction based on arrow key and current position
+    pub fn cursor_move(&self, logical_pos: usize, forward: bool) -> Option<usize> {
+        let text_len = self.text.chars().count();
+        if text_len == 0 {
+            return None;
+        }
+
+        // Find which run we're in
+        let run_idx = self
+            .runs
+            .iter()
+            .position(|r| r.range.contains(&logical_pos) || r.range.end == logical_pos);
+
+        let current_run = run_idx.map(|i| &self.runs[i]);
+
+        // Determine actual movement direction based on run direction
+        let move_right = match current_run {
+            Some(run) if run.direction.is_rtl() => !forward,
+            _ => forward,
+        };
+
+        if move_right {
+            if logical_pos < text_len {
+                Some(logical_pos + 1)
+            } else {
+                None
+            }
+        } else if logical_pos > 0 {
+            Some(logical_pos - 1)
+        } else {
+            None
+        }
+    }
+
+    /// Check if the text contains any RTL characters
+    pub fn has_rtl(&self) -> bool {
+        self.runs.iter().any(|r| r.direction.is_rtl())
+    }
+
+    /// Check if the text is pure LTR
+    pub fn is_pure_ltr(&self) -> bool {
+        !self.has_rtl()
+    }
+
+    /// Check if the text is pure RTL
+    pub fn is_pure_rtl(&self) -> bool {
+        self.runs.iter().all(|r| r.direction.is_rtl())
+    }
+}
+
+/// Detect the base direction of text
+pub fn detect_direction(text: &str) -> ResolvedDirection {
+    // UAX #9: The first strong character determines paragraph direction
+    for c in text.chars() {
+        let class = BidiClass::of(c);
+        if class == BidiClass::L {
+            return ResolvedDirection::Ltr;
+        }
+        if class.is_strong_rtl() {
+            return ResolvedDirection::Rtl;
+        }
+    }
+    // Default to LTR if no strong characters
+    ResolvedDirection::Ltr
+}
+
+/// Check if a character is RTL
+pub fn is_rtl_char(c: char) -> bool {
+    BidiClass::of(c).is_strong_rtl()
+}
+
+/// Check if text contains RTL characters
+pub fn contains_rtl(text: &str) -> bool {
+    text.chars().any(is_rtl_char)
+}
+
+/// Compute BiDi runs for text
+fn compute_runs(text: &str, base_direction: ResolvedDirection) -> Vec<BidiRun> {
+    if text.is_empty() {
+        return vec![];
+    }
+
+    let base_level = if base_direction.is_rtl() { 1 } else { 0 };
+    let mut runs = Vec::new();
+    let mut current_start = 0;
+    let mut current_text = String::new();
+    let mut current_level = base_level;
+
+    for (idx, c) in text.char_indices() {
+        let class = BidiClass::of(c);
+        let char_level = determine_char_level(class, base_level);
+
+        if char_level != current_level && !current_text.is_empty() {
+            // End current run
+            runs.push(BidiRun::new(
+                std::mem::take(&mut current_text),
+                current_start..idx,
+                current_level,
+            ));
+            current_start = idx;
+            current_level = char_level;
+        }
+
+        current_text.push(c);
+    }
+
+    // Don't forget the last run
+    if !current_text.is_empty() {
+        runs.push(BidiRun::new(
+            current_text,
+            current_start..text.len(),
+            current_level,
+        ));
+    }
+
+    runs
+}
+
+/// Determine the embedding level for a character
+fn determine_char_level(class: BidiClass, base_level: u8) -> u8 {
+    match class {
+        BidiClass::L => {
+            // L characters are at base level if base is LTR, or base+1 if RTL
+            if base_level.is_multiple_of(2) {
+                base_level
+            } else {
+                base_level + 1
+            }
+        }
+        BidiClass::R | BidiClass::AL => {
+            // R/AL characters are at base+1 if base is LTR, or base if RTL
+            if base_level.is_multiple_of(2) {
+                base_level + 1
+            } else {
+                base_level
+            }
+        }
+        BidiClass::EN | BidiClass::AN => {
+            // Numbers follow the base direction typically
+            base_level
+        }
+        _ => {
+            // Neutrals inherit from context (simplified: use base)
+            base_level
+        }
+    }
+}
+
+/// Compute visual ordering of runs
+fn compute_visual_order(runs: &[BidiRun]) -> Vec<usize> {
+    if runs.is_empty() {
+        return vec![];
+    }
+
+    // Find the maximum level
+    let max_level = runs.iter().map(|r| r.level).max().unwrap_or(0);
+
+    // Create initial order
+    let mut order: Vec<usize> = (0..runs.len()).collect();
+
+    // Reverse runs at each level from max down to 0
+    for level in (0..=max_level).rev() {
+        let mut i = 0;
+        while i < order.len() {
+            // Find a sequence of runs at this level or higher
+            if runs[order[i]].level >= level {
+                let start = i;
+                while i < order.len() && runs[order[i]].level >= level {
+                    i += 1;
+                }
+                // Reverse this sequence
+                order[start..i].reverse();
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    order
+}
+
+/// Configuration for BiDi text handling
+#[derive(Clone, Debug)]
+pub struct BidiConfig {
+    /// Default text direction
+    pub default_direction: TextDirection,
+    /// Whether to support directional override characters
+    pub enable_overrides: bool,
+    /// Whether to mirror characters in RTL context
+    pub enable_mirroring: bool,
+}
+
+impl Default for BidiConfig {
+    fn default() -> Self {
+        Self {
+            default_direction: TextDirection::Auto,
+            enable_overrides: true,
+            enable_mirroring: true,
+        }
+    }
+}
+
+/// Get the mirrored version of a character for RTL display
+pub fn mirror_char(c: char) -> char {
+    match c {
+        '(' => ')',
+        ')' => '(',
+        '[' => ']',
+        ']' => '[',
+        '{' => '}',
+        '}' => '{',
+        '<' => '>',
+        '>' => '<',
+        '«' => '»',
+        '»' => '«',
+        '‹' => '›',
+        '›' => '‹',
+        '⟨' => '⟩',
+        '⟩' => '⟨',
+        '⟪' => '⟫',
+        '⟫' => '⟪',
+        '⁅' => '⁆',
+        '⁆' => '⁅',
+        _ => c,
+    }
+}
+
+/// Reverse a string while preserving grapheme clusters
+pub fn reverse_graphemes(text: &str) -> String {
+    // Simple character-based reversal
+    // For proper grapheme handling, use unicode-segmentation crate
+    text.chars().rev().collect()
+}
+
+/// Layout helper for RTL text in a fixed-width area
+#[derive(Clone, Debug)]
+pub struct RtlLayout {
+    /// The available width
+    pub width: usize,
+    /// Text alignment
+    pub align: TextAlign,
+    /// Base direction
+    pub direction: ResolvedDirection,
+}
+
+/// Text alignment
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TextAlign {
+    /// Align to start (left for LTR, right for RTL)
+    #[default]
+    Start,
+    /// Align to end (right for LTR, left for RTL)
+    End,
+    /// Align to left
+    Left,
+    /// Align to right
+    Right,
+    /// Center alignment
+    Center,
+}
+
+impl RtlLayout {
+    /// Create a new RTL layout helper
+    pub fn new(width: usize, direction: ResolvedDirection) -> Self {
+        Self {
+            width,
+            align: TextAlign::Start,
+            direction,
+        }
+    }
+
+    /// Set text alignment
+    pub fn align(mut self, align: TextAlign) -> Self {
+        self.align = align;
+        self
+    }
+
+    /// Calculate the X position for text of given width
+    pub fn position(&self, text_width: usize) -> usize {
+        if text_width >= self.width {
+            return 0;
+        }
+
+        let padding = self.width - text_width;
+
+        match self.align {
+            TextAlign::Start => {
+                if self.direction.is_rtl() {
+                    padding
+                } else {
+                    0
+                }
+            }
+            TextAlign::End => {
+                if self.direction.is_rtl() {
+                    0
+                } else {
+                    padding
+                }
+            }
+            TextAlign::Left => 0,
+            TextAlign::Right => padding,
+            TextAlign::Center => padding / 2,
+        }
+    }
+
+    /// Pad text to fill width according to alignment
+    pub fn pad(&self, text: &str, text_width: usize) -> String {
+        if text_width >= self.width {
+            return text.to_string();
+        }
+
+        let padding = self.width - text_width;
+        let pos = self.position(text_width);
+        let left_pad = pos;
+        let right_pad = padding - left_pad;
+
+        format!("{}{}{}", " ".repeat(left_pad), text, " ".repeat(right_pad))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =============================================================================
+    // TextDirection Tests
+    // =============================================================================
+
+    #[test]
+    fn test_text_direction_default() {
+        assert_eq!(TextDirection::default(), TextDirection::Ltr);
+    }
+
+    #[test]
+    fn test_text_direction_is_methods() {
+        assert!(TextDirection::Ltr.is_ltr());
+        assert!(!TextDirection::Ltr.is_rtl());
+        assert!(!TextDirection::Ltr.is_auto());
+
+        assert!(!TextDirection::Rtl.is_ltr());
+        assert!(TextDirection::Rtl.is_rtl());
+        assert!(!TextDirection::Rtl.is_auto());
+
+        assert!(!TextDirection::Auto.is_ltr());
+        assert!(!TextDirection::Auto.is_rtl());
+        assert!(TextDirection::Auto.is_auto());
+    }
+
+    #[test]
+    fn test_text_direction_resolve() {
+        // LTR always resolves to LTR
+        assert_eq!(TextDirection::Ltr.resolve("مرحبا"), ResolvedDirection::Ltr);
+
+        // RTL always resolves to RTL
+        assert_eq!(TextDirection::Rtl.resolve("Hello"), ResolvedDirection::Rtl);
+
+        // Auto detects from content
+        assert_eq!(TextDirection::Auto.resolve("Hello"), ResolvedDirection::Ltr);
+        assert_eq!(TextDirection::Auto.resolve("مرحبا"), ResolvedDirection::Rtl);
+        assert_eq!(TextDirection::Auto.resolve("שלום"), ResolvedDirection::Rtl);
+    }
+
+    // =============================================================================
+    // ResolvedDirection Tests
+    // =============================================================================
+
+    #[test]
+    fn test_resolved_direction_opposite() {
+        assert_eq!(ResolvedDirection::Ltr.opposite(), ResolvedDirection::Rtl);
+        assert_eq!(ResolvedDirection::Rtl.opposite(), ResolvedDirection::Ltr);
+    }
+
+    // =============================================================================
+    // BidiClass Tests
+    // =============================================================================
+
+    #[test]
+    fn test_bidi_class_latin() {
+        assert_eq!(BidiClass::of('A'), BidiClass::L);
+        assert_eq!(BidiClass::of('z'), BidiClass::L);
+    }
+
+    #[test]
+    fn test_bidi_class_arabic() {
+        assert_eq!(BidiClass::of('م'), BidiClass::AL);
+        assert_eq!(BidiClass::of('ر'), BidiClass::AL);
+        assert_eq!(BidiClass::of('ح'), BidiClass::AL);
+    }
+
+    #[test]
+    fn test_bidi_class_hebrew() {
+        assert_eq!(BidiClass::of('ש'), BidiClass::R);
+        assert_eq!(BidiClass::of('ל'), BidiClass::R);
+        assert_eq!(BidiClass::of('ו'), BidiClass::R);
+    }
+
+    #[test]
+    fn test_bidi_class_numbers() {
+        assert_eq!(BidiClass::of('0'), BidiClass::EN);
+        assert_eq!(BidiClass::of('9'), BidiClass::EN);
+        // Arabic-Indic digits
+        assert_eq!(BidiClass::of('٠'), BidiClass::AN);
+        assert_eq!(BidiClass::of('٩'), BidiClass::AN);
+    }
+
+    #[test]
+    fn test_bidi_class_whitespace() {
+        assert_eq!(BidiClass::of(' '), BidiClass::WS);
+        assert_eq!(BidiClass::of('\n'), BidiClass::B);
+        assert_eq!(BidiClass::of('\t'), BidiClass::S);
+    }
+
+    #[test]
+    fn test_bidi_class_strong_checks() {
+        assert!(BidiClass::L.is_strong());
+        assert!(BidiClass::R.is_strong());
+        assert!(BidiClass::AL.is_strong());
+        assert!(!BidiClass::EN.is_strong());
+        assert!(!BidiClass::WS.is_strong());
+    }
+
+    #[test]
+    fn test_bidi_class_weak_checks() {
+        assert!(BidiClass::EN.is_weak());
+        assert!(BidiClass::AN.is_weak());
+        assert!(!BidiClass::L.is_weak());
+        assert!(!BidiClass::WS.is_weak());
+    }
+
+    #[test]
+    fn test_bidi_class_neutral_checks() {
+        assert!(BidiClass::WS.is_neutral());
+        assert!(BidiClass::ON.is_neutral());
+        assert!(!BidiClass::L.is_neutral());
+        assert!(!BidiClass::EN.is_neutral());
+    }
+
+    // =============================================================================
+    // Direction Detection Tests
+    // =============================================================================
+
+    #[test]
+    fn test_detect_direction_ltr() {
+        assert_eq!(detect_direction("Hello World"), ResolvedDirection::Ltr);
+        assert_eq!(detect_direction("123 abc"), ResolvedDirection::Ltr);
+    }
+
+    #[test]
+    fn test_detect_direction_rtl() {
+        assert_eq!(detect_direction("مرحبا"), ResolvedDirection::Rtl);
+        assert_eq!(detect_direction("שלום עולם"), ResolvedDirection::Rtl);
+    }
+
+    #[test]
+    fn test_detect_direction_mixed() {
+        // First strong character wins
+        assert_eq!(detect_direction("Hello مرحبا"), ResolvedDirection::Ltr);
+        assert_eq!(detect_direction("مرحبا Hello"), ResolvedDirection::Rtl);
+    }
+
+    #[test]
+    fn test_detect_direction_neutral_only() {
+        // Numbers and spaces default to LTR
+        assert_eq!(detect_direction("123"), ResolvedDirection::Ltr);
+        assert_eq!(detect_direction("   "), ResolvedDirection::Ltr);
+        assert_eq!(detect_direction(""), ResolvedDirection::Ltr);
+    }
+
+    #[test]
+    fn test_contains_rtl() {
+        assert!(!contains_rtl("Hello World"));
+        assert!(contains_rtl("Hello مرحبا"));
+        assert!(contains_rtl("שלום"));
+        assert!(!contains_rtl("123 456"));
+    }
+
+    // =============================================================================
+    // BidiInfo Tests
+    // =============================================================================
+
+    #[test]
+    fn test_bidi_info_pure_ltr() {
+        let info = BidiInfo::new("Hello World", TextDirection::Auto);
+        assert_eq!(info.base_direction, ResolvedDirection::Ltr);
+        assert!(info.is_pure_ltr());
+        assert!(!info.has_rtl());
+        assert_eq!(info.visual_text(), "Hello World");
+    }
+
+    #[test]
+    fn test_bidi_info_pure_rtl() {
+        let info = BidiInfo::new("שלום", TextDirection::Auto);
+        assert_eq!(info.base_direction, ResolvedDirection::Rtl);
+        assert!(info.is_pure_rtl());
+        assert!(info.has_rtl());
+        // RTL text should be reversed for display
+        assert_eq!(info.visual_text(), "םולש");
+    }
+
+    #[test]
+    fn test_bidi_info_mixed() {
+        let info = BidiInfo::new("Hello שלום World", TextDirection::Auto);
+        assert_eq!(info.base_direction, ResolvedDirection::Ltr);
+        assert!(info.has_rtl());
+        assert!(!info.is_pure_ltr());
+        assert!(!info.is_pure_rtl());
+    }
+
+    #[test]
+    fn test_bidi_info_empty() {
+        let info = BidiInfo::new("", TextDirection::Auto);
+        assert!(info.runs.is_empty());
+        assert_eq!(info.visual_text(), "");
+    }
+
+    #[test]
+    fn test_bidi_info_forced_direction() {
+        // Force LTR on Arabic text
+        let info = BidiInfo::new("مرحبا", TextDirection::Ltr);
+        assert_eq!(info.base_direction, ResolvedDirection::Ltr);
+
+        // Force RTL on English text
+        let info = BidiInfo::new("Hello", TextDirection::Rtl);
+        assert_eq!(info.base_direction, ResolvedDirection::Rtl);
+    }
+
+    // =============================================================================
+    // Cursor Movement Tests
+    // =============================================================================
+
+    #[test]
+    fn test_cursor_move_ltr() {
+        let info = BidiInfo::new("Hello", TextDirection::Auto);
+
+        // Forward movement
+        assert_eq!(info.cursor_move(0, true), Some(1));
+        assert_eq!(info.cursor_move(4, true), Some(5));
+        assert_eq!(info.cursor_move(5, true), None);
+
+        // Backward movement
+        assert_eq!(info.cursor_move(5, false), Some(4));
+        assert_eq!(info.cursor_move(1, false), Some(0));
+        assert_eq!(info.cursor_move(0, false), None);
+    }
+
+    #[test]
+    fn test_cursor_move_empty() {
+        let info = BidiInfo::new("", TextDirection::Auto);
+        assert_eq!(info.cursor_move(0, true), None);
+        assert_eq!(info.cursor_move(0, false), None);
+    }
+
+    // =============================================================================
+    // Position Conversion Tests
+    // =============================================================================
+
+    #[test]
+    fn test_logical_to_visual_ltr() {
+        let info = BidiInfo::new("Hello", TextDirection::Auto);
+        assert_eq!(info.logical_to_visual(0), 0);
+        assert_eq!(info.logical_to_visual(2), 2);
+        assert_eq!(info.logical_to_visual(4), 4);
+    }
+
+    #[test]
+    fn test_visual_to_logical_ltr() {
+        let info = BidiInfo::new("Hello", TextDirection::Auto);
+        assert_eq!(info.visual_to_logical(0), 0);
+        assert_eq!(info.visual_to_logical(2), 2);
+        assert_eq!(info.visual_to_logical(4), 4);
+    }
+
+    // =============================================================================
+    // BidiRun Tests
+    // =============================================================================
+
+    #[test]
+    fn test_bidi_run_new() {
+        let run = BidiRun::new("Hello".to_string(), 0..5, 0);
+        assert_eq!(run.direction, ResolvedDirection::Ltr);
+        assert_eq!(run.char_count(), 5);
+
+        let run = BidiRun::new("שלום".to_string(), 0..8, 1);
+        assert_eq!(run.direction, ResolvedDirection::Rtl);
+        assert_eq!(run.char_count(), 4);
+    }
+
+    // =============================================================================
+    // Character Mirroring Tests
+    // =============================================================================
+
+    #[test]
+    fn test_mirror_char() {
+        assert_eq!(mirror_char('('), ')');
+        assert_eq!(mirror_char(')'), '(');
+        assert_eq!(mirror_char('['), ']');
+        assert_eq!(mirror_char(']'), '[');
+        assert_eq!(mirror_char('{'), '}');
+        assert_eq!(mirror_char('}'), '{');
+        assert_eq!(mirror_char('<'), '>');
+        assert_eq!(mirror_char('>'), '<');
+        assert_eq!(mirror_char('«'), '»');
+        assert_eq!(mirror_char('»'), '«');
+        // Non-mirrorable characters return themselves
+        assert_eq!(mirror_char('A'), 'A');
+        assert_eq!(mirror_char('م'), 'م');
+    }
+
+    #[test]
+    fn test_reverse_graphemes() {
+        assert_eq!(reverse_graphemes("Hello"), "olleH");
+        assert_eq!(reverse_graphemes("שלום"), "םולש");
+        assert_eq!(reverse_graphemes(""), "");
+    }
+
+    // =============================================================================
+    // RtlLayout Tests
+    // =============================================================================
+
+    #[test]
+    fn test_rtl_layout_ltr_start() {
+        let layout = RtlLayout::new(20, ResolvedDirection::Ltr).align(TextAlign::Start);
+        assert_eq!(layout.position(10), 0);
+    }
+
+    #[test]
+    fn test_rtl_layout_ltr_end() {
+        let layout = RtlLayout::new(20, ResolvedDirection::Ltr).align(TextAlign::End);
+        assert_eq!(layout.position(10), 10);
+    }
+
+    #[test]
+    fn test_rtl_layout_rtl_start() {
+        let layout = RtlLayout::new(20, ResolvedDirection::Rtl).align(TextAlign::Start);
+        assert_eq!(layout.position(10), 10);
+    }
+
+    #[test]
+    fn test_rtl_layout_rtl_end() {
+        let layout = RtlLayout::new(20, ResolvedDirection::Rtl).align(TextAlign::End);
+        assert_eq!(layout.position(10), 0);
+    }
+
+    #[test]
+    fn test_rtl_layout_center() {
+        let layout = RtlLayout::new(20, ResolvedDirection::Ltr).align(TextAlign::Center);
+        assert_eq!(layout.position(10), 5);
+    }
+
+    #[test]
+    fn test_rtl_layout_left_right() {
+        let layout_left = RtlLayout::new(20, ResolvedDirection::Rtl).align(TextAlign::Left);
+        assert_eq!(layout_left.position(10), 0);
+
+        let layout_right = RtlLayout::new(20, ResolvedDirection::Rtl).align(TextAlign::Right);
+        assert_eq!(layout_right.position(10), 10);
+    }
+
+    #[test]
+    fn test_rtl_layout_pad() {
+        let layout = RtlLayout::new(10, ResolvedDirection::Ltr).align(TextAlign::Center);
+        let padded = layout.pad("Hi", 2);
+        assert_eq!(padded, "    Hi    ");
+        assert_eq!(padded.len(), 10);
+    }
+
+    #[test]
+    fn test_rtl_layout_pad_overflow() {
+        let layout = RtlLayout::new(5, ResolvedDirection::Ltr);
+        let padded = layout.pad("Hello World", 11);
+        assert_eq!(padded, "Hello World");
+    }
+
+    // =============================================================================
+    // BidiConfig Tests
+    // =============================================================================
+
+    #[test]
+    fn test_bidi_config_default() {
+        let config = BidiConfig::default();
+        assert_eq!(config.default_direction, TextDirection::Auto);
+        assert!(config.enable_overrides);
+        assert!(config.enable_mirroring);
+    }
+
+    // =============================================================================
+    // Edge Cases
+    // =============================================================================
+
+    #[test]
+    fn test_bidi_class_explicit_marks() {
+        assert_eq!(BidiClass::of('\u{202A}'), BidiClass::LRE);
+        assert_eq!(BidiClass::of('\u{202B}'), BidiClass::RLE);
+        assert_eq!(BidiClass::of('\u{202C}'), BidiClass::PDF);
+        assert_eq!(BidiClass::of('\u{202D}'), BidiClass::LRO);
+        assert_eq!(BidiClass::of('\u{202E}'), BidiClass::RLO);
+        assert_eq!(BidiClass::of('\u{2066}'), BidiClass::LRI);
+        assert_eq!(BidiClass::of('\u{2067}'), BidiClass::RLI);
+        assert_eq!(BidiClass::of('\u{2068}'), BidiClass::FSI);
+        assert_eq!(BidiClass::of('\u{2069}'), BidiClass::PDI);
+    }
+
+    #[test]
+    fn test_text_with_numbers() {
+        // Numbers embedded in RTL text
+        let info = BidiInfo::new("מחיר: 100", TextDirection::Auto);
+        assert_eq!(info.base_direction, ResolvedDirection::Rtl);
+        assert!(info.runs.len() >= 1);
+    }
+
+    #[test]
+    fn test_nko_script_rtl() {
+        // NKo script (U+07C0-07FF) is RTL
+        let c = '\u{07C1}'; // NKo digit one
+        assert_eq!(BidiClass::of(c), BidiClass::R);
+    }
+
+    #[test]
+    fn test_presentation_forms() {
+        // Arabic Presentation Forms
+        let c = '\u{FB50}'; // Arabic letter alef wasla isolated form
+        assert_eq!(BidiClass::of(c), BidiClass::AL);
+    }
+}

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -1,8 +1,13 @@
 //! Unicode and text handling
 
+pub mod bidi;
 mod width;
 mod wrap;
 
+pub use bidi::{
+    contains_rtl, detect_direction, is_rtl_char, mirror_char, reverse_graphemes, BidiClass,
+    BidiConfig, BidiInfo, BidiRun, ResolvedDirection, RtlLayout, TextAlign, TextDirection,
+};
 pub use width::{char_width, CharWidthTable};
 pub use wrap::{
     truncate, truncate_middle, wrap_chars, wrap_text, wrap_words, Overflow, TextWrapper, WrapMode,


### PR DESCRIPTION
## Summary

- **IME composition input (#7)**: Full support for CJK input method editors
- **RTL/BiDi text support (#8)**: Bidirectional text handling following UAX #9
- **Sixel/iTerm2 image protocol (#9)**: Additional image protocols alongside Kitty

## Changes

### IME Composition Input
- `ImeState` for managing composition state and candidates
- `CompositionEvent` for tracking composition lifecycle
- Preedit string rendering with styling support

### RTL/BiDi Text Support
- `TextDirection` enum (Ltr, Rtl, Auto) for direction control
- `BidiClass` for Unicode character classification (UAX #9)
- `BidiInfo` for text analysis with visual/logical position conversion
- `RtlLayout` helper for RTL-aware text positioning

### Sixel/iTerm2 Image Protocol
- `ImageProtocol` enum with auto-detection
- `ImageEncoder` for multi-protocol encoding
- `SixelEncoder` with palette quantization and RLE
- `Iterm2Image` and `KittyImage` helpers

## Test plan

- [x] All 16 IME tests pass
- [x] All 42 BiDi tests pass
- [x] All 25 image protocol tests pass
- [x] Clippy passes with no warnings
- [x] Pre-push hooks pass (3615 tests)

Closes #7
Closes #8
Closes #9