### PR TITLE
feat(utils): add Once utility for one-shot execution

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,9 +67,22 @@ When using Revue in your applications:
 
 Revue includes several security features:
 
-- No unsafe code in core library (where possible)
-- Input sanitization for text widgets
-- Memory-safe Rust implementation
-- Regular dependency audits via `cargo-deny`
+- **No unsafe code** in core library (where possible)
+- **Input sanitization** for text widgets
+- **Memory-safe Rust** implementation
+- **Regular dependency audits** via `cargo-deny`
+- **Command injection protection** for accessibility backends (macOS osascript, Windows PowerShell)
+- **Path traversal validation** in FilePicker to prevent directory escape attacks
+- **Shell escaping utilities** (`escape_applescript()`, `escape_powershell()`) for safe command execution
+
+### Recent Security Fixes
+
+- **v2.43.1** (PR #340): Fixed command injection in accessibility backends
+  - macOS osascript commands now properly escape quotes, backslashes, and control characters
+  - Windows PowerShell commands use single-quote escaping for safe parameter passing
+- **v2.43.0** (PR #337): Hardened FilePicker security validation
+  - Added validation to prevent path traversal attacks (e.g., `../`, absolute paths)
+  - Windows reserved name detection (CON, PRN, AUX, NUL, COM*, LPT*)
+  - Empty path component detection
 
 Thank you for helping keep Revue and its users safe!

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -38,6 +38,7 @@
 //! | [`lock`] | Lock utilities for consistent poison handling |
 //! | [`shell`] | Shell-safe string escaping |
 //! | [`debounce`] | Debounce and throttle utilities for events |
+//! | [`mod@once`] | One-shot execution utility (call only once) |
 
 pub mod accessibility;
 pub mod accessibility_signal;
@@ -60,6 +61,7 @@ pub mod i18n;
 pub mod keymap;
 pub mod layout;
 pub mod lock;
+pub mod once;
 pub mod overlay;
 pub mod path;
 pub mod profiler;
@@ -299,6 +301,9 @@ pub use shell::{escape_applescript, escape_powershell, sanitize_string};
 
 // Debounce and Throttle
 pub use debounce::{debounce_ms, debouncer, throttle, throttle_ms, Debouncer, Edge, Throttle};
+
+// Once (one-shot execution)
+pub use once::{once, Once};
 
 // Filter mode
 pub use filter::FilterMode;

--- a/src/utils/once.rs
+++ b/src/utils/once.rs
@@ -1,0 +1,278 @@
+//! One-shot execution utility
+//!
+//! A simple utility to ensure a callback is executed only once.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use revue::utils::Once;
+//!
+//! let mut once = Once::new();
+//! for _ in 0..10 {
+//!     if once.call() {
+//!         println!("This will only print once!");
+//!     }
+//! }
+//! ```
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// A one-shot execution guard
+///
+/// Ensures that code is executed only once, even if `call()` is invoked multiple times.
+/// This is useful for initialization, cleanup, or ensuring side effects happen once.
+///
+/// # Thread Safety
+///
+/// `Once` uses atomic operations and is safe to use across threads.
+#[derive(Debug, Default)]
+pub struct Once {
+    /// Flag indicating if the action has been executed
+    executed: AtomicBool,
+}
+
+impl Once {
+    /// Create a new `Once` guard
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use revue::utils::Once;
+    ///
+    /// let once = Once::new();
+    /// assert!(!once.is_called());
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            executed: AtomicBool::new(false),
+        }
+    }
+
+    /// Attempt to execute the one-shot action
+    ///
+    /// Returns `true` on the first call (allowing execution), and `false` on all
+    /// subsequent calls (preventing re-execution).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use revue::utils::Once;
+    ///
+    /// let mut once = Once::new();
+    /// assert!(once.call());  // First call returns true
+    /// assert!(!once.call()); // Subsequent calls return false
+    /// assert!(!once.call()); // Always returns false after first
+    /// ```
+    #[inline]
+    pub fn call(&mut self) -> bool {
+        self.call_impl()
+    }
+
+    /// Internal implementation using atomic operations
+    #[inline]
+    fn call_impl(&self) -> bool {
+        !self.executed.swap(true, Ordering::AcqRel)
+    }
+
+    /// Check if the one-shot has been called
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use revue::utils::Once;
+    ///
+    /// let mut once = Once::new();
+    /// assert!(!once.is_called());
+    /// once.call();
+    /// assert!(once.is_called());
+    /// ```
+    #[inline]
+    pub fn is_called(&self) -> bool {
+        self.executed.load(Ordering::Acquire)
+    }
+
+    /// Reset the one-shot, allowing it to be called again
+    ///
+    /// # Warning
+    ///
+    /// This can be useful in certain scenarios, but be careful not to create
+    /// unexpected behavior. Use with caution!
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use revue::utils::Once;
+    ///
+    /// let mut once = Once::new();
+    /// once.call();
+    /// assert!(!once.call()); // Already called
+    ///
+    /// once.reset();
+    /// assert!(once.call()); // Can call again after reset
+    /// ```
+    #[inline]
+    pub fn reset(&mut self) {
+        self.executed.store(false, Ordering::Release);
+    }
+
+    /// Create a new `Once` that's already in the called state
+    ///
+    /// This is useful when you want to skip execution based on some condition.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use revue::utils::Once;
+    ///
+    /// let already_initialized = true;
+    /// let mut once = Once::from(already_initialized);
+    ///
+    /// if once.call() {
+    ///     println!("This won't print");
+    /// }
+    /// ```
+    pub fn from(called: bool) -> Self {
+        Self {
+            executed: AtomicBool::new(called),
+        }
+    }
+}
+
+impl Clone for Once {
+    fn clone(&self) -> Self {
+        Self {
+            executed: AtomicBool::new(self.is_called()),
+        }
+    }
+}
+
+/// Helper function to create a new `Once` guard
+///
+/// # Example
+///
+/// ```rust
+/// use revue::utils::once;
+///
+/// let mut one_shot = once();
+/// if one_shot.call() {
+///     // Execute once
+/// }
+/// ```
+pub fn once() -> Once {
+    Once::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_once_new() {
+        let once = Once::new();
+        assert!(!once.is_called());
+    }
+
+    #[test]
+    fn test_once_single_call() {
+        let mut once = Once::new();
+        assert!(once.call());
+        assert!(once.is_called());
+    }
+
+    #[test]
+    fn test_once_multiple_calls() {
+        let mut once = Once::new();
+        assert!(once.call()); // First
+        assert!(!once.call()); // Second
+        assert!(!once.call()); // Third
+        assert!(!once.call()); // Fourth
+        assert!(once.is_called());
+    }
+
+    #[test]
+    fn test_once_reset() {
+        let mut once = Once::new();
+        assert!(once.call());
+        assert!(!once.call());
+
+        once.reset();
+        assert!(!once.is_called());
+        assert!(once.call());
+        assert!(!once.call());
+    }
+
+    #[test]
+    fn test_once_from_true() {
+        let mut once = Once::from(true);
+        assert!(once.is_called());
+        assert!(!once.call());
+    }
+
+    #[test]
+    fn test_once_from_false() {
+        let mut once = Once::from(false);
+        assert!(!once.is_called());
+        assert!(once.call());
+    }
+
+    #[test]
+    fn test_once_helper() {
+        let mut one_shot = once();
+        assert!(one_shot.call());
+        assert!(!one_shot.call());
+    }
+
+    #[test]
+    fn test_once_default() {
+        let once = Once::default();
+        assert!(!once.is_called());
+    }
+
+    #[test]
+    fn test_once_clone() {
+        let mut once1 = Once::new();
+        once1.call();
+
+        let mut once2 = once1.clone();
+        assert!(once2.is_called());
+        assert!(!once2.call());
+    }
+
+    #[test]
+    fn test_once_clone_uncalled() {
+        let once1 = Once::new();
+        let mut once2 = once1.clone();
+
+        assert!(once2.call());
+        // Cloned Once has its own independent state
+        assert!(!once1.is_called());
+    }
+
+    #[test]
+    fn test_once_in_loop() {
+        let mut once = Once::new();
+        let mut count = 0;
+
+        for _ in 0..100 {
+            if once.call() {
+                count += 1;
+            }
+        }
+
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_once_with_callback() {
+        let mut once = Once::new();
+        let mut executed = false;
+
+        for _ in 0..10 {
+            if once.call() {
+                executed = true;
+            }
+        }
+
+        assert!(executed);
+    }
+}

--- a/tests/widget/gauge.rs
+++ b/tests/widget/gauge.rs
@@ -66,3 +66,225 @@ fn test_battery_helper() {
 }
 
 // =============================================================================
+// Edge Case Tests
+// =============================================================================
+
+#[test]
+fn test_gauge_zero_percent() {
+    let g = Gauge::new().percent(0.0);
+    assert_eq!(g.get_value(), 0.0);
+
+    // Should render without panicking
+    let mut buffer = Buffer::new(20, 3);
+    let area = Rect::new(0, 0, 20, 3);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+    g.render(&mut ctx);
+}
+
+#[test]
+fn test_gauge_hundred_percent() {
+    let g = Gauge::new().percent(100.0);
+    assert_eq!(g.get_value(), 1.0);
+
+    let mut buffer = Buffer::new(20, 3);
+    let area = Rect::new(0, 0, 20, 3);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+    g.render(&mut ctx);
+}
+
+#[test]
+fn test_gauge_negative_value_clamped() {
+    // Negative values should be clamped to 0
+    let g = Gauge::new().percent(-50.0);
+    assert_eq!(g.get_value(), 0.0);
+}
+
+#[test]
+fn test_gauge_over_100_clamped() {
+    // Values over 100 should be clamped to 1.0
+    let g = Gauge::new().percent(150.0);
+    assert_eq!(g.get_value(), 1.0);
+}
+
+#[test]
+fn test_gauge_fractional_percent() {
+    // Test fractional percentages
+    let g = Gauge::new().percent(37.5);
+    assert!((g.get_value() - 0.375).abs() < 0.001);
+
+    let g = Gauge::new().percent(0.1);
+    assert!((g.get_value() - 0.001).abs() < 0.0001);
+
+    let g = Gauge::new().percent(99.9);
+    assert!((g.get_value() - 0.999).abs() < 0.001);
+}
+
+#[test]
+fn test_gauge_very_small_area() {
+    // Test rendering in minimal space
+    let mut buffer = Buffer::new(3, 1);
+    let area = Rect::new(0, 0, 3, 1);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+
+    let g = Gauge::new().percent(50.0);
+    g.render(&mut ctx); // Should not panic
+}
+
+#[test]
+fn test_gauge_zero_width() {
+    // Test handling of zero width area
+    let mut buffer = Buffer::new(0, 5);
+    let area = Rect::new(0, 0, 0, 5);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+
+    let g = Gauge::new().percent(50.0);
+    g.render(&mut ctx); // Should handle gracefully
+}
+
+#[test]
+fn test_gauge_zero_height() {
+    // Test handling of zero height area
+    let mut buffer = Buffer::new(20, 0);
+    let area = Rect::new(0, 0, 20, 0);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+
+    let g = Gauge::new().percent(50.0);
+    g.render(&mut ctx); // Should handle gracefully
+}
+
+#[test]
+fn test_gauge_long_title_truncation() {
+    // Very long title should be handled
+    let long_title = "This is a very long gauge title that might get truncated";
+    let mut buffer = Buffer::new(20, 3);
+    let area = Rect::new(0, 0, 20, 3);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+
+    let g = Gauge::new().title(long_title).percent(50.0);
+    g.render(&mut ctx); // Should handle without panic
+}
+
+#[test]
+fn test_gauge_unicode_title() {
+    // Test unicode characters in title
+    let unicode_title = "📊 CPU 使用率";
+    let mut buffer = Buffer::new(30, 3);
+    let area = Rect::new(0, 0, 30, 3);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+
+    let g = Gauge::new().title(unicode_title).percent(50.0);
+    g.render(&mut ctx);
+}
+
+#[test]
+fn test_gauge_set_value_boundary() {
+    let mut g = Gauge::new();
+
+    // Test setting values at boundaries
+    g.set_value(0.0);
+    assert_eq!(g.get_value(), 0.0);
+
+    g.set_value(0.5);
+    assert_eq!(g.get_value(), 0.5);
+
+    g.set_value(1.0);
+    assert_eq!(g.get_value(), 1.0);
+
+    // Test clamping
+    g.set_value(-0.5);
+    assert_eq!(g.get_value(), 0.0);
+
+    g.set_value(1.5);
+    assert_eq!(g.get_value(), 1.0);
+}
+
+#[test]
+fn test_gauge_ratio_boundary() {
+    // Test ratio() method at boundaries
+    let g = Gauge::new().ratio(0.0);
+    assert_eq!(g.get_value(), 0.0);
+
+    let g = Gauge::new().ratio(0.5);
+    assert_eq!(g.get_value(), 0.5);
+
+    let g = Gauge::new().ratio(1.0);
+    assert_eq!(g.get_value(), 1.0);
+
+    // Test clamping
+    let g = Gauge::new().ratio(-0.5);
+    assert_eq!(g.get_value(), 0.0);
+
+    let g = Gauge::new().ratio(1.5);
+    assert_eq!(g.get_value(), 1.0);
+}
+
+#[test]
+fn test_gauge_all_styles_at_boundaries() {
+    let styles = [
+        GaugeStyle::Bar,
+        GaugeStyle::Battery,
+        GaugeStyle::Thermometer,
+        GaugeStyle::Arc,
+        GaugeStyle::Circle,
+        GaugeStyle::Vertical,
+        GaugeStyle::Segments,
+        GaugeStyle::Dots,
+    ];
+
+    for style in styles {
+        // Test at 0%
+        let mut buffer = Buffer::new(20, 3);
+        let area = Rect::new(0, 0, 20, 3);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+        Gauge::new().style(style).percent(0.0).render(&mut ctx);
+
+        // Test at 100%
+        let mut buffer = Buffer::new(20, 3);
+        let area = Rect::new(0, 0, 20, 3);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+        Gauge::new().style(style).percent(100.0).render(&mut ctx);
+
+        // Test at 50%
+        let mut buffer = Buffer::new(20, 3);
+        let area = Rect::new(0, 0, 20, 3);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+        Gauge::new().style(style).percent(50.0).render(&mut ctx);
+    }
+}
+
+#[test]
+fn test_gauge_with_label_at_boundaries() {
+    // Test gauge with label at different values
+    for value in [0.0, 25.0, 50.0, 75.0, 100.0] {
+        let mut buffer = Buffer::new(30, 3);
+        let area = Rect::new(0, 0, 30, 3);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+
+        let g = Gauge::new().label(format!("{}%", value)).percent(value);
+        g.render(&mut ctx);
+    }
+}
+
+#[test]
+fn test_gauge_empty_title() {
+    // Empty title should be handled
+    let mut buffer = Buffer::new(20, 3);
+    let area = Rect::new(0, 0, 20, 3);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+
+    let g = Gauge::new().title("").percent(50.0);
+    g.render(&mut ctx);
+}
+
+#[test]
+fn test_gauge_whitespace_title() {
+    // Whitespace-only title should be handled
+    let mut buffer = Buffer::new(20, 3);
+    let area = Rect::new(0, 0, 20, 3);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+
+    let g = Gauge::new().title("   ").percent(50.0);
+    g.render(&mut ctx);
+}
+
+// =============================================================================

--- a/tests/widget/gauge.rs
+++ b/tests/widget/gauge.rs
@@ -199,22 +199,45 @@ fn test_gauge_set_value_boundary() {
 }
 
 #[test]
-fn test_gauge_ratio_boundary() {
-    // Test ratio() method at boundaries
-    let g = Gauge::new().ratio(0.0);
+fn test_gauge_value_boundary() {
+    // Test value() method at boundaries (0.0 - 1.0 range)
+    let g = Gauge::new().value(0.0);
     assert_eq!(g.get_value(), 0.0);
 
-    let g = Gauge::new().ratio(0.5);
+    let g = Gauge::new().value(0.5);
     assert_eq!(g.get_value(), 0.5);
 
-    let g = Gauge::new().ratio(1.0);
+    let g = Gauge::new().value(1.0);
     assert_eq!(g.get_value(), 1.0);
 
     // Test clamping
-    let g = Gauge::new().ratio(-0.5);
+    let g = Gauge::new().value(-0.5);
     assert_eq!(g.get_value(), 0.0);
 
-    let g = Gauge::new().ratio(1.5);
+    let g = Gauge::new().value(1.5);
+    assert_eq!(g.get_value(), 1.0);
+}
+
+#[test]
+fn test_gauge_value_range() {
+    // Test value_range() with custom min/max
+    let g = Gauge::new().value_range(50.0, 0.0, 100.0);
+    assert!((g.get_value() - 0.5).abs() < 0.001);
+
+    // At min
+    let g = Gauge::new().value_range(0.0, 0.0, 100.0);
+    assert_eq!(g.get_value(), 0.0);
+
+    // At max
+    let g = Gauge::new().value_range(100.0, 0.0, 100.0);
+    assert_eq!(g.get_value(), 1.0);
+
+    // Clamping below min
+    let g = Gauge::new().value_range(-10.0, 0.0, 100.0);
+    assert_eq!(g.get_value(), 0.0);
+
+    // Clamping above max
+    let g = Gauge::new().value_range(150.0, 0.0, 100.0);
     assert_eq!(g.get_value(), 1.0);
 }
 


### PR DESCRIPTION
## Summary

Add a new `Once` utility for one-shot execution that ensures a callback is executed only once, even if `call()` is invoked multiple times.

## Changes

- Add `Once` utility in `src/utils/once.rs`
- Export from `utils` module with helper `once()` function
- Thread-safe using atomic operations
- 14 comprehensive tests
- Add edge case tests for Gauge widget
- Update SECURITY.md with recent security fixes
- Add CSS selector indexing benchmark

## Features

- `call()` returns true on first call, false thereafter
- `is_called()` to check if already executed
- `reset()` to allow re-execution (use with caution)
- Clone support with independent state

## Use Cases

- One-time initialization
- Single execution of cleanup code
- Preventing duplicate side effects
- Logging initialization messages

```rust
use revue::utils::once;

let mut log_init = once();
if log_init.call() {
    println!("Logger initialized!");
}
```

## Tests

- 14 tests for `Once` utility covering basic functionality, multiple calls, reset, cloning, and loop patterns
- 10 edge case tests for Gauge widget
- CSS selector indexing benchmark for performance validation