### PR TITLE
fix: replace panics with proper error handling and fix flaky tests

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -48,17 +48,32 @@ pre-push:
         if [ -n "$CHANGED" ]; then
           echo "Testing changed files:"
           echo "$CHANGED"
-          # Run specific test targets based on changed files
-          if echo "$CHANGED" | grep -q "^tests/"; then
-            TEST_NAMES=$(echo "$CHANGED" | grep "^tests/" | sed 's/tests\///' | sed 's/\.rs$//' | tr '\n' ' ')
-            if [ -n "$TEST_NAMES" ]; then
-              echo "Running test targets: $TEST_NAMES"
-              cargo test --test $TEST_NAMES --all-features
-            fi
-          else
-            # For src/ changes, run lib tests
-            echo "Running library tests"
-            cargo test --lib --all-features
+          # Map test file paths to actual test targets
+          TEST_TARGETS=()
+          if echo "$CHANGED" | grep -q "^tests/widget/"; then
+            TEST_TARGETS+=("--test" "widget_tests")
+          fi
+          if echo "$CHANGED" | grep -q "^tests/reactive"; then
+            TEST_TARGETS+=("--test" "reactive_tests")
+          fi
+          if echo "$CHANGED" | grep -q "^tests/worker"; then
+            TEST_TARGETS+=("--test" "worker_tests")
+          fi
+          if echo "$CHANGED" | grep -q "^tests/event"; then
+            TEST_TARGETS+=("--test" "event_tests")
+          fi
+          # Other test files
+          OTHER_TESTS=$(echo "$CHANGED" | grep "^tests/" | grep -v "^tests/widget/" | grep -v "^tests/reactive" | grep -v "^tests/worker" | grep -v "^tests/event" | sed 's/tests\///' | sed 's/\.rs$//' | sed 's/$/_tests/' | tr '\n' ' ' | tr -s ' ')
+          for test in $OTHER_TESTS; do
+            TEST_TARGETS+=("--test" "$test")
+          done
+          if echo "$CHANGED" | grep -q "^src/"; then
+            # For src/ changes, run lib tests too
+            TEST_TARGETS+=("--lib")
+          fi
+          if [ ${#TEST_TARGETS[@]} -gt 0 ]; then
+            echo "Running test targets: ${TEST_TARGETS[*]}"
+            cargo test "${TEST_TARGETS[@]}" --all-features
           fi
         else
           echo "No Rust files changed, skipping tests"

--- a/tests/reactive/computed.rs
+++ b/tests/reactive/computed.rs
@@ -138,7 +138,8 @@ fn test_computed_no_data_race_on_concurrent_recompute() {
 
     let computed = Arc::new(Computed::new(move || {
         call_count_clone.fetch_add(1, Ordering::SeqCst);
-        std::thread::sleep(Duration::from_micros(100));
+        // Use longer duration to ensure concurrent access on all systems
+        std::thread::sleep(Duration::from_millis(5));
         42
     }));
 

--- a/tests/widget/debug_overlay.rs
+++ b/tests/widget/debug_overlay.rs
@@ -272,9 +272,9 @@ fn test_perf_metrics_start_frame() {
 fn test_perf_metrics_multiple_frames() {
     let mut metrics = PerfMetrics::new();
 
-    // Simulate frame timing
+    // Simulate frame timing - use longer duration for reliability
     metrics.start_frame();
-    std::thread::sleep(Duration::from_millis(10));
+    std::thread::sleep(Duration::from_millis(50));
     metrics.start_frame();
 
     // Should have recorded a frame time
@@ -876,7 +876,7 @@ fn test_perf_metrics_single_frame() {
     let mut metrics = PerfMetrics::new();
 
     metrics.start_frame();
-    std::thread::sleep(Duration::from_millis(10));
+    std::thread::sleep(Duration::from_millis(50));
     metrics.start_frame();
 
     assert!(metrics.avg_frame_time_ms() > 0.0);


### PR DESCRIPTION
## Summary
- Replace panic-causing `.expect()` calls with proper `Result` error handling in critical paths
- Fix flaky tests by replacing hardcoded sleeps with polling-based timeout checking
- Optimize CI to run only changed tests on PRs, full tests daily
- Add auto-issue creation for failed daily tests

## Changes

### Critical Bug Fixes (#230-#236)
- `src/worker/mod.rs`: Handle tokio runtime creation errors gracefully
- `src/worker/handle.rs`: Return Result instead of panicking on runtime errors
- `src/app/mod.rs`: Handle missing root DOM node gracefully
- `src/reactive/computed.rs`: Return Option instead of panicking on empty cache

### Flaky Test Fixes (#234)
- `tests/worker/handle.rs`: Add `poll_until` helper, replace 5+ sleeps
- `tests/worker/pool.rs`: Add `poll_until` helper, replace 11 sleeps
- `tests/widget/timer.rs`: Replace 8 hardcoded sleeps with polling
- `tests/reactive/async_state.rs`: Fix 9 timing-dependent sleeps
- `tests/widget/debug_overlay.rs`: Increase timing for reliability
- `tests/event/gesture.rs`: Add polling for long press test
- `tests/reactive/computed.rs`: Increase concurrent test timing
- `tests/reactive_edge/concurrent.rs`: Add `#[serial]` attribute

### CI/CD Improvements
- `.github/workflows/ci.yml`: Run only changed tests on PRs, full suite daily
- `.github/workflows/ci.yml`: Add auto-issue creation for failed daily tests
- `lefthook.yml`: Fix pre-push test target mapping and command formatting

## Test Plan
- [x] All worker tests pass
- [x] Timer tests pass (103 tests)
- [x] Reactive tests pass
- [x] Event/gesture tests pass
- [x] Pre-push hook runs correct test targets

## Related Issues
Fixes #230, #231, #232, #233, #234, #235, #236