### PR TITLE
test: add comprehensive test coverage to multiple modules

### DIFF
--- a/src/devtools/state.rs
+++ b/src/devtools/state.rs
@@ -339,4 +339,192 @@ mod tests {
         assert!(matches!(debugger.states[0].value, StateValue::Int(5)));
         assert_eq!(debugger.states[0].update_count, 1);
     }
+
+    // =========================================================================
+    // Additional coverage tests
+    // =========================================================================
+
+    #[test]
+    fn test_state_value_display_all() {
+        assert_eq!(StateValue::Float(3.14159).display(), "3.14");
+        assert_eq!(StateValue::Bool(false).display(), "false");
+        assert_eq!(StateValue::Null.display(), "null");
+
+        let list = StateValue::List(vec![
+            StateValue::Int(1),
+            StateValue::Int(2),
+            StateValue::Int(3),
+        ]);
+        assert_eq!(list.display(), "[3 items]");
+
+        let mut map = std::collections::HashMap::new();
+        map.insert("key".to_string(), StateValue::Int(1));
+        let map_value = StateValue::Map(map);
+        assert!(map_value.display().contains("1"));
+    }
+
+    #[test]
+    fn test_state_value_type_name() {
+        assert_eq!(StateValue::String("".into()).type_name(), "String");
+        assert_eq!(StateValue::Int(0).type_name(), "i64");
+        assert_eq!(StateValue::Float(0.0).type_name(), "f64");
+        assert_eq!(StateValue::Bool(true).type_name(), "bool");
+        assert_eq!(StateValue::List(vec![]).type_name(), "Vec");
+        assert_eq!(
+            StateValue::Map(std::collections::HashMap::new()).type_name(),
+            "Map"
+        );
+        assert_eq!(StateValue::Null.type_name(), "null");
+    }
+
+    #[test]
+    fn test_state_entry_updated() {
+        let mut entry = StateEntry::new("count", StateValue::Int(0));
+        assert_eq!(entry.update_count, 0);
+
+        entry.updated();
+        assert_eq!(entry.update_count, 1);
+
+        entry.updated();
+        assert_eq!(entry.update_count, 2);
+    }
+
+    #[test]
+    fn test_state_debugger_remove() {
+        let mut debugger = StateDebugger::new();
+        debugger.add(StateEntry::new("first", StateValue::Int(1)));
+        debugger.add(StateEntry::new("second", StateValue::Int(2)));
+
+        assert_eq!(debugger.states.len(), 2);
+
+        debugger.remove("first");
+        assert_eq!(debugger.states.len(), 1);
+        assert_eq!(debugger.states[0].name, "second");
+    }
+
+    #[test]
+    fn test_state_debugger_clear() {
+        let mut debugger = StateDebugger::new();
+        debugger.add(StateEntry::new("a", StateValue::Int(1)));
+        debugger.add(StateEntry::new("b", StateValue::Int(2)));
+
+        debugger.clear();
+        assert!(debugger.states.is_empty());
+        assert!(debugger.selected.is_none());
+    }
+
+    #[test]
+    fn test_state_debugger_set_filter() {
+        let mut debugger = StateDebugger::new();
+        debugger.add(StateEntry::new("counter", StateValue::Int(0)));
+        debugger.add(StateEntry::new(
+            "user_name",
+            StateValue::String("test".into()),
+        ));
+
+        debugger.set_filter("counter");
+        assert_eq!(debugger.filter, "counter");
+        assert!(debugger.selected.is_none());
+    }
+
+    #[test]
+    fn test_state_debugger_filtered() {
+        let mut debugger = StateDebugger::new();
+        debugger.add(StateEntry::new("counter", StateValue::Int(0)));
+        debugger.add(StateEntry::new(
+            "user_name",
+            StateValue::String("test".into()),
+        ));
+        debugger.add(StateEntry::new("count2", StateValue::Int(5)));
+
+        debugger.set_filter("count");
+        let filtered = debugger.filtered();
+        assert_eq!(filtered.len(), 2); // counter and count2
+    }
+
+    #[test]
+    fn test_state_debugger_filtered_computed() {
+        let mut debugger = StateDebugger::new();
+        debugger.add(StateEntry::new("regular", StateValue::Int(0)));
+        debugger.add(StateEntry::new("computed", StateValue::Int(0)).computed());
+
+        // Initially show_computed is true
+        assert_eq!(debugger.filtered().len(), 2);
+
+        // Hide computed values
+        debugger.show_computed = false;
+        assert_eq!(debugger.filtered().len(), 1);
+    }
+
+    #[test]
+    fn test_state_debugger_select_next_prev() {
+        let mut debugger = StateDebugger::new();
+        debugger.add(StateEntry::new("a", StateValue::Int(1)));
+        debugger.add(StateEntry::new("b", StateValue::Int(2)));
+        debugger.add(StateEntry::new("c", StateValue::Int(3)));
+
+        debugger.select_next();
+        assert_eq!(debugger.selected, Some(0));
+
+        debugger.select_next();
+        assert_eq!(debugger.selected, Some(1));
+
+        debugger.select_next();
+        assert_eq!(debugger.selected, Some(2));
+
+        debugger.select_next();
+        assert_eq!(debugger.selected, Some(2)); // Can't go beyond last
+
+        debugger.select_prev();
+        assert_eq!(debugger.selected, Some(1));
+
+        debugger.select_prev();
+        assert_eq!(debugger.selected, Some(0));
+
+        debugger.select_prev();
+        assert_eq!(debugger.selected, Some(0)); // Can't go below 0
+    }
+
+    #[test]
+    fn test_state_debugger_select_empty() {
+        let mut debugger = StateDebugger::new();
+        debugger.select_next();
+        debugger.select_prev();
+        // Should not panic on empty
+    }
+
+    #[test]
+    fn test_state_debugger_default() {
+        let debugger = StateDebugger::default();
+        assert!(debugger.states.is_empty());
+    }
+
+    #[test]
+    fn test_state_debugger_new() {
+        let debugger = StateDebugger::new();
+        assert!(debugger.show_computed);
+    }
+
+    #[test]
+    fn test_state_entry_clone() {
+        let entry = StateEntry::new("test", StateValue::Int(42))
+            .computed()
+            .subscribers(5);
+
+        let cloned = entry.clone();
+        assert_eq!(cloned.name, "test");
+        assert!(cloned.is_computed);
+        assert_eq!(cloned.subscribers, 5);
+    }
+
+    #[test]
+    fn test_state_value_clone() {
+        let value = StateValue::String("hello".into());
+        let cloned = value.clone();
+        if let StateValue::String(s) = cloned {
+            assert_eq!(s, "hello");
+        } else {
+            panic!("Clone failed");
+        }
+    }
 }

--- a/src/patterns/colors.rs
+++ b/src/patterns/colors.rs
@@ -248,4 +248,99 @@ mod tests {
         assert_eq!(priority_color(3), BLUE);
         assert_eq!(priority_color(4), FG_DIM);
     }
+
+    #[test]
+    fn test_priority_color_high_values() {
+        // Values > 4 should return FG_DIM
+        assert_eq!(priority_color(5), FG_DIM);
+        assert_eq!(priority_color(100), FG_DIM);
+        assert_eq!(priority_color(255), FG_DIM);
+    }
+
+    #[test]
+    fn test_primary_colors_rgb() {
+        // Verify CYAN
+        if let Color::Rgb { r, g, b } = CYAN {
+            assert_eq!(r, 118);
+            assert_eq!(g, 217);
+            assert_eq!(b, 224);
+        }
+
+        // Verify GREEN
+        if let Color::Rgb { r, g, b } = GREEN {
+            assert_eq!(r, 63);
+            assert_eq!(g, 185);
+            assert_eq!(b, 80);
+        }
+
+        // Verify RED
+        if let Color::Rgb { r, g, b } = RED {
+            assert_eq!(r, 248);
+            assert_eq!(g, 81);
+            assert_eq!(b, 73);
+        }
+    }
+
+    #[test]
+    fn test_foreground_colors() {
+        // Verify FG is brightest
+        if let Color::Rgb { r, g, b } = FG {
+            assert!(r > 200 && g > 200 && b > 200);
+        }
+
+        // Verify FG_DIM is dimmer
+        if let Color::Rgb { r, g, b } = FG_DIM {
+            assert!(r < 200 && g < 200 && b < 200);
+        }
+
+        // Verify FG_SUBTLE is dimmest
+        if let Color::Rgb { r, g, b } = FG_SUBTLE {
+            assert!(r < 100 && g < 100 && b < 110);
+        }
+    }
+
+    #[test]
+    fn test_background_colors() {
+        // Verify BG is darkest
+        if let Color::Rgb { r, g, b } = BG {
+            assert!(r < 20 && g < 20 && b < 30);
+        }
+
+        // Verify BG_INSET is even darker
+        if let Color::Rgb { r, g, b } = BG_INSET {
+            assert!(r < 10 && g < 10 && b < 15);
+        }
+    }
+
+    #[test]
+    fn test_semantic_color_aliases() {
+        assert_eq!(SUCCESS, GREEN);
+        assert_eq!(ERROR, RED);
+        assert_eq!(WARNING, YELLOW);
+        assert_eq!(INFO, BLUE);
+    }
+
+    #[test]
+    fn test_border_colors() {
+        // Verify BORDER is between BG and FG brightness
+        if let Color::Rgb { r, g, b } = BORDER {
+            assert!(r > 40 && r < 60);
+            assert!(g > 50 && g < 60);
+            assert!(b > 55 && b < 70);
+        }
+
+        // Verify BORDER_MUTED is dimmer than BORDER
+        if let (Color::Rgb { r: r1, .. }, Color::Rgb { r: r2, .. }) = (BORDER, BORDER_MUTED) {
+            assert!(r1 > r2);
+        }
+    }
+
+    #[test]
+    fn test_build_color_all_states() {
+        // Test all combinations
+        assert_eq!(build_color(true, true), YELLOW); // Building, was success
+        assert_eq!(build_color(true, false), YELLOW); // Building, was failure
+        assert_eq!(build_color(false, true), GREEN); // Not building, success
+        assert_eq!(build_color(false, false), RED); // Not building, failure
+    }
 }

