### PR TITLE
chore: bump version to 2.46.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "revue"
-version = "2.46.1"
+version = "2.46.2"
 edition = "2021"
 rust-version = "1.87"
 description = "A Vue-style TUI framework for Rust with CSS styling"


### PR DESCRIPTION
## Summary

Bump version to 2.46.2 to trigger new release with CSS theme fixes.

## Changes
- Fixed CSS themes path in Cargo.toml (src/style → src/runtime/style)
- This ensures CSS theme files are included in published crate

## Related
- Fixes publish failure in 2.46.1