### PR TITLE
docs(worker): add comprehensive safety documentation for unsafe waker

### DIFF
--- a/src/worker/handle.rs
+++ b/src/worker/handle.rs
@@ -183,9 +183,13 @@ impl<T: Send + 'static> WorkerHandle<T> {
             }
 
             // Simple polling executor
-            // SAFETY: RawWaker vtable is properly configured with no-op functions
-            // (clone, wake, wake_by_ref, drop). The waker is only used for polling
-            // and never actually wakes anything - this is a busy-polling executor.
+            // SAFETY:
+            // - The vtable functions are all no-ops that don't access any data
+            // - RawWaker is created with a null pointer since no data is needed
+            // - The waker is only used as a placeholder for Context
+            // - We never call wake() or wake_by_ref() on this waker
+            // - Only clone() and drop() are called, which are safe no-ops
+            // - This is a busy-polling executor that never actually needs to wake anything
             let waker = unsafe { Waker::from_raw(dummy_raw_waker()) };
             let mut cx = Context::from_waker(&waker);
             let mut future = Box::pin(future);


### PR DESCRIPTION
## Summary

Add comprehensive safety documentation for the unsafe waker creation in the worker handle's polling executor.

## Changes

- **File**: `src/worker/handle.rs`
- **Location**: Line 186-192
- **Change**: Expand SAFETY comment with detailed invariants

## Documentation Added

The SAFETY comment now explains:
1. Vtable functions are no-ops that don't access any data
2. RawWaker uses null pointer (no data is needed)
3. Waker is only used as a placeholder for Context
4. wake() and wake_by_ref() are never called on this waker
5. Only clone() and drop() are called, which are safe no-ops
6. This is a busy-polling executor that never needs to wake anything

## Why This Matters

Unsafe code requires clear documentation explaining:
- What invariants are being upheld
- Why the operation is safe in this context  
- What could go wrong if assumptions change

This makes the code easier to audit and maintain.

Fixes #238