### PR TITLE
fix(safety,image,a11y,publish): safety improvements and publishing fixes

### DIFF
--- a/.github/docs.rs
+++ b/.github/docs.rs
@@ -1,0 +1,4 @@
+[build.rs]
+# Don't run build.rs in docs.rs - it sets env vars that may not work
+# This is needed because our lib.rs uses env!() for VERSION, GIT_SHA, etc.
+skip-build = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 keywords = ["tui", "terminal", "css", "reactive", "ui"]
 categories = ["command-line-interface", "gui"]
 include = [
+    "build.rs",
     "src/**/*.rs",
     "src/style/themes/*.css",
     "Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["tui", "terminal", "css", "reactive", "ui"]
 categories = ["command-line-interface", "gui"]
 include = [
     "src/**/*.rs",
+    "src/style/themes/*.css",
     "Cargo.toml",
     "LICENSE*",
     "README.md",

--- a/build.rs
+++ b/build.rs
@@ -1,32 +1,38 @@
 use std::env;
-use std::process::Command;
 
 fn main() {
     // Read version from Cargo.toml
     let version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "unknown".to_string());
 
-    // Always append SHA for development builds
+    // Check if this is a release build (for crates.io publishing)
     let is_release_build = env::var("REVUE_RELEASE").is_ok();
 
-    if !is_release_build {
-        let output = Command::new("git")
-            .args(["rev-parse", "--short", "HEAD"])
-            .output();
-
-        if let Ok(sha) = output {
-            if let Ok(sha_str) = String::from_utf8(sha.stdout) {
-                let sha = sha_str.trim();
-                if !sha.is_empty() {
-                    println!("cargo:rustc-env=REVUE_VERSION={}-{}", version, sha);
-                    println!("cargo:rustc-env=GIT_SHA={}", sha);
-                    println!("cargo:rustc-env=REVUE_IS_DEV=true");
-                }
-            }
-        }
-    } else {
+    if is_release_build {
         // Release build: use version from Cargo.toml as-is
         println!("cargo:rustc-env=REVUE_VERSION={}", version);
         println!("cargo:rustc-env=GIT_SHA=");
         println!("cargo:rustc-env=REVUE_IS_DEV=false");
+    } else {
+        // Development build: try to get git SHA
+        let output = std::process::Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .output();
+
+        let sha = output
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        if let Some(sha) = sha {
+            println!("cargo:rustc-env=REVUE_VERSION={}-{}", version, sha);
+            println!("cargo:rustc-env=GIT_SHA={}", sha);
+            println!("cargo:rustc-env=REVUE_IS_DEV=true");
+        } else {
+            // Fallback when git is not available (e.g., crates.io build)
+            println!("cargo:rustc-env=REVUE_VERSION={}", version);
+            println!("cargo:rustc-env=GIT_SHA=");
+            println!("cargo:rustc-env=REVUE_IS_DEV=false");
+        }
     }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,9 @@
       "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
       "versioning": "default",
-      "extra-files": []
+      "extra-files": [
+        "Cargo.toml"
+      ]
     }
   },
   "changelog-sections": [

--- a/src/a11y/backend/core.rs
+++ b/src/a11y/backend/core.rs
@@ -3,6 +3,7 @@
 use super::platform::{LinuxBackend, LoggingBackend, MacOSBackend, NullBackend, WindowsBackend};
 use super::types::{BackendType, ScreenReader, ScreenReaderConfig};
 use crate::utils::accessibility::Priority;
+use crate::utils::lock::write_or_recover;
 use std::sync::RwLock;
 
 /// Main screen reader backend
@@ -58,7 +59,7 @@ impl ScreenReaderBackend {
         // Debounce check
         if self.config.debounce_ms > 0 {
             let now = std::time::Instant::now();
-            let mut last = self.last_announcement.write().unwrap();
+            let mut last = write_or_recover(&self.last_announcement);
 
             if let Some(last_time) = *last {
                 let elapsed = now.duration_since(last_time).as_millis() as u64;

--- a/src/a11y/backend/platform.rs
+++ b/src/a11y/backend/platform.rs
@@ -1,6 +1,7 @@
 //! Screen reader backend - platform-specific implementations
 
 use crate::utils::accessibility::Priority;
+use crate::utils::lock::{read_or_recover, write_or_recover};
 use std::sync::{Arc, RwLock};
 
 use super::types::ScreenReader;
@@ -231,17 +232,17 @@ impl LoggingBackend {
 
     /// Get all logged announcements
     pub fn announcements(&self) -> Vec<LoggedAnnouncement> {
-        self.announcements.read().unwrap().clone()
+        read_or_recover(&self.announcements).clone()
     }
 
     /// Clear logged announcements
     pub fn clear(&self) {
-        self.announcements.write().unwrap().clear();
+        write_or_recover(&self.announcements).clear();
     }
 
     /// Get the last announcement
     pub fn last(&self) -> Option<LoggedAnnouncement> {
-        self.announcements.read().unwrap().last().cloned()
+        read_or_recover(&self.announcements).last().cloned()
     }
 }
 
@@ -259,7 +260,7 @@ impl ScreenReader for LoggingBackend {
             timestamp: std::time::Instant::now(),
         };
 
-        self.announcements.write().unwrap().push(announcement);
+        write_or_recover(&self.announcements).push(announcement);
 
         // Also print to stderr for visibility
         let priority_str = match priority {

--- a/src/widget/chart/chart_stats.rs
+++ b/src/widget/chart/chart_stats.rs
@@ -45,7 +45,8 @@ pub fn median(data: &[f64]) -> Option<f64> {
     if valid.is_empty() {
         return None;
     }
-    valid.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    // Safe: filter_finite() removes NaN, so partial_cmp always returns Some
+    valid.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let mid = valid.len() / 2;
     if valid.len().is_multiple_of(2) {
         Some((valid[mid - 1] + valid[mid]) / 2.0)
@@ -60,7 +61,8 @@ pub fn quartiles(data: &[f64]) -> Option<(f64, f64, f64)> {
     if valid.is_empty() {
         return None;
     }
-    valid.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    // Safe: filter_finite() removes NaN, so partial_cmp always returns Some
+    valid.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
     let q1 = percentile(&valid, 25.0);
     let med = percentile(&valid, 50.0);
@@ -91,7 +93,8 @@ pub fn outliers_iqr(data: &[f64]) -> Vec<f64> {
     if valid.is_empty() {
         return Vec::new();
     }
-    valid.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    // Safe: filter_finite() removes NaN, so partial_cmp always returns Some
+    valid.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
     let q1 = percentile(&valid, 25.0);
     let q3 = percentile(&valid, 75.0);


### PR DESCRIPTION
## Summary

Fixes version mismatch between GitHub release v2.36.1 and Cargo.toml 2.36.0.

Also includes multiple safety improvements and fixes for crates.io publishing.

### ✅ Version Sync
- Update .release-please-manifest.json: 2.36.0 -> 2.36.1
- Update Cargo.toml: 2.36.0 -> 2.36.1
- Add Cargo.toml to release-please extra-files for auto-update

### ✅ #292 - Fix partial_cmp().unwrap() in chart stats
- widget/chart/chart_stats.rs: Use unwrap_or(Ordering::Equal)
- Document NaN-free invariant after filter_finite()

### ✅ #291 - Replace lock().unwrap() with recovery helpers  
- a11y/backend/platform.rs: Use read_or_recover/write_or_recover
- a11y/backend/core.rs: Use write_or_recover
- Prevents panic on poisoned locks

### ✅ #288 - Add error logging for PNG encode/decode
- image_protocol.rs: Log PNG encoding failures
- image_protocol.rs: Log PNG decoding failures
- Better debugging for image operations

### ✅ #287 - Add REVUE_IMAGE_PROTOCOL environment variable
- ImageProtocol::detect(): Check REVUE_IMAGE_PROTOCOL first
- Supports: kitty, iterm2, sixel, none
- Allows user override for debugging/compatibility

### ✅ crates.io Publishing Fixes
- build.rs: Add fallback when git unavailable
- Cargo.toml: Include build.rs and CSS theme files
- Set REVUE_IS_DEV=false when git SHA unavailable

### ✅ docs.rs Build Fix
- Add .github/docs.rs: Skip build.rs for documentation builds
- Fixes env!() errors in docs.rs environment

## Impact

- **Version Sync**: GitHub release and Cargo.toml now match at v2.36.1
- **Safety**: No more panics from poisoned locks or partial_cmp
- **Usability**: Users can override image protocol detection
- **Publishing**: Library can now be published to crates.io
- **Documentation**: docs.rs builds will work correctly
- **Automation**: Cargo.toml will auto-update with future releases

## Test Results

### crates.io
``\bash
cargo publish --dry-run
Packaged 1050 files, 8.4MiB (1.4MiB compressed)
Verifying revue v2.36.1
Finished dev profile target(s)
✅ SUCCESS
```

## Checklist
- [x] Version synced with GitHub release
- [x] All tests pass
- [x] No clippy warnings
- [x] Formatted with cargo fmt
- [x] cargo publish --dry-run succeeds
- [x] docs.rs configuration added
- [x] Commit messages follow conventional commits

Closes #287, #288, #291, #292