### PR TITLE
fix(layout): use safe i32 to u16 conversion in position offsets

### DIFF
--- a/src/layout/position.rs
+++ b/src/layout/position.rs
@@ -5,6 +5,12 @@
 use super::node::{ComputedLayout, LayoutNode};
 use crate::style::Position;
 
+/// Safely convert i32 to u16, clamping to valid range [0, u16::MAX]
+#[inline]
+fn clamp_to_u16(value: i32) -> u16 {
+    value.clamp(0, u16::MAX as i32) as u16
+}
+
 /// Apply position offsets to a node's computed layout
 ///
 /// # Arguments
@@ -41,16 +47,16 @@ fn apply_relative_offset(node: &mut LayoutNode) {
 
     // Vertical: top takes precedence over bottom
     if let Some(top) = inset.top {
-        node.computed.y = (node.computed.y as i32 + top as i32).max(0) as u16;
+        node.computed.y = clamp_to_u16(node.computed.y as i32 + top as i32);
     } else if let Some(bottom) = inset.bottom {
-        node.computed.y = (node.computed.y as i32 - bottom as i32).max(0) as u16;
+        node.computed.y = clamp_to_u16(node.computed.y as i32 - bottom as i32);
     }
 
     // Horizontal: left takes precedence over right
     if let Some(left) = inset.left {
-        node.computed.x = (node.computed.x as i32 + left as i32).max(0) as u16;
+        node.computed.x = clamp_to_u16(node.computed.x as i32 + left as i32);
     } else if let Some(right) = inset.right {
-        node.computed.x = (node.computed.x as i32 - right as i32).max(0) as u16;
+        node.computed.x = clamp_to_u16(node.computed.x as i32 - right as i32);
     }
 }
 
@@ -62,22 +68,22 @@ fn apply_absolute_offset(node: &mut LayoutNode, parent_layout: ComputedLayout) {
 
     // Vertical positioning
     if let Some(top) = inset.top {
-        node.computed.y = (top as i32).max(0) as u16;
+        node.computed.y = clamp_to_u16(top as i32);
     } else if let Some(bottom) = inset.bottom {
         node.computed.y = parent_layout
             .height
             .saturating_sub(node.computed.height)
-            .saturating_sub((bottom as i32).max(0) as u16);
+            .saturating_sub(clamp_to_u16(bottom as i32));
     }
 
     // Horizontal positioning
     if let Some(left) = inset.left {
-        node.computed.x = (left as i32).max(0) as u16;
+        node.computed.x = clamp_to_u16(left as i32);
     } else if let Some(right) = inset.right {
         node.computed.x = parent_layout
             .width
             .saturating_sub(node.computed.width)
-            .saturating_sub((right as i32).max(0) as u16);
+            .saturating_sub(clamp_to_u16(right as i32));
     }
 }
 
@@ -90,20 +96,20 @@ fn apply_fixed_offset(node: &mut LayoutNode, viewport: (u16, u16)) {
 
     // Vertical positioning
     if let Some(top) = inset.top {
-        node.computed.y = (top as i32).max(0) as u16;
+        node.computed.y = clamp_to_u16(top as i32);
     } else if let Some(bottom) = inset.bottom {
         node.computed.y = vh
             .saturating_sub(node.computed.height)
-            .saturating_sub((bottom as i32).max(0) as u16);
+            .saturating_sub(clamp_to_u16(bottom as i32));
     }
 
     // Horizontal positioning
     if let Some(left) = inset.left {
-        node.computed.x = (left as i32).max(0) as u16;
+        node.computed.x = clamp_to_u16(left as i32);
     } else if let Some(right) = inset.right {
         node.computed.x = vw
             .saturating_sub(node.computed.width)
-            .saturating_sub((right as i32).max(0) as u16);
+            .saturating_sub(clamp_to_u16(right as i32));
     }
 }
 
