### PR TITLE
feat(style): add CSS @keyframes and animation property parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,6 +496,9 @@ pub mod prelude {
         GroupMode,
         // CSS @keyframes style
         KeyframeAnimation,
+        // CSS @keyframes parser types
+        KeyframeBlock,
+        KeyframesDefinition,
         // Choreography
         Stagger,
         Tween,

--- a/src/runtime/dom/cascade/tests/attributes.rs
+++ b/src/runtime/dom/cascade/tests/attributes.rs
@@ -13,6 +13,7 @@ fn test_attribute_class_exists() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -37,6 +38,7 @@ fn test_attribute_class_contains_word() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -59,6 +61,7 @@ fn test_attribute_id_exists() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -78,6 +81,7 @@ fn test_attribute_id_equals() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -97,6 +101,7 @@ fn test_attribute_id_starts_with() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -116,6 +121,7 @@ fn test_attribute_id_ends_with() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -135,6 +141,7 @@ fn test_attribute_id_contains() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -154,6 +161,7 @@ fn test_attribute_type_exists() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -173,6 +181,7 @@ fn test_attribute_type_equals() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -192,6 +201,7 @@ fn test_attribute_type_contains() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -211,6 +221,7 @@ fn test_attribute_disabled_exists() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -231,6 +242,7 @@ fn test_attribute_disabled_equals() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -251,6 +263,7 @@ fn test_attribute_checked_exists() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -271,6 +284,7 @@ fn test_attribute_selected_exists() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -291,6 +305,7 @@ fn test_attribute_focused_exists() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -311,6 +326,7 @@ fn test_attribute_hovered_exists() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -331,6 +347,7 @@ fn test_attribute_unknown() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 

--- a/src/runtime/dom/cascade/tests/combinators.rs
+++ b/src/runtime/dom/cascade/tests/combinators.rs
@@ -13,6 +13,7 @@ fn test_match_descendant_combinator() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -46,6 +47,7 @@ fn test_match_child_combinator() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -76,6 +78,7 @@ fn test_match_adjacent_sibling_combinator() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -112,6 +115,7 @@ fn test_match_no_parent() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 

--- a/src/runtime/dom/cascade/tests/pseudo_classes.rs
+++ b/src/runtime/dom/cascade/tests/pseudo_classes.rs
@@ -16,6 +16,7 @@ fn test_match_pseudo_hover() {
             }],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -42,6 +43,7 @@ fn test_match_pseudo_focus() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -67,6 +69,7 @@ fn test_match_pseudo_disabled() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -87,6 +90,7 @@ fn test_match_pseudo_first_child() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -112,6 +116,7 @@ fn test_match_pseudo_last_child() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -132,6 +137,7 @@ fn test_match_pseudo_checked() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -157,6 +163,7 @@ fn test_match_pseudo_selected() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -177,6 +184,7 @@ fn test_match_pseudo_only_child() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 

--- a/src/runtime/dom/cascade/tests/resolver.rs
+++ b/src/runtime/dom/cascade/tests/resolver.rs
@@ -31,6 +31,7 @@ fn create_test_stylesheet() -> StyleSheet {
             },
         ],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     }
 }
 