--- a/src/plugin/builtin.rs
+++ b/src/plugin/builtin.rs
@@ -281,4 +281,87 @@ mod tests {
 
         plugin.on_unmount(&mut ctx).unwrap();
     }
+
+    #[test]
+    fn test_logger_plugin_default() {
+        let plugin = LoggerPlugin::new();
+        assert_eq!(plugin.name(), "logger");
+        assert_eq!(plugin.priority(), 100);
+    }
+
+    #[test]
+    fn test_logger_plugin_builders() {
+        let plugin = LoggerPlugin::new().verbose(true).log_interval(30);
+        assert!(plugin.verbose);
+        assert_eq!(plugin.log_interval, 30);
+    }
+
+    #[test]
+    fn test_logger_plugin_default_trait() {
+        let plugin = LoggerPlugin::default();
+        assert!(!plugin.verbose);
+        assert_eq!(plugin.log_interval, 60);
+    }
+
+    #[test]
+    fn test_performance_plugin_default() {
+        let plugin = PerformancePlugin::new();
+        assert_eq!(plugin.name(), "performance");
+        assert_eq!(plugin.priority(), -100);
+    }
+
+    #[test]
+    fn test_performance_plugin_builders() {
+        let plugin = PerformancePlugin::new()
+            .max_samples(60)
+            .report_interval(Duration::from_secs(10));
+        assert_eq!(plugin.max_samples, 60);
+        assert_eq!(plugin.report_interval, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn test_performance_plugin_default_trait() {
+        let plugin = PerformancePlugin::default();
+        assert_eq!(plugin.max_samples, 120);
+    }
+
+    #[test]
+    fn test_performance_calculate_fps_empty() {
+        let plugin = PerformancePlugin::new();
+        assert_eq!(plugin.calculate_fps(), 0.0);
+    }
+
+    #[test]
+    fn test_performance_frame_time_stats_empty() {
+        let plugin = PerformancePlugin::new();
+        let (min, max, avg) = plugin.frame_time_stats();
+        assert_eq!(min, Duration::ZERO);
+        assert_eq!(max, Duration::ZERO);
+        assert_eq!(avg, Duration::ZERO);
+    }
+
+    #[test]
+    fn test_performance_frame_time_stats() {
+        let mut plugin = PerformancePlugin::new();
+        plugin.frame_times.push(Duration::from_millis(10));
+        plugin.frame_times.push(Duration::from_millis(20));
+        plugin.frame_times.push(Duration::from_millis(30));
+
+        let (min, max, avg) = plugin.frame_time_stats();
+        assert_eq!(min, Duration::from_millis(10));
+        assert_eq!(max, Duration::from_millis(30));
+        assert_eq!(avg, Duration::from_millis(20));
+    }
+
+    #[test]
+    fn test_logger_tick_count() {
+        let mut plugin = LoggerPlugin::new();
+        let mut ctx = PluginContext::new();
+        ctx.set_current_plugin("logger");
+
+        for _ in 0..5 {
+            plugin.on_tick(&mut ctx, Duration::from_millis(16)).unwrap();
+        }
+        assert_eq!(plugin.tick_count, 5);
+    }
 }

--- a/src/plugin/context.rs
+++ b/src/plugin/context.rs
@@ -204,4 +204,86 @@ mod tests {
         ctx.set_terminal_size(120, 40);
         assert_eq!(ctx.terminal_size(), (120, 40));
     }
+
+    #[test]
+    fn test_plugin_context_default() {
+        let ctx = PluginContext::default();
+        assert_eq!(ctx.terminal_size(), (80, 24));
+        assert!(!ctx.is_running());
+    }
+
+    #[test]
+    fn test_plugin_context_running_state() {
+        let mut ctx = PluginContext::new();
+        assert!(!ctx.is_running());
+
+        ctx.set_running(true);
+        assert!(ctx.is_running());
+
+        ctx.set_running(false);
+        assert!(!ctx.is_running());
+    }
+
+    #[test]
+    fn test_plugin_context_remove_data() {
+        let mut ctx = PluginContext::new();
+        ctx.set_current_plugin("test");
+
+        ctx.set_data("key", 42i32);
+        assert!(ctx.get_data::<i32>("key").is_some());
+
+        assert!(ctx.remove_data("key"));
+        assert!(ctx.get_data::<i32>("key").is_none());
+
+        // Removing non-existent key returns false
+        assert!(!ctx.remove_data("nonexistent"));
+    }
+
+    #[test]
+    fn test_plugin_context_remove_data_no_plugin() {
+        let mut ctx = PluginContext::new();
+        // No current plugin set
+        assert!(!ctx.remove_data("key"));
+    }
+
+    #[test]
+    fn test_plugin_context_get_data_wrong_type() {
+        let mut ctx = PluginContext::new();
+        ctx.set_current_plugin("test");
+
+        ctx.set_data("number", 42i32);
+        // Try to get as different type
+        assert!(ctx.get_data::<String>("number").is_none());
+    }
+
+    #[test]
+    fn test_plugin_context_clear_current_plugin() {
+        let mut ctx = PluginContext::new();
+        ctx.set_current_plugin("test");
+        ctx.set_data("key", 42i32);
+
+        ctx.clear_current_plugin();
+        // After clearing, get_data returns None (no current plugin)
+        assert!(ctx.get_data::<i32>("key").is_none());
+    }
+
+    #[test]
+    fn test_plugin_context_log_methods() {
+        let mut ctx = PluginContext::new();
+        ctx.set_current_plugin("test");
+
+        // Just verify these don't panic
+        ctx.log("info message");
+        ctx.warn("warning message");
+        ctx.error("error message");
+    }
+
+    #[test]
+    fn test_plugin_context_log_no_plugin() {
+        let ctx = PluginContext::new();
+        // Just verify these don't panic without current plugin
+        ctx.log("info message");
+        ctx.warn("warning message");
+        ctx.error("error message");
+    }
 }

--- a/src/render/backend/traits.rs
+++ b/src/render/backend/traits.rs
@@ -115,3 +115,56 @@ pub trait Backend: Write {
     /// Get backend name for debugging
     fn name(&self) -> &'static str;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_backend_capabilities_default() {
+        let caps = BackendCapabilities::default();
+        assert!(!caps.true_color);
+        assert!(!caps.hyperlinks);
+        assert!(!caps.mouse);
+        assert!(!caps.bracketed_paste);
+        assert!(!caps.focus_events);
+    }
+
+    #[test]
+    fn test_backend_capabilities_custom() {
+        let caps = BackendCapabilities {
+            true_color: true,
+            hyperlinks: true,
+            mouse: true,
+            bracketed_paste: true,
+            focus_events: true,
+        };
+        assert!(caps.true_color);
+        assert!(caps.hyperlinks);
+        assert!(caps.mouse);
+        assert!(caps.bracketed_paste);
+        assert!(caps.focus_events);
+    }
+
+    #[test]
+    fn test_backend_capabilities_clone() {
+        let caps = BackendCapabilities {
+            true_color: true,
+            hyperlinks: false,
+            mouse: true,
+            bracketed_paste: false,
+            focus_events: true,
+        };
+        let cloned = caps.clone();
+        assert_eq!(cloned.true_color, caps.true_color);
+        assert_eq!(cloned.hyperlinks, caps.hyperlinks);
+        assert_eq!(cloned.mouse, caps.mouse);
+    }
+
+    #[test]
+    fn test_backend_capabilities_debug() {
+        let caps = BackendCapabilities::default();
+        let debug = format!("{:?}", caps);
+        assert!(debug.contains("BackendCapabilities"));
+    }
+}

--- a/src/testing/actions.rs
+++ b/src/testing/actions.rs
@@ -234,4 +234,126 @@ mod tests {
         let action = MouseAction::click(10, 20);
         assert_eq!(action.position(), (10, 20));
     }
