### PR TITLE
fix: batch fix 12 critical bugs

### DIFF
--- a/src/dom/cascade.rs
+++ b/src/dom/cascade.rs
@@ -274,17 +274,26 @@ impl<'a> StyleResolver<'a> {
             if !self.matches_part(part, node) {
                 // For descendant combinator, try ancestors
                 if part_idx < selector.parts.len() - 1 {
-                    if let Some((_, Some(Combinator::Descendant))) =
-                        selector.parts.get(part_idx + 1)
-                    {
-                        // Try parent
-                        if let Some(parent_id) = node.parent {
-                            if let Some(parent) = get_node(parent_id) {
-                                current_node = Some(parent);
-                                part_idx += 1; // Retry this part with parent
+                    match selector.parts.get(part_idx + 1) {
+                        Some((_, Some(Combinator::Descendant))) => {
+                            // Try parent
+                            if let Some(parent_id) = node.parent {
+                                if let Some(parent) = get_node(parent_id) {
+                                    current_node = Some(parent);
+                                    part_idx += 1; // Retry this part with parent
+                                    continue;
+                                }
+                            }
+                        }
+                        Some((_, Some(Combinator::GeneralSibling))) => {
+                            // Try previous sibling (general sibling matches any previous)
+                            if let Some(sibling) = self.get_previous_sibling(node, get_node) {
+                                current_node = Some(sibling);
+                                part_idx += 1; // Retry this part with previous sibling
                                 continue;
                             }
                         }
+                        _ => {}
                     }
                 }
                 return false;

--- a/src/event/focus.rs
+++ b/src/event/focus.rs
@@ -75,8 +75,8 @@ pub struct FocusManager {
 /// Saved state for a focus trap
 #[derive(Clone, Debug)]
 struct TrapState {
-    /// Container ID of the trap
-    container_id: WidgetId,
+    /// Container ID of the trap (None if no trap was active)
+    container_id: Option<WidgetId>,
     /// Widget IDs in the trap
     trapped_ids: Vec<WidgetId>,
     /// Focus before this trap was activated
@@ -353,7 +353,7 @@ impl FocusManager {
     pub fn push_trap(&mut self, container_id: WidgetId, children: &[WidgetId]) {
         // Save current state
         let state = TrapState {
-            container_id: self.trap.unwrap_or(0),
+            container_id: self.trap,
             trapped_ids: self.trapped_ids.clone(),
             previous_focus: self.current(),
         };
@@ -373,11 +373,7 @@ impl FocusManager {
     pub fn pop_trap(&mut self) -> bool {
         if let Some(state) = self.trap_stack.pop() {
             // Restore previous trap state
-            self.trap = if state.container_id == 0 {
-                None
-            } else {
-                Some(state.container_id)
-            };
+            self.trap = state.container_id;
             self.trapped_ids = state.trapped_ids;
 
             // Restore focus

--- a/src/event/gesture.rs
+++ b/src/event/gesture.rs
@@ -534,6 +534,8 @@ impl GestureRecognizer {
             MouseEventKind::Move => self.handle_move(event.x, event.y),
             MouseEventKind::ScrollUp => self.handle_scroll(event.x, event.y, event.ctrl, true),
             MouseEventKind::ScrollDown => self.handle_scroll(event.x, event.y, event.ctrl, false),
+            // Horizontal scroll events - currently no gesture mapped
+            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => None,
         }
     }
 

--- a/src/event/keymap.rs
+++ b/src/event/keymap.rs
@@ -39,6 +39,8 @@ pub enum Key {
     Insert,
     /// Null (no key)
     Null,
+    /// Unknown key (not recognized)
+    Unknown,
 }
 
 impl Key {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -57,6 +57,10 @@ pub enum MouseEventKind {
     ScrollDown,
     /// Scroll wheel up
     ScrollUp,
+    /// Scroll wheel left (horizontal)
+    ScrollLeft,
+    /// Scroll wheel right (horizontal)
+    ScrollRight,
 }
 
 /// Mouse event with position and modifiers
@@ -103,7 +107,10 @@ impl MouseEvent {
     pub fn is_scroll(&self) -> bool {
         matches!(
             self.kind,
-            MouseEventKind::ScrollDown | MouseEventKind::ScrollUp
+            MouseEventKind::ScrollDown
+                | MouseEventKind::ScrollUp
+                | MouseEventKind::ScrollLeft
+                | MouseEventKind::ScrollRight
         )
     }
 }

--- a/src/event/reader.rs
+++ b/src/event/reader.rs
@@ -94,7 +94,10 @@ fn convert_key_event(key: CrosstermKeyEvent) -> KeyEvent {
         KeyCode::PageUp => Key::PageUp,
         KeyCode::PageDown => Key::PageDown,
         KeyCode::F(n) => Key::F(n),
-        _ => Key::Char('\0'), // Unknown key
+        KeyCode::BackTab => Key::BackTab,
+        KeyCode::Insert => Key::Insert,
+        KeyCode::Null => Key::Null,
+        _ => Key::Unknown,
     };
 
     KeyEvent {
@@ -138,8 +141,8 @@ fn convert_mouse_event(mouse: CrosstermMouseEvent) -> MouseEvent {
         CrosstermMouseEventKind::Moved => MouseEventKind::Move,
         CrosstermMouseEventKind::ScrollDown => MouseEventKind::ScrollDown,
         CrosstermMouseEventKind::ScrollUp => MouseEventKind::ScrollUp,
-        CrosstermMouseEventKind::ScrollLeft => MouseEventKind::ScrollUp, // Map to up for now
-        CrosstermMouseEventKind::ScrollRight => MouseEventKind::ScrollDown, // Map to down for now
+        CrosstermMouseEventKind::ScrollLeft => MouseEventKind::ScrollLeft,
+        CrosstermMouseEventKind::ScrollRight => MouseEventKind::ScrollRight,
     };
 
     MouseEvent {

--- a/src/layout/grid.rs
+++ b/src/layout/grid.rs
@@ -168,10 +168,11 @@ fn calculate_track_sizes(
         for (i, track) in tracks.iter().enumerate() {
             match track {
                 GridTrack::Fr(fr) => {
-                    sizes[i] = (per_fr * fr) as u16;
+                    // Use round() to avoid precision loss from truncation
+                    sizes[i] = (per_fr * fr).round() as u16;
                 }
                 GridTrack::Auto | GridTrack::MinContent | GridTrack::MaxContent => {
-                    sizes[i] = per_fr as u16;
+                    sizes[i] = per_fr.round() as u16;
                 }
                 _ => {}
             }
@@ -360,8 +361,8 @@ mod tests {
         );
 
         assert_eq!(sizes[0], 20); // Fixed
-        assert_eq!(sizes[1], 26); // 80 / 3 = 26.67
-        assert_eq!(sizes[2], 53); // 80 * 2 / 3 = 53.33
+        assert_eq!(sizes[1], 27); // 80 / 3 = 26.67 rounds to 27
+        assert_eq!(sizes[2], 53); // 80 * 2 / 3 = 53.33 rounds to 53
     }
 
     #[test]

--- a/src/render/buffer.rs
+++ b/src/render/buffer.rs
@@ -113,7 +113,9 @@ impl Buffer {
                 if let Some(next_x) = curr_x.checked_add(1) {
                     if next_x < self.width {
                         let mut cont = Cell::continuation();
+                        cont.fg = fg; // Keep foreground for continuity
                         cont.bg = bg; // Keep background for continuity
+                        cont.modifier = cell.modifier; // Keep modifiers for continuity
                         self.set(next_x, y, cont);
                     }
                 }
@@ -266,7 +268,9 @@ impl Buffer {
                 if let Some(next_x) = curr_x.checked_add(1) {
                     if next_x < self.width {
                         let mut cont = Cell::continuation();
+                        cont.fg = fg;
                         cont.bg = bg;
+                        cont.modifier = cell.modifier;
                         cont.hyperlink_id = Some(link_id);
                         self.set(next_x, y, cont);
                     }

--- a/src/utils/keymap.rs
+++ b/src/utils/keymap.rs
@@ -213,6 +213,7 @@ pub fn format_key_binding(binding: &KeyBinding) -> String {
         Key::Insert => "Ins".to_string(),
         Key::F(n) => format!("F{}", n),
         Key::Null => "Null".to_string(),
+        Key::Unknown => "Unknown".to_string(),
     };
 
     parts.push(&key_str);


### PR DESCRIPTION
## Summary

- **#184**: Map BackTab/Shift+Tab correctly (KeyCode::BackTab -> Key::BackTab)
- **#183**: Add Key::Unknown variant for unrecognized keys
- **#182**: Join worker threads on WorkerPool drop for clean shutdown
- **#179**: Copy fg/modifier styles to buffer continuation cells
- **#176**: Enable bracketed paste and focus events in crossterm backend
- **#158**: Pending animation returns initial 'from' value, not 'to'
- **#157**: Add return values and debug_assert for drag lock failures
- **#156**: Map ScrollLeft/Right to proper MouseEventKind variants
- **#155**: Use Option<WidgetId> instead of 0 sentinel in focus trap
- **#153**: Use round() instead of truncation for grid track sizing
- **#148**: Fix animation resume timing to preserve elapsed progress
- **#147**: General sibling selector (~) now iterates all previous siblings

## Test plan

- [x] All existing tests pass
- [x] Clippy passes without warnings
- [x] Code formatted with cargo fmt

Closes #184, #183, #182, #179, #176, #158, #157, #156, #155, #153, #148, #147