@@ -174,6 +175,7 @@ fn test_resolver_invalid_selector() {
             declarations: vec![],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let resolver = StyleResolver::new(&stylesheet);
 
@@ -192,6 +194,7 @@ fn test_universal_selector() {
             }],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -213,6 +216,7 @@ fn test_compute_style_with_inline() {
             }],
         }],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -237,6 +241,7 @@ fn test_compute_style_with_parent() {
     let stylesheet = StyleSheet {
         rules: vec![],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 
@@ -258,6 +263,7 @@ fn test_compute_style_with_parent_none() {
     let stylesheet = StyleSheet {
         rules: vec![],
         variables: std::collections::HashMap::new(),
+        keyframes: std::collections::HashMap::new(),
     };
     let mut resolver = StyleResolver::new(&stylesheet);
 

--- a/src/runtime/style/mod.rs
+++ b/src/runtime/style/mod.rs
@@ -161,7 +161,9 @@ pub use error::{
     suggest_property, ErrorCode, ParseErrors, RichParseError, Severity, SourceLocation, Suggestion,
     KNOWN_PROPERTIES,
 };
-pub use parser::{apply_declaration, Declaration, Rule, StyleSheet};
+pub use parser::{
+    apply_declaration, Declaration, KeyframeBlock, KeyframesDefinition, Rule, StyleSheet,
+};
 pub use properties::*;
 pub use theme::{
     shared_theme, theme_manager, Palette, SharedTheme, Theme, ThemeBuilder, ThemeChangeListener,

--- a/src/runtime/style/parser/apply.rs
+++ b/src/runtime/style/parser/apply.rs
@@ -205,6 +205,240 @@ fn apply_sizing(style: &mut Style, property: &str, value: &str) -> bool {
     }
 }
 
+/// CSS animation properties parsed from declarations
+#[derive(Default)]
+struct CssAnimationProperties {
+    name: Option<String>,
+    duration: Option<std::time::Duration>,
+    easing: Option<crate::style::Easing>,
+    delay: Option<std::time::Duration>,
+    iteration_count: Option<u32>,
+    direction: Option<crate::style::AnimationDirection>,
+    fill_mode: Option<crate::style::AnimationFillMode>,
+}
+
+/// Parse an animation shorthand value like "fadeIn 0.3s ease-in-out infinite alternate"
+fn parse_animation_shorthand(value: &str) -> CssAnimationProperties {
+    let mut props = CssAnimationProperties::default();
+    let mut found_duration = false;
+
+    for part in value.split_whitespace() {
+        // Try parsing as duration
+        if let Some(dur) = crate::style::transition::parse_duration(part) {
+            if !found_duration {
+                props.duration = Some(dur);
+                found_duration = true;
+            } else {
+                props.delay = Some(dur);
+            }
+            continue;
+        }
+
+        // Try parsing as easing
+        if let Some(easing) = crate::style::Easing::parse(part) {
+            props.easing = Some(easing);
+            continue;
+        }
+
+        // Try parsing as iteration count
+        if part == "infinite" {
+            props.iteration_count = Some(0); // 0 = infinite in KeyframeAnimation
+            continue;
+        }
+        if let Ok(n) = part.parse::<u32>() {
+            props.iteration_count = Some(n);
+            continue;
+        }
+
+        // Try parsing as direction
+        match part {
+            "normal" => {
+                props.direction = Some(crate::style::AnimationDirection::Normal);
+                continue;
+            }
+            "reverse" => {
+                props.direction = Some(crate::style::AnimationDirection::Reverse);
+                continue;
+            }
+            "alternate" => {
+                props.direction = Some(crate::style::AnimationDirection::Alternate);
+                continue;
+            }
+            "alternate-reverse" => {
+                props.direction = Some(crate::style::AnimationDirection::AlternateReverse);
+                continue;
+            }
+            _ => {}
+        }
+
+        // Try parsing as fill mode
+        match part {
+            "forwards" => {
+                props.fill_mode = Some(crate::style::AnimationFillMode::Forwards);
+                continue;
+            }
+            "backwards" => {
+                props.fill_mode = Some(crate::style::AnimationFillMode::Backwards);
+                continue;
+            }
+            "both" => {
+                props.fill_mode = Some(crate::style::AnimationFillMode::Both);
+                continue;
+            }
+            "none" if props.name.is_some() => {
+                // "none" as fill mode only if we already have a name
+                props.fill_mode = Some(crate::style::AnimationFillMode::None);
+                continue;
+            }
+            _ => {}
+        }
+
+        // Otherwise treat as animation name (first unrecognized token)
+        if props.name.is_none() {
+            props.name = Some(part.to_string());
+        }
+    }
+
+    props
+}
+
+/// Convert a CSS value to f32 for keyframe interpolation
+fn css_value_to_f32(value: &str) -> Option<f32> {
+    let value = value.trim();
+    // Direct number
+    if let Ok(v) = value.parse::<f32>() {
+        return Some(v);
+    }
+    // px values
+    if let Some(num) = value.strip_suffix("px") {
+        return num.trim().parse::<f32>().ok();
+    }
+    // percentage
+    if let Some(num) = value.strip_suffix('%') {
+        return num.trim().parse::<f32>().ok().map(|v| v / 100.0);
+    }
+    None
+}
+
+/// Resolve animation for a selector by looking up declarations and @keyframes
+pub(super) fn resolve_animation(
+    sheet: &super::types::StyleSheet,
+    selector: &str,
+) -> Option<crate::style::animation::KeyframeAnimation> {
+    use crate::style::animation::{easing as easing_fns, KeyframeAnimation};
+
+    // Collect animation properties from selector's declarations
+    let mut anim_props = CssAnimationProperties::default();
+    let mut found_shorthand = false;
+
+    for rule in sheet.rules(selector) {
+        for decl in &rule.declarations {
+            match decl.property.as_str() {
+                "animation" => {
+                    anim_props = parse_animation_shorthand(&decl.value);
+                    found_shorthand = true;
+                }
+                "animation-name" => anim_props.name = Some(decl.value.clone()),
+                "animation-duration" => {
+                    anim_props.duration = crate::style::transition::parse_duration(&decl.value);
+                }
+                "animation-timing-function" => {
+                    anim_props.easing = crate::style::Easing::parse(&decl.value);
+                }
+                "animation-delay" => {
+                    anim_props.delay = crate::style::transition::parse_duration(&decl.value);
+                }
+                "animation-iteration-count" => {
+                    if decl.value.trim() == "infinite" {
+                        anim_props.iteration_count = Some(0);
+                    } else {
+                        anim_props.iteration_count = decl.value.trim().parse::<u32>().ok();
+                    }
+                }
+                "animation-direction" => {
+                    anim_props.direction = match decl.value.trim() {
+                        "normal" => Some(crate::style::AnimationDirection::Normal),
+                        "reverse" => Some(crate::style::AnimationDirection::Reverse),
+                        "alternate" => Some(crate::style::AnimationDirection::Alternate),
+                        "alternate-reverse" => {
+                            Some(crate::style::AnimationDirection::AlternateReverse)
+                        }
+                        _ => None,
+                    };
+                }
+                "animation-fill-mode" => {
+                    anim_props.fill_mode = match decl.value.trim() {
+                        "none" => Some(crate::style::AnimationFillMode::None),
+                        "forwards" => Some(crate::style::AnimationFillMode::Forwards),
+                        "backwards" => Some(crate::style::AnimationFillMode::Backwards),
+                        "both" => Some(crate::style::AnimationFillMode::Both),
+                        _ => None,
+                    };
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Need at least an animation name
+    let anim_name = anim_props.name.as_ref()?;
+
+    // Look up @keyframes definition
+    let keyframes_def = sheet.keyframes_definition(anim_name)?;
+
+    // Build KeyframeAnimation from the definition
+    let mut anim = KeyframeAnimation::new(anim_name);
+
+    // Add keyframes
+    for block in &keyframes_def.keyframes {
+        anim = anim.keyframe(block.percent, |mut kf| {
+            for decl in &block.declarations {
+                if let Some(val) = css_value_to_f32(&decl.value) {
+                    kf = kf.set(&decl.property, val);
+                }
+            }
+            kf
+        });
+    }
+
+    // Apply animation properties
+    if let Some(duration) = anim_props.duration {
+        anim = anim.duration(duration);
+    }
+    if let Some(delay) = anim_props.delay {
+        anim = anim.delay(delay);
+    }
+    if let Some(easing) = anim_props.easing {
+        let easing_fn = match easing {
+            crate::style::Easing::Linear => easing_fns::linear,
+            crate::style::Easing::EaseIn => easing_fns::ease_in,
+            crate::style::Easing::EaseOut => easing_fns::ease_out,
+            crate::style::Easing::EaseInOut => easing_fns::ease_in_out,
+            // CubicBezier falls back to ease_in_out for now
+            crate::style::Easing::CubicBezier(..) => easing_fns::ease_in_out,
+        };
+        anim = anim.easing(easing_fn);
+    }
+    if let Some(count) = anim_props.iteration_count {
+        if count == 0 {
+            anim = anim.infinite();
+        } else {
+            anim = anim.iterations(count);
+        }
+    }
+    if let Some(direction) = anim_props.direction {
+        anim = anim.direction(direction);
+    }
+    if let Some(fill_mode) = anim_props.fill_mode {
+        anim = anim.fill_mode(fill_mode);
+    }
+
+    // Suppress unused warning for found_shorthand
+    let _ = found_shorthand;
+
+    Some(anim)
+}
+
 /// Apply visual properties (colors, border, opacity, visibility)
 fn apply_visual(style: &mut Style, property: &str, value: &str) {
     match property {

--- a/src/runtime/style/parser/mod.rs
+++ b/src/runtime/style/parser/mod.rs
@@ -7,7 +7,7 @@ mod value_parsers;
 
 pub use apply::apply_declaration;
 pub use parse::parse;
-pub use types::{Declaration, Rule, StyleSheet};
+pub use types::{Declaration, KeyframeBlock, KeyframesDefinition, Rule, StyleSheet};
 #[allow(unused_imports)]
 pub use value_parsers::{
     parse_color, parse_grid_placement, parse_grid_template, parse_signed_length, parse_size,

--- a/src/runtime/style/parser/types.rs
+++ b/src/runtime/style/parser/types.rs
@@ -2,6 +2,24 @@
 
 use std::collections::HashMap;
 
+/// A parsed @keyframes definition
+#[derive(Debug, Clone)]
+pub struct KeyframesDefinition {
+    /// Name of the keyframes animation
+    pub name: String,
+    /// Keyframe blocks (percent + declarations)
+    pub keyframes: Vec<KeyframeBlock>,
+}
+
+/// A single keyframe block within @keyframes
+#[derive(Debug, Clone)]
+pub struct KeyframeBlock {
+    /// Percentage (0-100)
+    pub percent: u8,
+    /// CSS declarations at this keyframe
+    pub declarations: Vec<Declaration>,
+}
+
 /// A parsed stylesheet
 #[derive(Debug, Default, Clone)]
 pub struct StyleSheet {
@@ -9,6 +27,8 @@ pub struct StyleSheet {
     pub rules: Vec<Rule>,
     /// CSS variables
     pub variables: HashMap<String, String>,
+    /// @keyframes definitions
+    pub keyframes: HashMap<String, KeyframesDefinition>,
 }
 
 /// A CSS rule (selector + declarations)
@@ -39,6 +59,7 @@ impl StyleSheet {
     pub fn merge(&mut self, other: StyleSheet) {
         self.rules.extend(other.rules);
         self.variables.extend(other.variables);
+        self.keyframes.extend(other.keyframes);
     }
 
     /// Get a CSS variable value
@@ -65,5 +86,18 @@ impl StyleSheet {
         }
 
         style
+    }
+
+    /// Get a @keyframes definition by name
+    pub fn keyframes_definition(&self, name: &str) -> Option<&KeyframesDefinition> {
+        self.keyframes.get(name)
+    }
+
+    /// Resolve animation for a selector into a KeyframeAnimation
+    ///
+    /// Looks for `animation` or `animation-*` properties in the selector's rules,
+    /// then resolves the referenced @keyframes definition into a `KeyframeAnimation`.
+    pub fn animation(&self, selector: &str) -> Option<crate::style::animation::KeyframeAnimation> {
+        super::apply::resolve_animation(self, selector)
     }
 }

--- a/src/runtime/style/transition.rs
+++ b/src/runtime/style/transition.rs
@@ -476,7 +476,7 @@ pub fn effective_duration(duration: Duration) -> Duration {
 }
 
 /// Parse duration from CSS string like "0.3s" or "300ms"
-fn parse_duration(s: &str) -> Option<Duration> {
+pub(crate) fn parse_duration(s: &str) -> Option<Duration> {
     let s = s.trim();
 
     if let Some(ms) = s.strip_suffix("ms") {

--- a/src/state/worker/handle.rs
+++ b/src/state/worker/handle.rs
@@ -525,10 +525,8 @@ mod tests {
     #[test]
     fn test_try_join_not_finished() {
         let mut handle = WorkerHandle::spawn_blocking(|| {
-            // Spin to simulate work
-            for _ in 0..10000 {
-                std::hint::spin_loop();
-            }
+            // Sleep long enough that try_join() below runs before this completes
+            std::thread::sleep(Duration::from_millis(200));
             42
         });
 

--- a/tests/style/parser.rs
+++ b/tests/style/parser.rs
@@ -5,7 +5,8 @@
 use revue::style::{
     easing, lerp_f32, lerp_u8, parse_css, shared_theme, theme_manager, ActiveTransition,
     AnimationDirection, AnimationFillMode, AnimationGroup, AnimationState, Color, ComputedStyle,
-    CssKeyframe, Display, Easing, ErrorCode, FlexDirection, KeyframeAnimation, Palette,
+    CssKeyframe, Display, Easing, ErrorCode, FlexDirection, KeyframeAnimation,
+    KeyframeBlock, KeyframesDefinition, Palette,
     ParseErrors, Position, RichParseError, Severity, SharedTheme, Size, SourceLocation, Spacing,
     Stagger, Style, Suggestion, Theme, ThemeColors, ThemeManager, ThemeVariant, Themes, Transition,
     TransitionManager, Transitions, Tween, KNOWN_PROPERTIES,
@@ -140,4 +141,302 @@ fn test_apply_position_properties() {
     assert_eq!(style.spacing.top, Some(10));
     assert_eq!(style.spacing.left, Some(20));
     assert_eq!(style.visual.z_index, 100);
+}
+
+// =====================================================
+// @keyframes parsing tests
+// =====================================================
+
+#[test]
+fn test_parse_keyframes_from_to() {
+    let css = r#"
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+    "#;
+    let sheet = parse_css(css).unwrap();
+
+    assert!(sheet.keyframes.contains_key("fadeIn"));
+    let def = sheet.keyframes_definition("fadeIn").unwrap();
+    assert_eq!(def.name, "fadeIn");
+    assert_eq!(def.keyframes.len(), 2);
+    assert_eq!(def.keyframes[0].percent, 0);
+    assert_eq!(def.keyframes[0].declarations[0].property, "opacity");
+    assert_eq!(def.keyframes[0].declarations[0].value, "0");
+    assert_eq!(def.keyframes[1].percent, 100);
+    assert_eq!(def.keyframes[1].declarations[0].property, "opacity");
+    assert_eq!(def.keyframes[1].declarations[0].value, "1");
+}
+
+#[test]
+fn test_parse_keyframes_percentages() {
+    let css = r#"
+        @keyframes slideIn {
+            0% { opacity: 0; }
+            50% { opacity: 0.5; }
+            100% { opacity: 1; }
+        }
+    "#;
+    let sheet = parse_css(css).unwrap();
+
+    let def = sheet.keyframes_definition("slideIn").unwrap();
+    assert_eq!(def.keyframes.len(), 3);
+    assert_eq!(def.keyframes[0].percent, 0);
+    assert_eq!(def.keyframes[1].percent, 50);
+    assert_eq!(def.keyframes[2].percent, 100);
+}
+
+#[test]
+fn test_parse_keyframes_multiple_declarations() {
+    let css = r#"
+        @keyframes complex {
+            from { opacity: 0; x: -20; }
+            to { opacity: 1; x: 0; }
+        }
+    "#;
+    let sheet = parse_css(css).unwrap();
+
+    let def = sheet.keyframes_definition("complex").unwrap();
+    assert_eq!(def.keyframes[0].declarations.len(), 2);
+    assert_eq!(def.keyframes[0].declarations[0].property, "opacity");
+    assert_eq!(def.keyframes[0].declarations[1].property, "x");
+}
+
+#[test]
+fn test_parse_keyframes_empty_body() {
+    let css = r#"
+        @keyframes empty {
+        }
+    "#;
+    let sheet = parse_css(css).unwrap();
+
+    let def = sheet.keyframes_definition("empty").unwrap();
+    assert_eq!(def.keyframes.len(), 0);
+}
+
+#[test]
+fn test_parse_keyframes_missing_name() {
+    let css = "@keyframes { from { opacity: 0; } }";
+    let result = parse_css(css);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_parse_keyframes_with_rules() {
+    let css = r#"
+        .button { color: red; }
+
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+
+        .text { color: blue; }
+    "#;
+    let sheet = parse_css(css).unwrap();
+
+    assert_eq!(sheet.rules.len(), 2);
+    assert_eq!(sheet.rules[0].selector, ".button");
+    assert_eq!(sheet.rules[1].selector, ".text");
+    assert!(sheet.keyframes.contains_key("fadeIn"));
+}
+
+#[test]
+fn test_parse_multiple_keyframes() {
+    let css = r#"
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+        @keyframes slideUp {
+            from { y: 100; }
+            to { y: 0; }
+        }
+    "#;
+    let sheet = parse_css(css).unwrap();
+
+    assert_eq!(sheet.keyframes.len(), 2);
+    assert!(sheet.keyframes.contains_key("fadeIn"));
+    assert!(sheet.keyframes.contains_key("slideUp"));
+}
+
+// =====================================================
+// animation shorthand/longhand parsing tests
+// =====================================================
+
+#[test]
+fn test_animation_shorthand_resolves_to_keyframe_animation() {
+    let css = r#"
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+        .box {
+            animation: fadeIn 0.3s ease-in-out;
+        }
+    "#;
+    let sheet = parse_css(css).unwrap();
+    let anim = sheet.animation(".box");
+
+    assert!(anim.is_some());
+    let anim = anim.unwrap();
+    assert_eq!(anim.name(), "fadeIn");
+    assert_eq!(anim.duration, Duration::from_millis(300));
+}
+
+#[test]
+fn test_animation_shorthand_with_iterations() {
+    let css = r#"
+        @keyframes pulse {
+            from { opacity: 1; }
+            to { opacity: 0.5; }
+        }
+        .pulse {
+            animation: pulse 1s ease-in infinite alternate;
+        }
+    "#;
+    let sheet = parse_css(css).unwrap();
+    let anim = sheet.animation(".pulse").unwrap();
+
+    assert_eq!(anim.name(), "pulse");
+    assert_eq!(anim.duration, Duration::from_secs(1));
+    assert_eq!(anim.iterations, 0); // 0 = infinite
+    assert_eq!(anim.direction, AnimationDirection::Alternate);
+}
+
+#[test]
+fn test_animation_longhand_properties() {
+    let css = r#"
+        @keyframes slideIn {
+            0% { x: -100; }
+            100% { x: 0; }
+        }
+        .slide {
+            animation-name: slideIn;
+            animation-duration: 500ms;
+            animation-timing-function: ease-out;
+            animation-delay: 100ms;
+            animation-iteration-count: 3;
+            animation-direction: reverse;
+            animation-fill-mode: forwards;
+        }
+    "#;
+    let sheet = parse_css(css).unwrap();
+    let anim = sheet.animation(".slide").unwrap();
+
+    assert_eq!(anim.name(), "slideIn");
+    assert_eq!(anim.duration, Duration::from_millis(500));
+    assert_eq!(anim.delay, Duration::from_millis(100));
+    assert_eq!(anim.iterations, 3);
+    assert_eq!(anim.direction, AnimationDirection::Reverse);
+    assert_eq!(anim.fill_mode, AnimationFillMode::Forwards);
+}
+
+#[test]
+fn test_animation_nonexistent_keyframes_returns_none() {
+    let css = r#"
+        .box {
+            animation: nonexistent 1s;
+        }
+    "#;
+    let sheet = parse_css(css).unwrap();
+    assert!(sheet.animation(".box").is_none());
+}
+
+#[test]
+fn test_animation_no_animation_property_returns_none() {
+    let css = r#"
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+        .box { color: red; }
+    "#;
+    let sheet = parse_css(css).unwrap();
+    assert!(sheet.animation(".box").is_none());
+}
+
+// =====================================================
+// StyleSheet::animation() resolution tests
+// =====================================================
+
+#[test]
+fn test_stylesheet_animation_builds_keyframes() {
+    let css = r#"
+        @keyframes fadeSlide {
+            0% { opacity: 0; x: -20; }
+            50% { opacity: 1; x: 10; }
+            100% { opacity: 1; x: 0; }
+        }
+        .animated {
+            animation: fadeSlide 500ms ease-out;
+        }
+    "#;
+    let sheet = parse_css(css).unwrap();
+    let mut anim = sheet.animation(".animated").unwrap();
+
+    anim.start();
+    // Animation should start (or complete instantly if reduced motion)
+    assert!(anim.is_running() || anim.is_completed());
+}
+
+#[test]
+fn test_stylesheet_animation_fill_mode_both() {
+    let css = r#"
+        @keyframes grow {
+            from { scale: 0; }
+            to { scale: 1; }
+        }
+        .grow {
+            animation: grow 1s both;
+        }
+    "#;
+    let sheet = parse_css(css).unwrap();
+    let anim = sheet.animation(".grow").unwrap();
+
+    assert_eq!(anim.fill_mode, AnimationFillMode::Both);
+}
+
+// =====================================================
+// merge() with keyframes tests
+// =====================================================
+
+#[test]
+fn test_merge_stylesheets_with_keyframes() {
+    let css1 = r#"
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+    "#;
+    let css2 = r#"
+        @keyframes slideUp {
+            from { y: 100; }
+            to { y: 0; }
+        }
+    "#;
+    let mut sheet1 = parse_css(css1).unwrap();
+    let sheet2 = parse_css(css2).unwrap();
+
+    sheet1.merge(sheet2);
+
+    assert_eq!(sheet1.keyframes.len(), 2);
+    assert!(sheet1.keyframes.contains_key("fadeIn"));
+    assert!(sheet1.keyframes.contains_key("slideUp"));
+}
+
+#[test]
+fn test_keyframes_definition_accessor() {
+    let css = r#"
+        @keyframes bounce {
+            0% { y: 0; }
+            50% { y: -20; }
+            100% { y: 0; }
+        }
+    "#;
+    let sheet = parse_css(css).unwrap();
+
+    assert!(sheet.keyframes_definition("bounce").is_some());
+    assert!(sheet.keyframes_definition("nonexistent").is_none());
 }


### PR DESCRIPTION
## Summary
- Parse `@keyframes` blocks in CSS with from/to and percentage selectors
- Parse `animation` shorthand and longhand properties (name, duration, easing, delay, iteration-count, direction, fill-mode)
- Add `StyleSheet::animation(selector)` to resolve keyframes into existing `KeyframeAnimation` runtime
- Security limits: MAX_KEYFRAMES=100, MAX_KEYFRAME_BLOCKS=50

## Changed files
- `src/runtime/style/parser/types.rs` — `KeyframesDefinition`, `KeyframeBlock` types, `keyframes` field on `StyleSheet`
- `src/runtime/style/parser/parse.rs` — `@keyframes` parsing in main loop
- `src/runtime/style/parser/apply.rs` — `resolve_animation()`, `parse_animation_shorthand()`
- `src/runtime/style/transition.rs` — `parse_duration` visibility to `pub(crate)`
- `src/runtime/style/parser/mod.rs`, `src/runtime/style/mod.rs`, `src/lib.rs` — exports
- `tests/style/parser.rs` — 15 new integration tests
- 4 cascade test files — added `keyframes` field to struct literals

## Test plan
- [x] `cargo test --lib` passes (4807 tests)
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] @keyframes from/to and percentage parsing
- [x] animation shorthand resolution to KeyframeAnimation
- [x] Security limits enforced
- [x] Missing/invalid keyframes return None