### PR TITLE
fix: add workspace configuration for revue-macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = ["revue-macros"]
+resolver = "2"
+
 [package]
 name = "revue"
 version = "2.37.0"

--- a/revue-macros/Cargo.toml
+++ b/revue-macros/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "revue-macros"
-version = "2.36.0"
+version = "2.37.0"
 edition = "2021"
 rust-version = "1.87"
+publish = false
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This PR fixes the crates.io publishing failure by adding workspace configuration.

**Changes:**
- Add  with  as member
- revue-macros has `publish = false`
- Workspace properly handles internal path dependencies during publish

**Error before:**
revue-macros

This ensures revue-macros is not published separately to crates.io.