### PR TITLE
fix(hot-reload): use ref binding in match to avoid move error

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -346,22 +346,22 @@ impl App {
         // Non-blocking check for events
         if let Some(event) = hr.poll() {
             match event {
-                HotReloadEvent::StylesheetChanged(path) => {
+                HotReloadEvent::StylesheetChanged(ref path) => {
                     crate::log_debug!("Hot reload: stylesheet changed {:?}", path);
-                    self.reload_stylesheet(&path);
+                    self.reload_stylesheet(path);
                     return Some(true);
                 }
-                HotReloadEvent::FileCreated(path) => {
+                HotReloadEvent::FileCreated(ref path) => {
                     crate::log_debug!("Hot reload: file created {:?}", path);
-                    if self.style_paths.contains(&path) {
-                        self.reload_stylesheet(&path);
+                    if self.style_paths.contains(path) {
+                        self.reload_stylesheet(path);
                         return Some(true);
                     }
                 }
-                HotReloadEvent::FileDeleted(path) => {
+                HotReloadEvent::FileDeleted(ref path) => {
                     crate::log_debug!("Hot reload: file deleted {:?}", path);
                 }
-                HotReloadEvent::Error(e) => {
+                HotReloadEvent::Error(ref e) => {
                     crate::log_warn!("Hot reload error: {}", e);
                 }
             }


### PR DESCRIPTION
## Summary

Fixes compilation error when `hot-reload` feature is enabled.

## Problem

When the `hot-reload` feature is enabled, the code failed to compile with:
```
error[E0382]: borrow of moved value: `path`
```

The match arms were taking ownership of `path` from `HotReloadEvent`, then trying to use it after the move.

## Fix

Use `ref` binding in match patterns to bind by reference instead of moving:
```rust
HotReloadEvent::StylesheetChanged(ref path) => { ... }
```

This allows the same `path` to be used in both the log_debug! call and reload_stylesheet().

## Test

- `test_builder_hot_reload_with_style_path` now passes in ~0.14s