### PR TITLE
perf(utils): optimize Cow<str> to String conversion with into_owned()

### DIFF
--- a/src/utils/browser.rs
+++ b/src/utils/browser.rs
@@ -263,7 +263,7 @@ pub fn reveal_in_finder(path: &str) -> bool {
     let result = {
         let parent = std::path::Path::new(path)
             .parent()
-            .map(|p| p.to_string_lossy().to_string())
+            .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or_else(|| path.to_string());
         Command::new("xdg-open").arg(&parent).spawn()
     };

--- a/src/widget/developer/procmon.rs
+++ b/src/widget/developer/procmon.rs
@@ -259,7 +259,7 @@ impl ProcessMonitor {
                 ProcessInfo {
                     pid: pid.as_u32(),
                     parent_pid: proc.parent().map(|p| p.as_u32()),
-                    name: proc.name().to_string_lossy().to_string(),
+                    name: proc.name().to_string_lossy().into_owned(),
                     cpu: proc.cpu_usage(),
                     memory,
                     memory_percent: (memory as f32 / total_memory) * 100.0,
@@ -267,7 +267,7 @@ impl ProcessMonitor {
                     cmd: proc
                         .cmd()
                         .iter()
-                        .map(|s| s.to_string_lossy().to_string())
+                        .map(|s| s.to_string_lossy().into_owned())
                         .collect::<Vec<_>>()
                         .join(" "),
                     user: proc.user_id().map(|u| u.to_string()).unwrap_or_default(),


### PR DESCRIPTION
## Summary
Optimize Cow<str> to String conversions using into_owned() instead of to_string().

## Changes
- browser.rs: Use into_owned() for path conversion in reveal_file()
- procmon.rs: Use into_owned() for process name and command arguments

## Benefits
into_owned() is more efficient than to_string() for Cow<str>:
- When Cow is Owned(String): moves instead of cloning
- When Cow is Borrowed(&str): allocates new String (same as to_string())

This eliminates unnecessary clones when the data is already owned.