### PR TITLE
docs: add constructor pattern standard documentation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,3 +22,4 @@ jobs:
         run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          REVUE_RELEASE: "1"

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,9 @@ use std::env;
 use std::process::Command;
 
 fn main() {
+    // Read version from Cargo.toml
+    let version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "unknown".to_string());
+
     // Always append SHA for development builds
     let is_release_build = env::var("REVUE_RELEASE").is_ok();
 
@@ -14,7 +17,7 @@ fn main() {
             if let Ok(sha_str) = String::from_utf8(sha.stdout) {
                 let sha = sha_str.trim();
                 if !sha.is_empty() {
-                    println!("cargo:rustc-env=REVUE_VERSION=2.33.4-{}", sha);
+                    println!("cargo:rustc-env=REVUE_VERSION={}-{}", version, sha);
                     println!("cargo:rustc-env=GIT_SHA={}", sha);
                     println!("cargo:rustc-env=REVUE_IS_DEV=true");
                 }
@@ -22,7 +25,7 @@ fn main() {
         }
     } else {
         // Release build: use version from Cargo.toml as-is
-        println!("cargo:rustc-env=REVUE_VERSION=2.33.4");
+        println!("cargo:rustc-env=REVUE_VERSION={}", version);
         println!("cargo:rustc-env=GIT_SHA=");
         println!("cargo:rustc-env=REVUE_IS_DEV=false");
     }

--- a/src/widget/mermaid/types.rs
+++ b/src/widget/mermaid/types.rs
@@ -19,18 +19,18 @@ pub enum DiagramType {
 /// Node shape
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum NodeShape {
-    /// Rectangle [text]
+    /// Rectangle `[text]` (Mermaid syntax)
     #[default]
     Rectangle,
-    /// Rounded rectangle (text)
+    /// Rounded rectangle `(text)` (Mermaid syntax)
     Rounded,
-    /// Diamond {text}
+    /// Diamond `{text}` (Mermaid syntax)
     Diamond,
-    /// Circle ((text))
+    /// Circle `((text))` (Mermaid syntax)
     Circle,
-    /// Parallelogram /text/
+    /// Parallelogram `/text/` (Mermaid syntax)
     Parallelogram,
-    /// Database [(text)]
+    /// Database `[(text)]` (Mermaid syntax)
     Database,
 }
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -127,6 +127,59 @@
 //!     .child(ui);
 //! ```
 //!
+//! # Constructor Pattern
+//!
+//! Revue uses a **hybrid constructor pattern** to balance ergonomics and clarity:
+//!
+//! ## Function-Style (Simple Widgets)
+//!
+//! Widgets with fewer than 5 configuration options use function-style constructors:
+//!
+//! ```rust,ignore
+//! use revue::prelude::*;
+//!
+//! // Simple, single-purpose widgets
+//! let btn = button("Click me");
+//! let chk = checkbox("Enable");
+//! let txt = text("Hello");
+//! let badge = badge("New");
+//! let divider = divider();
+//! ```
+//!
+//! **Benefits**: Concise, chainable, IDE-friendly autocomplete.
+//!
+//! ## Builder-Style (Complex Widgets)
+//!
+//! Widgets with 5+ configuration options use builder-style:
+//!
+//! ```rust,ignore
+//! use revue::prelude::*;
+//!
+//! // Complex widgets with many options
+//! let grid = DataGrid::builder()
+//!     .columns(vec![/* ... */])
+//!     .data(&data)
+//!     .selectable(true)
+//!     .sortable(true)
+//!     .build();
+//! ```
+//!
+//! **Benefits**: Clear option names, handles complex configuration well.
+//!
+//! ## Creating New Widgets
+//!
+//! When adding new widgets, follow this guideline:
+//!
+//! | Config Options | Pattern | Example |
+//! |----------------|---------|---------|
+//! | < 5 | Function-style | `button()`, `text()` |
+//! | >= 5 | Builder-style | `DataGrid::builder()` |
+//!
+//! ## Transition Period
+//!
+//! Some widgets may have both patterns during migration. Prefer function-style
+//! for simple widgets, but `Widget::new()` remains valid for all widgets.
+//!
 //! # Creating Custom Widgets
 //!
 //! Implement the [`View`] trait to create custom widgets:


### PR DESCRIPTION
## Summary

Add documentation for the **hybrid constructor pattern** and fix version handling issues:

1. Add "Constructor Pattern" section to widget module documentation
2. Fix broken intra-doc links in `mermaid/types.rs`
3. Fix `build.rs` to read version from `CARGO_PKG_VERSION` instead of hardcoding
4. Set `REVUE_RELEASE=1` in publish workflow for clean release versions

## Changes

### Documentation
- Add "Constructor Pattern" section to `src/widget/mod.rs` explaining:
  - Function-style for simple widgets (< 5 config options)
  - Builder-style for complex widgets (>= 5 config options)
- Fix doc comments in `src/widget/mermaid/types.rs` (use backticks for Mermaid syntax)

### Build System Fixes
- `build.rs`: Use `CARGO_PKG_VERSION` instead of hardcoded `2.33.4`
- `.github/workflows/publish.yml`: Set `REVUE_RELEASE=1` for release builds

This ensures:
- Development builds include SHA: `2.34.1-abc1234`
- Release builds have clean versions: `2.34.1`

## Guidelines

When adding new widgets, follow this pattern:

| Config Options | Pattern | Example |
|----------------|---------|---------|
| < 5 | Function-style | `button()`, `text()` |
| >= 5 | Builder-style | `DataGrid::builder()` |

Partially addresses #251 (documentation portion)