+
+    #[test]
+    fn test_action_variants() {
+        let key_action = Action::Key(KeyAction::Press(Key::Enter));
+        assert!(matches!(key_action, Action::Key(_)));
+
+        let mouse_action = Action::Mouse(MouseAction::Click(5, 10));
+        assert!(matches!(mouse_action, Action::Mouse(_)));
+
+        let wait_action = Action::Wait(Duration::from_millis(100));
+        assert!(matches!(wait_action, Action::Wait(_)));
+
+        let resize_action = Action::Resize(80, 24);
+        assert!(matches!(resize_action, Action::Resize(80, 24)));
+
+        let custom_action = Action::Custom("test".to_string());
+        assert!(matches!(custom_action, Action::Custom(_)));
+    }
+
+    #[test]
+    fn test_key_action_constructors() {
+        let press = KeyAction::press(Key::Tab);
+        assert_eq!(press.key(), Some(Key::Tab));
+
+        let ctrl = KeyAction::press_ctrl(Key::Char('c'));
+        assert_eq!(ctrl.key(), Some(Key::Char('c')));
+
+        let alt = KeyAction::press_alt(Key::Char('x'));
+        assert_eq!(alt.key(), Some(Key::Char('x')));
+
+        let type_action = KeyAction::type_text("hello");
+        assert_eq!(type_action.key(), None);
+    }
+
+    #[test]
+    fn test_key_action_hold_release() {
+        let hold = KeyAction::Hold(Key::Char('a'), Duration::from_millis(500));
+        assert_eq!(hold.key(), Some(Key::Char('a')));
+
+        let release = KeyAction::Release(Key::Char('a'));
+        assert_eq!(release.key(), Some(Key::Char('a')));
+    }
+
+    #[test]
+    fn test_mouse_action_constructors() {
+        assert_eq!(MouseAction::double_click(5, 10).position(), (5, 10));
+        assert_eq!(MouseAction::right_click(15, 20).position(), (15, 20));
+        assert_eq!(MouseAction::move_to(25, 30).position(), (25, 30));
+    }
+
+    #[test]
+    fn test_mouse_action_drag() {
+        let drag = MouseAction::drag(0, 0, 100, 100);
+        assert_eq!(drag.position(), (0, 0)); // Start position
+    }
+
+    #[test]
+    fn test_mouse_action_scroll_positions() {
+        let scroll_up = MouseAction::ScrollUp(10, 20, 3);
+        assert_eq!(scroll_up.position(), (10, 20));
+
+        let scroll_down = MouseAction::ScrollDown(30, 40, 5);
+        assert_eq!(scroll_down.position(), (30, 40));
+    }
+
+    #[test]
+    fn test_action_sequence_empty() {
+        let seq = ActionSequence::new();
+        assert!(seq.is_empty());
+        assert_eq!(seq.len(), 0);
+    }
+
+    #[test]
+    fn test_action_sequence_push() {
+        let mut seq = ActionSequence::new();
+        seq.push(Action::Key(KeyAction::Press(Key::Enter)));
+        assert_eq!(seq.len(), 1);
+        assert!(!seq.is_empty());
+    }
+
+    #[test]
+    fn test_action_sequence_wait() {
+        let seq = ActionSequence::new()
+            .wait(Duration::from_secs(1))
+            .wait_ms(500);
+        assert_eq!(seq.len(), 2);
+    }
+
+    #[test]
+    fn test_action_sequence_iter() {
+        let seq = ActionSequence::new().press(Key::Up).press(Key::Down);
+        let actions: Vec<_> = seq.iter().collect();
+        assert_eq!(actions.len(), 2);
+    }
+
+    #[test]
+    fn test_action_sequence_into_iter() {
+        let seq = ActionSequence::new().press(Key::Left).press(Key::Right);
+        let actions: Vec<_> = seq.into_iter().collect();
+        assert_eq!(actions.len(), 2);
+    }
+
+    #[test]
+    fn test_action_sequence_actions() {
+        let seq = ActionSequence::new().click(5, 10);
+        let actions = seq.actions();
+        assert_eq!(actions.len(), 1);
+    }
+
+    #[test]
+    fn test_action_clone() {
+        let action = Action::Key(KeyAction::Press(Key::Enter));
+        let cloned = action.clone();
+        assert!(matches!(cloned, Action::Key(KeyAction::Press(Key::Enter))));
+    }
+
+    #[test]
+    fn test_action_debug() {
+        let action = Action::Resize(100, 50);
+        let debug = format!("{:?}", action);
+        assert!(debug.contains("Resize"));
+    }
 }

--- a/src/widget/accordion.rs
+++ b/src/widget/accordion.rs
@@ -658,4 +658,205 @@ mod tests {
         assert_eq!(s.expanded_icon, '-');
         assert_eq!(s.icon(), '+');
     }
+
+    // =========================================================================
+    // Additional coverage tests
+    // =========================================================================
+
+    #[test]
+    fn test_accordion_default() {
+        let acc = Accordion::default();
+        assert!(acc.is_empty());
+    }
+
+    #[test]
+    fn test_accordion_collapse_selected() {
+        let mut acc = Accordion::new().section(AccordionSection::new("A").expanded(true));
+
+        assert!(acc.sections[0].expanded);
+        acc.collapse_selected();
+        assert!(!acc.sections[0].expanded);
+    }
+
+    #[test]
+    fn test_accordion_collapse_selected_empty() {
+        let mut acc = Accordion::new();
+        // Should not panic on empty
+        acc.collapse_selected();
+    }
+
+    #[test]
+    fn test_accordion_expand_selected_empty() {
+        let mut acc = Accordion::new();
+        // Should not panic on empty
+        acc.expand_selected();
+    }
+
+    #[test]
+    fn test_accordion_toggle_multi_expand() {
+        let mut acc = Accordion::new()
+            .multi_expand(true)
+            .section(AccordionSection::new("A"))
+            .section(AccordionSection::new("B"));
+
+        acc.toggle_selected();
+        assert!(acc.sections[0].expanded);
+
+        acc.toggle_selected();
+        assert!(!acc.sections[0].expanded);
+    }
+
+    #[test]
+    fn test_accordion_set_selected() {
+        let mut acc = Accordion::new()
+            .section(AccordionSection::new("A"))
+            .section(AccordionSection::new("B"));
+
+        acc.set_selected(1);
+        assert_eq!(acc.selected(), 1);
+    }
+
+    #[test]
+    fn test_accordion_remove_section_out_of_range() {
+        let mut acc = Accordion::new().section(AccordionSection::new("A"));
+
+        let removed = acc.remove_section(10);
+        assert!(removed.is_none());
+        assert_eq!(acc.len(), 1);
+    }
+
+    #[test]
+    fn test_accordion_sections_batch() {
+        let sections = vec![
+            AccordionSection::new("A"),
+            AccordionSection::new("B"),
+            AccordionSection::new("C"),
+        ];
+        let acc = Accordion::new().sections(sections);
+        assert_eq!(acc.len(), 3);
+    }
+
+    #[test]
+    fn test_accordion_handle_key_j_k() {
+        use crate::event::Key;
+
+        let mut acc = Accordion::new()
+            .section(AccordionSection::new("A"))
+            .section(AccordionSection::new("B"));
+
+        // j for down
+        assert!(acc.handle_key(&Key::Char('j')));
+        assert_eq!(acc.selected(), 1);
+
+        // k for up
+        assert!(acc.handle_key(&Key::Char('k')));
+        assert_eq!(acc.selected(), 0);
+    }
+
+    #[test]
+    fn test_accordion_handle_key_space() {
+        use crate::event::Key;
+
+        let mut acc = Accordion::new().section(AccordionSection::new("A").line("Content"));
+
+        assert!(acc.handle_key(&Key::Char(' ')));
+        assert!(acc.sections[0].expanded);
+    }
+
+    #[test]
+    fn test_accordion_handle_key_l_h() {
+        use crate::event::Key;
+
+        let mut acc = Accordion::new().section(AccordionSection::new("A").line("Content"));
+
+        // l for expand
+        assert!(acc.handle_key(&Key::Char('l')));
+        assert!(acc.sections[0].expanded);
+
+        // h for collapse
+        assert!(acc.handle_key(&Key::Char('h')));
+        assert!(!acc.sections[0].expanded);
+    }
+
+    #[test]
+    fn test_accordion_handle_key_unhandled() {
+        use crate::event::Key;
+
+        let mut acc = Accordion::new().section(AccordionSection::new("A"));
+
+        let changed = acc.handle_key(&Key::Tab);
+        assert!(!changed);
+    }
+
+    #[test]
+    fn test_accordion_colors() {
+        let acc = Accordion::new()
+            .header_colors(Color::WHITE, Color::RED)
+            .content_colors(Color::BLACK, Color::GREEN)
+            .selected_bg(Color::BLUE);
+
+        assert_eq!(acc.header_fg, Color::WHITE);
+        assert_eq!(acc.header_bg, Color::RED);
+        assert_eq!(acc.content_fg, Color::BLACK);
+        assert_eq!(acc.content_bg, Color::GREEN);
+        assert_eq!(acc.selected_bg, Color::BLUE);
+    }
+
+    #[test]
+    fn test_accordion_dividers() {
+        let acc = Accordion::new().dividers(false);
+        assert!(!acc.show_dividers);
+    }
+
+    #[test]
+    fn test_accordion_render_small_area() {
+        let mut buffer = Buffer::new(2, 1);
+        let area = Rect::new(0, 0, 2, 1);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let acc = Accordion::new().section(AccordionSection::new("Test"));
+
+        acc.render(&mut ctx);
+        // Small area should not panic
+    }
+
+    #[test]
+    fn test_accordion_render_content_overflow() {
+        let mut buffer = Buffer::new(40, 3);
+        let area = Rect::new(0, 0, 40, 3);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let acc = Accordion::new().section(
+            AccordionSection::new("Section 1")
+                .line("Line 1")
+                .line("Line 2")
+                .line("Line 3")
+                .line("Line 4")
+                .line("Line 5")
+                .expanded(true),
+        );
+
+        acc.render(&mut ctx);
+        // Should not panic when content exceeds area
+    }
+
+    #[test]
+    fn test_section_lines() {
+        let s = AccordionSection::new("Test").lines(&["Line 1", "Line 2", "Line 3"]);
+        assert_eq!(s.content.len(), 3);
+    }
+
+    #[test]
+    fn test_section_icon_expanded() {
+        let s = AccordionSection::new("Test").expanded(true);
+        assert_eq!(s.icon(), '▼');
+    }
+
+    #[test]
+    fn test_section_clone() {
+        let s = AccordionSection::new("Test").line("Content");
+        let cloned = s.clone();
+        assert_eq!(cloned.title, "Test");
+        assert_eq!(cloned.content.len(), 1);
+    }
 }

