### PR TITLE
test(reactive): replace hardcoded sleep with poll_until in async_state test

### DIFF
--- a/tests/reactive/async_state.rs
+++ b/tests/reactive/async_state.rs
@@ -207,7 +207,8 @@ fn test_use_async_poll_start_from_different_thread() {
     });
     start_thread.join().expect("start thread should not panic");
 
-    thread::sleep(Duration::from_millis(5));
+    // Wait for async operation to enter loading state (with timeout)
+    let _ = poll_until(|| state.get().is_loading(), 100);
     assert!(state.get().is_loading());
 
     // Wait for async operation to complete (up to 500ms)


### PR DESCRIPTION
## Summary

Fixes flaky async state test by replacing hardcoded `thread::sleep(5ms)` with proper `poll_until()` call.

## Changes

- **File**: `tests/reactive/async_state.rs`
- **Test**: `test_use_async_poll_start_from_different_thread`
- **Fix**: Replaced hardcoded 5ms sleep with `poll_until(|| state.get().is_loading(), 100)`

## Problem

The test used a hardcoded `thread::sleep(Duration::from_millis(5))` before checking `is_loading()` state. This assumed the async operation would be in loading state after exactly 5ms, which could fail on:
- Slow systems
- Systems under high load
- CI environments with variable scheduler delays

## Solution

Use `poll_until()` with a 100ms timeout to properly poll for the loading state instead of assuming a fixed delay is sufficient. This makes the test:
- More reliable across different system loads
- Self-documenting (explicitly waits for condition)
- Still fast (completes immediately when condition is met)

Fixes #234