### PR TITLE
fix(macosros): add publish=false and sync version

### DIFF
--- a/revue-macros/Cargo.toml
+++ b/revue-macros/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "revue-macros"
-version = "2.36.0"
+version = "2.37.0"
 edition = "2021"
 rust-version = "1.87"
+publish = false
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This PR fixes the crates.io publishing failure by:
- Adding `publish = false` to revue-macros
- Syncing version to 2.37.0

Tested with `cargo publish --dry-run`.