--- a/src/widget/autocomplete.rs
+++ b/src/widget/autocomplete.rs
@@ -573,4 +573,288 @@ mod tests {
         let ac = autocomplete().placeholder("Search...");
         assert_eq!(ac.placeholder, "Search...");
     }
+
+    // =========================================================================
+    // Additional coverage tests
+    // =========================================================================
+
+    #[test]
+    fn test_autocomplete_default() {
+        let ac = Autocomplete::default();
+        assert_eq!(ac.get_value(), "");
+    }
+
+    #[test]
+    fn test_autocomplete_blur() {
+        let mut ac = Autocomplete::new().suggestions(vec!["apple", "banana"]);
+
+        ac.focus();
+        ac.set_value("a");
+        assert!(ac.is_focused());
+
+        ac.blur();
+        assert!(!ac.is_focused());
+        assert!(!ac.dropdown_visible);
+    }
+
+    #[test]
+    fn test_autocomplete_selected_suggestion_empty() {
+        let ac = Autocomplete::new().suggestions(vec!["apple", "banana"]);
+        // No filter applied yet
+        assert!(ac.selected_suggestion().is_none());
+    }
+
+    #[test]
+    fn test_autocomplete_accept_selection_empty() {
+        let mut ac = Autocomplete::new();
+        // No suggestions, should return false
+        assert!(!ac.accept_selection());
+    }
+
+    #[test]
+    fn test_autocomplete_min_chars() {
+        let mut ac = Autocomplete::new()
+            .suggestions(vec!["apple", "banana"])
+            .min_chars(3);
+
+        ac.set_value("ap");
+        // Should not filter because min_chars is 3
+        assert!(ac.filtered.is_empty());
+
+        ac.set_value("app");
+        // Now should filter
+        assert!(!ac.filtered.is_empty());
+    }
+
+    #[test]
+    fn test_autocomplete_max_suggestions() {
+        let mut ac = Autocomplete::new()
+            .suggestions(vec!["a1", "a2", "a3", "a4", "a5", "a6"])
+            .max_suggestions(3)
+            .min_chars(1);
+
+        ac.set_value("a");
+        assert_eq!(ac.filtered.len(), 3);
+    }
+
+    #[test]
+    fn test_autocomplete_filter_mode_prefix() {
+        let mut ac = Autocomplete::new()
+            .suggestions(vec!["apple", "application", "banana"])
+            .filter_mode(FilterMode::Prefix)
+            .min_chars(1);
+
+        ac.set_value("app");
+        assert_eq!(ac.filtered.len(), 2); // apple, application
+    }
+
+    #[test]
+    fn test_autocomplete_filter_mode_contains() {
+        let mut ac = Autocomplete::new()
+            .suggestions(vec!["apple", "pineapple", "banana"])
+            .filter_mode(FilterMode::Contains)
+            .min_chars(1);
+
+        ac.set_value("apple");
+        assert_eq!(ac.filtered.len(), 2); // apple, pineapple
+    }
+
+    #[test]
+    fn test_autocomplete_filter_mode_exact() {
+        let mut ac = Autocomplete::new()
+            .suggestions(vec!["apple", "APPLE", "apples"])
+            .filter_mode(FilterMode::Exact)
+            .min_chars(1);
+
+        ac.set_value("apple");
+        assert_eq!(ac.filtered.len(), 2); // apple, APPLE (case insensitive)
+    }
+
+    #[test]
+    fn test_autocomplete_filter_mode_none() {
+        let mut ac = Autocomplete::new()
+            .suggestions(vec!["apple", "banana", "cherry"])
+            .filter_mode(FilterMode::None)
+            .min_chars(1);
+
+        ac.set_value("xyz");
+        assert_eq!(ac.filtered.len(), 3); // All suggestions shown
+    }
+
+    #[test]
+    fn test_autocomplete_handle_key_delete() {
+        let mut ac = Autocomplete::new();
+        ac.focus();
+
+        ac.handle_key(KeyEvent::new(Key::Char('a')));
+        ac.handle_key(KeyEvent::new(Key::Char('b')));
+        ac.handle_key(KeyEvent::new(Key::Home));
+        ac.handle_key(KeyEvent::new(Key::Delete));
+        assert_eq!(ac.get_value(), "b");
+    }
+
+    #[test]
+    fn test_autocomplete_handle_key_cursor_movement() {
+        let mut ac = Autocomplete::new();
+        ac.focus();
+
+        ac.handle_key(KeyEvent::new(Key::Char('a')));
+        ac.handle_key(KeyEvent::new(Key::Char('b')));
+        ac.handle_key(KeyEvent::new(Key::Char('c')));
+
+        ac.handle_key(KeyEvent::new(Key::Home));
+        assert_eq!(ac.cursor, 0);
+
+        ac.handle_key(KeyEvent::new(Key::End));
+        assert_eq!(ac.cursor, 3);
+
+        ac.handle_key(KeyEvent::new(Key::Left));
+        assert_eq!(ac.cursor, 2);
+
+        ac.handle_key(KeyEvent::new(Key::Right));
+        assert_eq!(ac.cursor, 3);
+    }
+
+    #[test]
+    fn test_autocomplete_handle_key_dropdown_navigation() {
+        let mut ac = Autocomplete::new()
+            .suggestions(vec!["a1", "a2", "a3"])
+            .min_chars(1);
+
+        ac.focus();
+        ac.handle_key(KeyEvent::new(Key::Char('a')));
+
+        assert!(ac.dropdown_visible);
+
+        ac.handle_key(KeyEvent::new(Key::Down));
+        assert_eq!(ac.selection.index, 1);
+
+        ac.handle_key(KeyEvent::new(Key::Up));
+        assert_eq!(ac.selection.index, 0);
+    }
+
+    #[test]
+    fn test_autocomplete_handle_key_escape() {
+        let mut ac = Autocomplete::new()
+            .suggestions(vec!["a1", "a2"])
+            .min_chars(1);
+
+        ac.focus();
+        ac.handle_key(KeyEvent::new(Key::Char('a')));
+        assert!(ac.dropdown_visible);
+
+        ac.handle_key(KeyEvent::new(Key::Escape));
+        assert!(!ac.dropdown_visible);
+    }
+
+    #[test]
+    fn test_autocomplete_handle_key_tab() {
+        let mut ac = Autocomplete::new()
+            .suggestions(vec!["apple", "banana"])
+            .min_chars(1);
+
+        ac.focus();
+        ac.handle_key(KeyEvent::new(Key::Char('a')));
+        ac.handle_key(KeyEvent::new(Key::Tab));
+
+        assert_eq!(ac.get_value(), "apple");
+    }
+
+    #[test]
+    fn test_autocomplete_handle_key_unhandled() {
+        let mut ac = Autocomplete::new();
+        ac.focus();
+
+        let handled = ac.handle_key(KeyEvent::new(Key::F(1)));
+        assert!(!handled);
+    }
+
+    #[test]
+    fn test_autocomplete_colors() {
+        let ac = Autocomplete::new()
+            .input_style(Color::WHITE, Color::BLACK)
+            .dropdown_style(Color::rgb(50, 50, 50), Color::WHITE, Color::BLUE)
+            .highlight_fg(Color::YELLOW);
+
+        assert_eq!(ac.input_fg, Color::WHITE);
+        assert_eq!(ac.input_bg, Color::BLACK);
+        assert_eq!(ac.dropdown_bg, Color::rgb(50, 50, 50));
+        assert_eq!(ac.selected_fg, Color::WHITE);
+        assert_eq!(ac.selected_bg, Color::BLUE);
+        assert_eq!(ac.highlight_fg, Color::YELLOW);
+    }
+
+    #[test]
+    fn test_autocomplete_render_with_placeholder() {
+        let mut buffer = Buffer::new(30, 5);
+        let area = Rect::new(0, 0, 30, 5);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let ac = Autocomplete::new().placeholder("Type here...");
+        ac.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_autocomplete_render_with_cursor() {
+        let mut buffer = Buffer::new(30, 5);
+        let area = Rect::new(0, 0, 30, 5);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let mut ac = Autocomplete::new().value("test");
+        ac.focus();
+        ac.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_autocomplete_render_dropdown() {
+        let mut buffer = Buffer::new(30, 10);
+        let area = Rect::new(0, 0, 30, 10);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let mut ac = Autocomplete::new()
+            .suggestions(vec![
+                Suggestion::new("apple").description("A fruit").icon('🍎'),
+                Suggestion::new("banana"),
+            ])
+            .min_chars(1);
+
+        ac.focus();
+        ac.set_value("a");
+        ac.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_autocomplete_render_small_area() {
+        let mut buffer = Buffer::new(2, 1);
+        let area = Rect::new(0, 0, 2, 1);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let ac = Autocomplete::new().value("test");
+        ac.render(&mut ctx);
+        // Small area should not panic
+    }
+
+    #[test]
+    fn test_suggestion_description_and_icon() {
+        let s = Suggestion::new("test")
+            .description("A test suggestion")
+            .icon('✓');
+
+        assert_eq!(s.description, Some("A test suggestion".to_string()));
+        assert_eq!(s.icon, Some('✓'));
+    }
+
+    #[test]
+    fn test_suggestion_from() {
+        let s: Suggestion = "quick".into();
+        assert_eq!(s.label, "quick");
+        assert_eq!(s.value, "quick");
+    }
+
+    #[test]
+    fn test_autocomplete_set_suggestions() {
+        let mut ac = Autocomplete::new();
+        ac.set_suggestions(vec![Suggestion::new("one"), Suggestion::new("two")]);
+        assert_eq!(ac.suggestions.len(), 2);
+    }
 }

--- a/src/widget/breadcrumb.rs
+++ b/src/widget/breadcrumb.rs
@@ -592,4 +592,229 @@ mod tests {
 
         assert_eq!(bc.len(), 1);
     }
+
+    // =========================================================================
+    // Additional coverage tests
+    // =========================================================================
+
+    #[test]
+    fn test_breadcrumb_default() {
+        let bc = Breadcrumb::default();
+        assert!(bc.is_empty());
+    }
+
+    #[test]
+    fn test_breadcrumb_item_clickable() {
+        let item = BreadcrumbItem::new("Test").clickable(false);
+        assert!(!item.clickable);
+    }
+
+    #[test]
+    fn test_breadcrumb_item_clone() {
+        let item = BreadcrumbItem::new("Test").icon('📁');
+        let cloned = item.clone();
+        assert_eq!(cloned.label, "Test");
+        assert_eq!(cloned.icon, Some('📁'));
+    }
+
+    #[test]
+    fn test_separator_style_all() {
+        assert_eq!(SeparatorStyle::DoubleArrow.char(), '»');
+        assert_eq!(SeparatorStyle::Dot.char(), '•');
+        assert_eq!(SeparatorStyle::Pipe.char(), '|');
+    }
+
+    #[test]
+    fn test_separator_style_debug() {
+        let style = SeparatorStyle::Chevron;
+        let debug = format!("{:?}", style);
+        assert!(debug.contains("Chevron"));
+    }
+
+    #[test]
+    fn test_separator_style_eq() {
+        assert_eq!(SeparatorStyle::Slash, SeparatorStyle::Slash);
+        assert_ne!(SeparatorStyle::Slash, SeparatorStyle::Arrow);
+    }
+
+    #[test]
+    fn test_breadcrumb_colors() {
+        let bc = Breadcrumb::new()
+            .item_color(Color::WHITE)
+            .selected_color(Color::CYAN)
+            .separator_color(Color::rgb(80, 80, 80));
+
+        assert_eq!(bc.item_color, Color::WHITE);
+        assert_eq!(bc.selected_color, Color::CYAN);
+    }
+
+    #[test]
+    fn test_breadcrumb_home_settings() {
+        let bc = Breadcrumb::new().home(false).home_icon('🏠');
+
+        assert!(!bc.show_home);
+        assert_eq!(bc.home_icon, '🏠');
+    }
+
+    #[test]
+    fn test_breadcrumb_max_width() {
+        let bc = Breadcrumb::new().max_width(50);
+        assert_eq!(bc.max_width, 50);
+    }
+
+    #[test]
+    fn test_breadcrumb_collapse() {
+        let bc = Breadcrumb::new().collapse(false);
+        assert!(!bc.collapse);
+    }
+
+    #[test]
+    fn test_breadcrumb_total_width() {
+        let bc = Breadcrumb::new().home(false).push("Home").push("Documents");
+
+        let width = bc.total_width();
+        // "Home" (4) + " › " (3) + "Documents" (9) = 16
+        assert!(width > 0);
+    }
+
+    #[test]
+    fn test_breadcrumb_total_width_with_icons() {
+        let bc = Breadcrumb::new()
+            .home(false)
+            .item(BreadcrumbItem::new("Home").icon('📁'))
+            .item(BreadcrumbItem::new("Work"));
+
+        let width = bc.total_width();
+        assert!(width > 0);
+    }
+
+    #[test]
+    fn test_breadcrumb_total_width_with_home() {
+        let bc = Breadcrumb::new().home(true).push("Documents");
+
+        let width = bc.total_width();
+        // Home icon + space + separator + Documents
+        assert!(width > 0);
+    }
+
+    #[test]
+    fn test_breadcrumb_render_empty() {
+        let mut buffer = Buffer::new(40, 3);
+        let area = Rect::new(0, 0, 40, 3);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let bc = Breadcrumb::new().home(false);
+        bc.render(&mut ctx);
+        // Empty breadcrumb should not panic
+    }
+
+    #[test]
+    fn test_breadcrumb_render_small_area() {
+        let mut buffer = Buffer::new(2, 1);
+        let area = Rect::new(0, 0, 2, 1);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let bc = Breadcrumb::new().push("Test");
+        bc.render(&mut ctx);
+        // Small area should not panic
+    }
+
+    #[test]
+    fn test_breadcrumb_render_with_collapse() {
+        let mut buffer = Buffer::new(30, 3);
+        let area = Rect::new(0, 0, 30, 3);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let bc = Breadcrumb::new()
+            .home(false)
+            .max_width(20)
+            .collapse(true)
+            .push("Very")
+            .push("Long")
+            .push("Path")
+            .push("That")
+            .push("Needs")
+            .push("Collapse");
+
+        bc.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_breadcrumb_render_with_icons() {
+        let mut buffer = Buffer::new(60, 3);
+        let area = Rect::new(0, 0, 60, 3);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let bc = Breadcrumb::new()
+            .home(true)
+            .item(BreadcrumbItem::new("Documents").icon('📁'))
+            .item(BreadcrumbItem::new("Work").icon('💼'));
+
+        bc.render(&mut ctx);
+    }
+
+    #[test]
+    fn test_breadcrumb_handle_key_vim() {
+        use crate::event::Key;
+
+        let mut bc = Breadcrumb::new().push("A").push("B");
+
+        bc.set_selected(0);
+
+        // 'l' for right
+        assert!(bc.handle_key(&Key::Char('l')));
+        assert_eq!(bc.selected(), 1);
+
+        // 'h' for left
+        assert!(bc.handle_key(&Key::Char('h')));
+        assert_eq!(bc.selected(), 0);
+    }
+
+    #[test]
+    fn test_breadcrumb_handle_key_unhandled() {
+        use crate::event::Key;
+
+        let mut bc = Breadcrumb::new().push("Test");
+
+        let handled = bc.handle_key(&Key::Escape);
+        assert!(!handled);
+    }
+
+    #[test]
+    fn test_breadcrumb_selected_item() {
+        let bc = Breadcrumb::new().push("First").push("Second");
+
+        let item = bc.selected_item();
+        assert!(item.is_some());
+        assert_eq!(item.unwrap().label, "Second");
+    }
+
+    #[test]
+    fn test_breadcrumb_selected_item_empty() {
+        let bc = Breadcrumb::new();
+        assert!(bc.selected_item().is_none());
+    }
+
+    #[test]
+    fn test_breadcrumb_navigate_to_out_of_bounds() {
+        let mut bc = Breadcrumb::new().push("A").push("B").push("C");
+
+        bc.navigate_to(10); // Out of bounds, should do nothing
+        assert_eq!(bc.len(), 3);
+    }
+
+    #[test]
+    fn test_breadcrumb_pop_empty() {
+        let mut bc = Breadcrumb::new();
+        let item = bc.pop();
+        assert!(item.is_none());
+    }
+
+    #[test]
+    fn test_crumb_helper() {
+        let item = crumb("Test").icon('✓').clickable(false);
+        assert_eq!(item.label, "Test");
+        assert_eq!(item.icon, Some('✓'));
+        assert!(!item.clickable);
+    }
 }

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -370,4 +370,145 @@ mod tests {
         let tab = Tab::new("My Tab");
         assert_eq!(tab.label, "My Tab");
     }
+
+    // =========================================================================
+    // Additional coverage tests
+    // =========================================================================
+
+    #[test]
+    fn test_tabs_default() {
+        let t = Tabs::default();
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn test_tabs_fg_bg_colors() {
+        let t = Tabs::new().fg(Color::RED).bg(Color::BLUE);
+        assert_eq!(t.fg, Some(Color::RED));
+        assert_eq!(t.bg, Some(Color::BLUE));
+    }
+
+    #[test]
+    fn test_tabs_active_style() {
+        let t = Tabs::new().active_style(Color::WHITE, Color::GREEN);
+        assert_eq!(t.active_fg, Some(Color::WHITE));
+        assert_eq!(t.active_bg, Some(Color::GREEN));
+    }
+
+    #[test]
+    fn test_tabs_divider() {
+        let t = Tabs::new().divider('|');
+        assert_eq!(t.divider, '|');
+    }
+
+    #[test]
+    fn test_tabs_handle_key_h_l() {
+        use crate::event::Key;
+
+        let mut t = Tabs::new().tabs(vec!["A", "B", "C"]);
+
+        // l for right
+        t.handle_key(&Key::Char('l'));
+        assert_eq!(t.selected_index(), 1);
+
+        // h for left
+        t.handle_key(&Key::Char('h'));
+        assert_eq!(t.selected_index(), 0);
+    }
+
+    #[test]
+    fn test_tabs_handle_key_home_end() {
+        use crate::event::Key;
+
+        let mut t = Tabs::new().tabs(vec!["A", "B", "C"]);
+
+        t.handle_key(&Key::End);
+        assert_eq!(t.selected_index(), 2);
+
+        t.handle_key(&Key::Home);
+        assert_eq!(t.selected_index(), 0);
+    }
+
+    #[test]
+    fn test_tabs_handle_key_number_out_of_range() {
+        use crate::event::Key;
+
+        let mut t = Tabs::new().tabs(vec!["A", "B"]);
+
+        // Pressing '9' when there are only 2 tabs should do nothing
+        let changed = t.handle_key(&Key::Char('9'));
+        assert!(!changed);
+        assert_eq!(t.selected_index(), 0);
+    }
+
+    #[test]
+    fn test_tabs_handle_key_unhandled() {
+        use crate::event::Key;
+
+        let mut t = Tabs::new().tabs(vec!["A", "B"]);
+
+        let changed = t.handle_key(&Key::Escape);
+        assert!(!changed);
+    }
+
+    #[test]
+    fn test_tabs_selected_label_empty() {
+        let t = Tabs::new();
+        assert!(t.selected_label().is_none());
+    }
+
+    #[test]
+    fn test_tabs_render_empty() {
+        let mut buffer = Buffer::new(40, 5);
+        let area = Rect::new(0, 0, 40, 5);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let t = Tabs::new();
+        t.render(&mut ctx);
+        // Empty tabs should not panic
+    }
+
+    #[test]
+    fn test_tabs_render_small_area() {
+        let mut buffer = Buffer::new(2, 1);
+        let area = Rect::new(0, 0, 2, 1);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let t = Tabs::new().tab("Test");
+        t.render(&mut ctx);
+        // Small area should not panic
+    }
+
+    #[test]
+    fn test_tabs_render_with_divider() {
+        let mut buffer = Buffer::new(40, 5);
+        let area = Rect::new(0, 0, 40, 5);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let t = Tabs::new().tab("A").tab("B").divider('|');
+
+        t.render(&mut ctx);
+        // Verify divider appears
+    }
+
+    #[test]
+    fn test_tabs_render_selected() {
+        let mut buffer = Buffer::new(40, 5);
+        let area = Rect::new(0, 0, 40, 5);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let t = Tabs::new()
+            .tabs(vec!["First", "Second", "Third"])
+            .selected(1);
+
+        t.render(&mut ctx);
+        // Verify selection rendering
+    }
+
+    #[test]
+    fn test_tab_clone() {
+        let tab = Tab::new("Original");
+        let cloned = tab.clone();
+        assert_eq!(cloned.label, "Original");
+    }
 }

--- a/src/widget/traits/element.rs
+++ b/src/widget/traits/element.rs
@@ -11,3 +11,34 @@ pub enum Element {
     /// View element
     View(Box<dyn View>),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::widget::traits::render_context::RenderContext;
+
+    struct DummyView;
+
+    impl View for DummyView {
+        fn render(&self, _ctx: &mut RenderContext) {}
+    }
+
+    #[test]
+    fn test_element_default() {
+        let element = Element::default();
+        assert!(matches!(element, Element::Empty));
+    }
+
+    #[test]
+    fn test_element_empty_variant() {
+        let element = Element::Empty;
+        assert!(matches!(element, Element::Empty));
+    }
+
+    #[test]
+    fn test_element_view_variant() {
+        let view: Box<dyn View> = Box::new(DummyView);
+        let element = Element::View(view);
+        assert!(matches!(element, Element::View(_)));
+    }
+}

--- a/src/widget/traits/event.rs
+++ b/src/widget/traits/event.rs
@@ -65,3 +65,152 @@ pub enum FocusStyle {
     /// ASCII compatible (+--+)
     Ascii,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // EventResult Tests
+    // =========================================================================
+
+    #[test]
+    fn test_event_result_default() {
+        let result = EventResult::default();
+        assert_eq!(result, EventResult::Ignored);
+    }
+
+    #[test]
+    fn test_event_result_is_consumed() {
+        assert!(!EventResult::Ignored.is_consumed());
+        assert!(EventResult::Consumed.is_consumed());
+        assert!(EventResult::ConsumedAndRender.is_consumed());
+    }
+
+    #[test]
+    fn test_event_result_needs_render() {
+        assert!(!EventResult::Ignored.needs_render());
+        assert!(!EventResult::Consumed.needs_render());
+        assert!(EventResult::ConsumedAndRender.needs_render());
+    }
+
+    #[test]
+    fn test_event_result_or_consumed_and_render() {
+        // ConsumedAndRender wins over everything
+        assert_eq!(
+            EventResult::ConsumedAndRender.or(EventResult::Ignored),
+            EventResult::ConsumedAndRender
+        );
+        assert_eq!(
+            EventResult::Ignored.or(EventResult::ConsumedAndRender),
+            EventResult::ConsumedAndRender
+        );
+        assert_eq!(
+            EventResult::Consumed.or(EventResult::ConsumedAndRender),
+            EventResult::ConsumedAndRender
+        );
+    }
+
+    #[test]
+    fn test_event_result_or_consumed() {
+        // Consumed wins over Ignored
+        assert_eq!(
+            EventResult::Consumed.or(EventResult::Ignored),
+            EventResult::Consumed
+        );
+        assert_eq!(
+            EventResult::Ignored.or(EventResult::Consumed),
+            EventResult::Consumed
+        );
+    }
+
+    #[test]
+    fn test_event_result_or_ignored() {
+        // Ignored + Ignored = Ignored
+        assert_eq!(
+            EventResult::Ignored.or(EventResult::Ignored),
+            EventResult::Ignored
+        );
+    }
+
+    #[test]
+    fn test_event_result_from_bool_true() {
+        let result: EventResult = true.into();
+        assert_eq!(result, EventResult::ConsumedAndRender);
+    }
+
+    #[test]
+    fn test_event_result_from_bool_false() {
+        let result: EventResult = false.into();
+        assert_eq!(result, EventResult::Ignored);
+    }
+
+    #[test]
+    fn test_event_result_clone() {
+        let result = EventResult::ConsumedAndRender;
+        let cloned = result;
+        assert_eq!(cloned, EventResult::ConsumedAndRender);
+    }
+
+    #[test]
+    fn test_event_result_debug() {
+        let result = EventResult::Consumed;
+        let debug = format!("{:?}", result);
+        assert!(debug.contains("Consumed"));
+    }
+
+    #[test]
+    fn test_event_result_copy() {
+        let result = EventResult::Consumed;
+        let copied = result;
+        assert_eq!(result, copied);
+    }
+
+    // =========================================================================
+    // FocusStyle Tests
+    // =========================================================================
+
+    #[test]
+    fn test_focus_style_default() {
+        let style = FocusStyle::default();
+        assert_eq!(style, FocusStyle::Solid);
+    }
+
+    #[test]
+    fn test_focus_style_variants() {
+        assert_eq!(FocusStyle::Solid, FocusStyle::Solid);
+        assert_eq!(FocusStyle::Rounded, FocusStyle::Rounded);
+        assert_eq!(FocusStyle::Double, FocusStyle::Double);
+        assert_eq!(FocusStyle::Dotted, FocusStyle::Dotted);
+        assert_eq!(FocusStyle::Bold, FocusStyle::Bold);
+        assert_eq!(FocusStyle::Ascii, FocusStyle::Ascii);
+    }
+
+    #[test]
+    fn test_focus_style_ne() {
+        assert_ne!(FocusStyle::Solid, FocusStyle::Rounded);
+        assert_ne!(FocusStyle::Double, FocusStyle::Dotted);
+        assert_ne!(FocusStyle::Bold, FocusStyle::Ascii);
+    }
+
+    #[test]
+    fn test_focus_style_clone() {
+        let style = FocusStyle::Rounded;
+        let cloned = style;
+        assert_eq!(cloned, FocusStyle::Rounded);
+    }
+
+    #[test]
+    fn test_focus_style_debug() {
+        let style = FocusStyle::Double;
+        let debug = format!("{:?}", style);
+        assert!(debug.contains("Double"));
+    }
+
+    #[test]
+    fn test_focus_style_copy() {
+        let style = FocusStyle::Bold;
+        let copied = style;
+        assert_eq!(style, copied);
+    }
+}

--- a/src/widget/traits/symbols.rs
+++ b/src/widget/traits/symbols.rs
@@ -72,3 +72,63 @@ impl Symbols {
     /// Double angle left
     pub const CHEVRON_LEFT: char = '«';
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_arrow_symbols() {
+        assert_eq!(Symbols::ARROW_LEFT, '←');
+        assert_eq!(Symbols::ARROW_RIGHT, '→');
+        assert_eq!(Symbols::ARROW_UP, '↑');
+        assert_eq!(Symbols::ARROW_DOWN, '↓');
+    }
+
+    #[test]
+    fn test_triangle_symbols() {
+        assert_eq!(Symbols::TRIANGLE_RIGHT, '▶');
+        assert_eq!(Symbols::TRIANGLE_DOWN, '▼');
+        assert_eq!(Symbols::TRIANGLE_SMALL_RIGHT, '▸');
+        assert_eq!(Symbols::TRIANGLE_SMALL_DOWN, '▾');
+    }
+
+    #[test]
+    fn test_checkbox_symbols() {
+        assert_eq!(Symbols::CHECKBOX_EMPTY, '☐');
+        assert_eq!(Symbols::CHECKBOX_CHECKED, '☑');
+        assert_eq!(Symbols::CHECKBOX_CROSSED, '☒');
+    }
+
+    #[test]
+    fn test_radio_symbols() {
+        assert_eq!(Symbols::RADIO_EMPTY, '○');
+        assert_eq!(Symbols::RADIO_SELECTED, '●');
+    }
+
+    #[test]
+    fn test_star_symbols() {
+        assert_eq!(Symbols::STAR_EMPTY, '☆');
+        assert_eq!(Symbols::STAR_FILLED, '★');
+    }
+
+    #[test]
+    fn test_block_symbols() {
+        assert_eq!(Symbols::BLOCK_FULL, '█');
+        assert_eq!(Symbols::BLOCK_3_4, '▓');
+        assert_eq!(Symbols::BLOCK_HALF, '▒');
+        assert_eq!(Symbols::BLOCK_1_4, '░');
+        assert_eq!(Symbols::BLOCK_EMPTY, '░');
+        assert_eq!(Symbols::BLOCK_LIGHT, '░');
+        assert_eq!(Symbols::BLOCK_MEDIUM, '▒');
+        assert_eq!(Symbols::BLOCK_DARK, '▓');
+    }
+
+    #[test]
+    fn test_separator_symbols() {
+        assert_eq!(Symbols::SEP_VERT, '│');
+        assert_eq!(Symbols::BULLET, '•');
+        assert_eq!(Symbols::CHEVRON_RIGHT, '»');
+        assert_eq!(Symbols::CHEVRON_LEFT, '«');
+    }
+}

--- a/src/widget/traits/view.rs
+++ b/src/widget/traits/view.rs
@@ -194,3 +194,440 @@ pub trait StyledView: View {
     /// Check if has class
     fn has_class(&self, class: &str) -> bool;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::Buffer;
+
+    // =========================================================================
+    // Test View Implementation
+    // =========================================================================
+
+    struct TestWidget {
+        id: Option<String>,
+        classes: Vec<String>,
+    }
+
+    impl TestWidget {
+        fn new() -> Self {
+            Self {
+                id: None,
+                classes: Vec::new(),
+            }
+        }
+
+        fn with_id(mut self, id: &str) -> Self {
+            self.id = Some(id.to_string());
+            self
+        }
+
+        fn with_class(mut self, class: &str) -> Self {
+            self.classes.push(class.to_string());
+            self
+        }
+    }
+
+    impl View for TestWidget {
+        fn render(&self, _ctx: &mut RenderContext) {
+            // No-op for testing
+        }
+
+        fn id(&self) -> Option<&str> {
+            self.id.as_deref()
+        }
+
+        fn classes(&self) -> &[String] {
+            &self.classes
+        }
+    }
+
+    // =========================================================================
+    // View Trait Tests
+    // =========================================================================
+
+    #[test]
+    fn test_view_widget_type() {
+        let widget = TestWidget::new();
+        let type_name = widget.widget_type();
+        assert!(type_name.contains("TestWidget"));
+    }
+
+    #[test]
+    fn test_view_id_none() {
+        let widget = TestWidget::new();
+        assert!(widget.id().is_none());
+    }
+
+    #[test]
+    fn test_view_id_some() {
+        let widget = TestWidget::new().with_id("my-widget");
+        assert_eq!(widget.id(), Some("my-widget"));
+    }
+
+    #[test]
+    fn test_view_classes_empty() {
+        let widget = TestWidget::new();
+        assert!(widget.classes().is_empty());
+    }
+
+    #[test]
+    fn test_view_classes_with_values() {
+        let widget = TestWidget::new().with_class("primary").with_class("active");
+        let classes = widget.classes();
+        assert_eq!(classes.len(), 2);
+        assert_eq!(classes[0], "primary");
+        assert_eq!(classes[1], "active");
+    }
+
+    #[test]
+    fn test_view_children_default() {
+        let widget = TestWidget::new();
+        assert!(widget.children().is_empty());
+    }
+
+    #[test]
+    fn test_view_meta_basic() {
+        let widget = TestWidget::new();
+        let meta = widget.meta();
+        assert!(meta.widget_type.contains("TestWidget"));
+        assert!(meta.id.is_none());
+        assert!(meta.classes.is_empty());
+    }
+
+    #[test]
+    fn test_view_meta_with_id() {
+        let widget = TestWidget::new().with_id("test-id");
+        let meta = widget.meta();
+        assert_eq!(meta.id, Some("test-id".to_string()));
+    }
+
+    #[test]
+    fn test_view_meta_with_classes() {
+        let widget = TestWidget::new().with_class("foo").with_class("bar");
+        let meta = widget.meta();
+        assert!(meta.classes.contains("foo"));
+        assert!(meta.classes.contains("bar"));
+    }
+
+    #[test]
+    fn test_view_render() {
+        let widget = TestWidget::new();
+        let mut buffer = Buffer::new(10, 5);
+        let area = Rect::new(0, 0, 10, 5);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+        widget.render(&mut ctx);
+        // Just verify it doesn't panic
+    }
+
+    // =========================================================================
+    // Box<dyn View> Tests
+    // =========================================================================
+
+    #[test]
+    fn test_boxed_view_widget_type() {
+        let widget: Box<dyn View> = Box::new(TestWidget::new());
+        assert!(widget.widget_type().contains("TestWidget"));
+    }
+
+    #[test]
+    fn test_boxed_view_id() {
+        let widget: Box<dyn View> = Box::new(TestWidget::new().with_id("boxed"));
+        assert_eq!(widget.id(), Some("boxed"));
+    }
+
+    #[test]
+    fn test_boxed_view_classes() {
+        let widget: Box<dyn View> = Box::new(TestWidget::new().with_class("test"));
+        assert_eq!(widget.classes().len(), 1);
+        assert_eq!(widget.classes()[0], "test");
+    }
+
+    #[test]
+    fn test_boxed_view_children() {
+        let widget: Box<dyn View> = Box::new(TestWidget::new());
+        assert!(widget.children().is_empty());
+    }
+
+    #[test]
+    fn test_boxed_view_meta() {
+        let widget: Box<dyn View> =
+            Box::new(TestWidget::new().with_id("box-id").with_class("box-class"));
+        let meta = widget.meta();
+        assert_eq!(meta.id, Some("box-id".to_string()));
+        assert!(meta.classes.contains("box-class"));
+    }
+
+    #[test]
+    fn test_boxed_view_render() {
+        let widget: Box<dyn View> = Box::new(TestWidget::new());
+        let mut buffer = Buffer::new(10, 5);
+        let area = Rect::new(0, 0, 10, 5);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+        widget.render(&mut ctx);
+    }
+
+    // =========================================================================
+    // Interactive Trait Tests
+    // =========================================================================
+
+    struct TestInteractive {
+        focused: bool,
+        focusable: bool,
+    }
+
+    impl TestInteractive {
+        fn new() -> Self {
+            Self {
+                focused: false,
+                focusable: true,
+            }
+        }
+
+        fn non_focusable() -> Self {
+            Self {
+                focused: false,
+                focusable: false,
+            }
+        }
+    }
+
+    impl View for TestInteractive {
+        fn render(&self, _ctx: &mut RenderContext) {}
+    }
+
+    impl Interactive for TestInteractive {
+        fn focusable(&self) -> bool {
+            self.focusable
+        }
+
+        fn on_focus(&mut self) {
+            self.focused = true;
+        }
+
+        fn on_blur(&mut self) {
+            self.focused = false;
+        }
+    }
+
+    #[test]
+    fn test_interactive_handle_key_default() {
+        use crate::event::Key;
+        let mut widget = TestInteractive::new();
+        let event = KeyEvent::new(Key::Enter);
+        let result = widget.handle_key(&event);
+        assert_eq!(result, EventResult::Ignored);
+    }
+
+    #[test]
+    fn test_interactive_handle_mouse_default() {
+        use crate::event::MouseEventKind;
+        let mut widget = TestInteractive::new();
+        let event = MouseEvent::new(5, 5, MouseEventKind::Move);
+        let area = Rect::new(0, 0, 10, 5);
+        let result = widget.handle_mouse(&event, area);
+        assert_eq!(result, EventResult::Ignored);
+    }
+
+    #[test]
+    fn test_interactive_focusable_true() {
+        let widget = TestInteractive::new();
+        assert!(widget.focusable());
+    }
+
+    #[test]
+    fn test_interactive_focusable_false() {
+        let widget = TestInteractive::non_focusable();
+        assert!(!widget.focusable());
+    }
+
+    #[test]
+    fn test_interactive_on_focus() {
+        let mut widget = TestInteractive::new();
+        assert!(!widget.focused);
+        widget.on_focus();
+        assert!(widget.focused);
+    }
+
+    #[test]
+    fn test_interactive_on_blur() {
+        let mut widget = TestInteractive::new();
+        widget.on_focus();
+        assert!(widget.focused);
+        widget.on_blur();
+        assert!(!widget.focused);
+    }
+
+    // =========================================================================
+    // Draggable Trait Tests
+    // =========================================================================
+
+    struct TestDraggable {
+        can_drag: bool,
+        can_drop: bool,
+        accepted_types: Vec<&'static str>,
+    }
+
+    impl TestDraggable {
+        fn new() -> Self {
+            Self {
+                can_drag: false,
+                can_drop: false,
+                accepted_types: Vec::new(),
+            }
+        }
+
+        fn draggable() -> Self {
+            Self {
+                can_drag: true,
+                can_drop: false,
+                accepted_types: Vec::new(),
+            }
+        }
+
+        fn droppable(types: Vec<&'static str>) -> Self {
+            Self {
+                can_drag: false,
+                can_drop: true,
+                accepted_types: types,
+            }
+        }
+    }
+
+    impl View for TestDraggable {
+        fn render(&self, _ctx: &mut RenderContext) {}
+    }
+
+    impl Draggable for TestDraggable {
+        fn can_drag(&self) -> bool {
+            self.can_drag
+        }
+
+        fn can_drop(&self) -> bool {
+            self.can_drop
+        }
+
+        fn accepted_types(&self) -> &[&'static str] {
+            &self.accepted_types
+        }
+    }
+
+    #[test]
+    fn test_draggable_can_drag_default() {
+        let widget = TestDraggable::new();
+        assert!(!widget.can_drag());
+    }
+
+    #[test]
+    fn test_draggable_can_drag_enabled() {
+        let widget = TestDraggable::draggable();
+        assert!(widget.can_drag());
+    }
+
+    #[test]
+    fn test_draggable_drag_data_default() {
+        let widget = TestDraggable::new();
+        assert!(widget.drag_data().is_none());
+    }
+
+    #[test]
+    fn test_draggable_drag_preview_default() {
+        let widget = TestDraggable::new();
+        assert!(widget.drag_preview().is_none());
+    }
+
+    #[test]
+    fn test_draggable_on_drag_start() {
+        let mut widget = TestDraggable::draggable();
+        widget.on_drag_start();
+        // Just verify it doesn't panic
+    }
+
+    #[test]
+    fn test_draggable_on_drag_end() {
+        let mut widget = TestDraggable::draggable();
+        widget.on_drag_end(DropResult::Accepted);
+        widget.on_drag_end(DropResult::Cancelled);
+        // Just verify it doesn't panic
+    }
+
+    #[test]
+    fn test_draggable_can_drop_default() {
+        let widget = TestDraggable::new();
+        assert!(!widget.can_drop());
+    }
+
+    #[test]
+    fn test_draggable_can_drop_enabled() {
+        let widget = TestDraggable::droppable(vec!["text"]);
+        assert!(widget.can_drop());
+    }
+
+    #[test]
+    fn test_draggable_accepted_types_empty() {
+        let widget = TestDraggable::new();
+        assert!(widget.accepted_types().is_empty());
+    }
+
+    #[test]
+    fn test_draggable_accepted_types_with_values() {
+        let widget = TestDraggable::droppable(vec!["text", "file"]);
+        let types = widget.accepted_types();
+        assert_eq!(types.len(), 2);
+        assert!(types.contains(&"text"));
+        assert!(types.contains(&"file"));
+    }
+
+    #[test]
+    fn test_draggable_can_accept_empty_types() {
+        let widget = TestDraggable::droppable(vec![]);
+        let data = DragData::text("anything");
+        // Empty types means accept all
+        assert!(widget.can_accept(&data));
+    }
+
+    #[test]
+    fn test_draggable_can_accept_matching_type() {
+        let widget = TestDraggable::droppable(vec!["text", "file"]);
+        let data = DragData::text("test-text");
+        assert!(widget.can_accept(&data));
+    }
+
+    #[test]
+    fn test_draggable_can_accept_non_matching_type() {
+        let widget = TestDraggable::droppable(vec!["text", "file"]);
+        let data = DragData::new("image", "image-data");
+        assert!(!widget.can_accept(&data));
+    }
+
+    #[test]
+    fn test_draggable_on_drag_enter() {
+        let mut widget = TestDraggable::droppable(vec!["text"]);
+        let data = DragData::text("test-text");
+        widget.on_drag_enter(&data);
+        // Just verify it doesn't panic
+    }
+
+    #[test]
+    fn test_draggable_on_drag_leave() {
+        let mut widget = TestDraggable::droppable(vec!["text"]);
+        widget.on_drag_leave();
+        // Just verify it doesn't panic
+    }
+
+    #[test]
+    fn test_draggable_on_drop_default() {
+        let mut widget = TestDraggable::droppable(vec!["text"]);
+        let data = DragData::text("test-text");
+        let accepted = widget.on_drop(data);
+        assert!(!accepted);
+    }
+
+    #[test]
+    fn test_draggable_drop_bounds() {
+        let widget = TestDraggable::new();
+        let area = Rect::new(10, 20, 30, 40);
+        let bounds = widget.drop_bounds(area);
+        assert_eq!(bounds, area);
+    }
+}


### PR DESCRIPTION
## Summary

- Add comprehensive test coverage across multiple modules
- Total: 4852 tests passing (+122 new tests)
- All clippy checks pass

## Files Changed

### Plugin System
- `plugin/traits.rs`: lifecycle, styles, priority, unmount tests
- `plugin/builtin.rs`: LoggerPlugin, PerformancePlugin builders, FPS stats
- `plugin/context.rs`: default, running state, remove data, logging

### Testing Framework
- `testing/actions.rs`: Action variants, constructors, ActionSequence

### Core Modules
- `patterns/colors.rs`: RGB values, semantic aliases, border colors
- `dom/node.rs`: WidgetMeta, NodeState, DomId, DomNode, pseudo-class matching
- `render/backend/traits.rs`: BackendCapabilities

### Widget Traits
- `widget/traits/view.rs`: View, Interactive, Draggable traits
- `widget/traits/element.rs`: Element enum
- `widget/traits/event.rs`: EventResult, FocusStyle
- `widget/traits/symbols.rs`: UI symbols
- `widget/traits/render_context.rs`: drawing utilities
- `widget/traits/widget_state.rs`: WidgetProps, WidgetState

### Widgets
- `widget/streamline.rs`: builders, layers, stacks, ordering
- `widget/tree.rs`: expand/collapse, search, rendering
- `widget/tabs.rs`: colors, dividers, key handling
- `widget/accordion.rs`: collapse, multi-expand, colors
- `widget/autocomplete.rs`: filter modes, key handling
- `widget/breadcrumb.rs`: colors, width calculation

### DevTools
- `devtools/events.rs`: EventType, EventFilter, EventLogger
- `devtools/state.rs`: StateValue, StateDebugger

## Test plan
- [x] All 4852 tests pass
- [x] Clippy clean
- [x] Code formatted