### PR TITLE
perf(text): remove per-character allocation in justified text

### DIFF
--- a/src/widget/display/text.rs
+++ b/src/widget/display/text.rs
@@ -198,7 +198,7 @@ impl Text {
     /// Render text with justify alignment (distribute space between words)
     fn render_justified(&self, ctx: &mut RenderContext) {
         use crate::render::{Cell, Modifier};
-        use unicode_width::UnicodeWidthStr;
+        use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
         let area = ctx.area;
         let words: Vec<&str> = self.content.split_whitespace().collect();
@@ -255,7 +255,7 @@ impl Text {
                 cell.bg = self.bg;
                 cell.modifier = modifier;
                 ctx.buffer.set(x, area.y, cell);
-                x += UnicodeWidthStr::width(ch.to_string().as_str()) as u16;
+                x += UnicodeWidthChar::width(ch).unwrap_or(0) as u16;
             }
 
             // Add spacing after word (except last word)


### PR DESCRIPTION
## Summary

Fixes unnecessary String allocation for each character when rendering justified text.

## Problem

In `src/widget/display/text.rs:258`, the code was:
```rust
x += UnicodeWidthStr::width(ch.to_string().as_str()) as u16;
```

This creates a new `String` for every character just to measure its width. For a line with 80 characters, that's 80 unnecessary allocations.

## Solution

Use `UnicodeWidthChar::width(ch)` which measures a `char` directly:
```rust
x += UnicodeWidthChar::width(ch).unwrap_or(0) as u16;
```

## Impact

- **Before**: O(n) String allocations per line
- **After**: Zero additional allocations for width calculation
- **Benefit**: Reduced memory pressure and GC overhead, especially for long text lines

## Files Changed

- `src/widget/display/text.rs`: Added `UnicodeWidthChar` import, replaced `to_string()` call