@@ -291,5 +297,92 @@ mod tests {
         apply_position_offsets(&mut node, parent, (200, 200));
 
         assert_eq!(node.computed.x, 15); // Uses left, not right
+    }
+
+    #[test]
+    fn test_clamp_to_u16() {
+        // Test the helper function directly
+        assert_eq!(clamp_to_u16(0), 0);
+        assert_eq!(clamp_to_u16(100), 100);
+        assert_eq!(clamp_to_u16(-100), 0);
+        assert_eq!(clamp_to_u16(u16::MAX as i32), u16::MAX);
+        assert_eq!(clamp_to_u16(u16::MAX as i32 + 1), u16::MAX);
+        assert_eq!(clamp_to_u16(i32::MAX), u16::MAX);
+        assert_eq!(clamp_to_u16(i32::MIN), 0);
+    }
+
+    #[test]
+    fn test_relative_overflow_clamps_to_u16_max() {
+        // Test that large offsets clamp to u16::MAX instead of wrapping
+        // This is the fix for issue #150
+        let mut node = make_node_at(60000, 60000, 50, 30, Position::Relative);
+        node.spacing.inset = Inset {
+            top: Some(10000),  // 60000 + 10000 = 70000 > u16::MAX
+            left: Some(10000), // 60000 + 10000 = 70000 > u16::MAX
+            right: None,
+            bottom: None,
+        };
+
+        let parent = ComputedLayout::new(0, 0, 100, 100);
+        apply_position_offsets(&mut node, parent, (200, 200));
+
+        // Should clamp to u16::MAX (65535), not wrap to 4464
+        assert_eq!(node.computed.x, u16::MAX);
+        assert_eq!(node.computed.y, u16::MAX);
+    }
+
+    #[test]
+    fn test_absolute_large_inset_clamps() {
+        // Test that very large inset values clamp properly
+        let mut node = make_node_at(10, 20, 50, 30, Position::Absolute);
+        node.spacing.inset = Inset {
+            top: Some(i16::MAX), // Large positive value
+            left: Some(i16::MAX),
+            right: None,
+            bottom: None,
+        };
+
+        let parent = ComputedLayout::new(0, 0, 100, 100);
+        apply_position_offsets(&mut node, parent, (200, 200));
+
+        // i16::MAX (32767) fits in u16, should work correctly
+        assert_eq!(node.computed.x, 32767);
+        assert_eq!(node.computed.y, 32767);
+    }
+
+    #[test]
+    fn test_fixed_large_inset_clamps() {
+        let mut node = make_node_at(10, 20, 50, 30, Position::Fixed);
+        node.spacing.inset = Inset {
+            top: Some(i16::MAX),
+            left: Some(i16::MAX),
+            right: None,
+            bottom: None,
+        };
+
+        let parent = ComputedLayout::new(0, 0, 100, 100);
+        apply_position_offsets(&mut node, parent, (200, 200));
+
+        assert_eq!(node.computed.x, 32767);
+        assert_eq!(node.computed.y, 32767);
+    }
+
+    #[test]
+    fn test_relative_negative_inset_clamps_to_zero() {
+        // Large negative offset should clamp to 0
+        let mut node = make_node_at(100, 100, 50, 30, Position::Relative);
+        node.spacing.inset = Inset {
+            top: None,
+            left: None,
+            right: Some(i16::MAX), // Large subtraction
+            bottom: Some(i16::MAX),
+        };
+
+        let parent = ComputedLayout::new(0, 0, 100, 100);
+        apply_position_offsets(&mut node, parent, (200, 200));
+
+        // 100 - 32767 = negative, should clamp to 0
+        assert_eq!(node.computed.x, 0);
+        assert_eq!(node.computed.y, 0);
     }
 }


### PR DESCRIPTION
## Summary
Prevent silent integer overflow when casting i32 to u16 in position offset calculations.

## Problem
The previous code used `.max(0) as u16` which only prevented negative values but allowed overflow:
```rust
// If node.computed.y = 60000 and top = 10000:
// 60000 + 10000 = 70000 > u16::MAX (65535)
// Result: 70000 % 65536 = 4464 (wrong!)
(node.computed.y as i32 + top as i32).max(0) as u16
```

## Solution
Added `clamp_to_u16()` helper that clamps values to `[0, u16::MAX]` range:
```rust
fn clamp_to_u16(value: i32) -> u16 {
    value.clamp(0, u16::MAX as i32) as u16
}
```

## Changes
- Added `clamp_to_u16()` helper function
- Updated `apply_relative_offset()` - 4 casts fixed
- Updated `apply_absolute_offset()` - 4 casts fixed  
- Updated `apply_fixed_offset()` - 4 casts fixed

## Test plan
- [x] Added `test_clamp_to_u16` - tests helper function edge cases
- [x] Added `test_relative_overflow_clamps_to_u16_max` - verifies clamping instead of wrapping
- [x] Added `test_absolute_large_inset_clamps`
- [x] Added `test_fixed_large_inset_clamps`
- [x] Added `test_relative_negative_inset_clamps_to_zero`
- [x] All 3765 library tests pass

Closes #150