### PR TITLE
docs: add Store, Query, and Routing guides; enhance testing docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,11 +110,11 @@ jobs:
       # PR: Quick coverage check without report (run tests for coverage)
       - name: Coverage (PR)
         if: github.event_name == 'pull_request'
-        run: cargo llvm-cov --no-report --ignore-run-fail
+        run: cargo llvm-cov --all-features --tests --no-report --ignore-run-fail
       # Main: Full coverage with lcov for badge
       - name: Coverage (Main)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: cargo llvm-cov --all-features --lcov --output-path lcov.info --ignore-run-fail
+        run: cargo llvm-cov --all-features --tests --lcov --output-path lcov.info --ignore-run-fail
       - uses: codecov/codecov-action@v5
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -1,0 +1,319 @@
+# Query Guide
+
+Revue provides a powerful query DSL for filtering, sorting, and paginating data collections.
+
+## Overview
+
+The Query system lets you filter items using a string-based query language or a programmatic builder API. It supports free-text search, field comparisons, boolean combinators, sorting, and pagination.
+
+## Quick Start
+
+```rust
+use revue::query::{Query, Queryable, QueryValue};
+
+struct Article {
+    title: String,
+    author: String,
+    views: i64,
+    published: bool,
+}
+
+impl Queryable for Article {
+    fn field_value(&self, field: &str) -> Option<QueryValue> {
+        match field {
+            "title" => Some(QueryValue::string(&self.title)),
+            "author" => Some(QueryValue::string(&self.author)),
+            "views" => Some(QueryValue::int(self.views)),
+            "published" => Some(QueryValue::bool(self.published)),
+            _ => None,
+        }
+    }
+
+    fn full_text(&self) -> String {
+        format!("{} {}", self.title, self.author)
+    }
+}
+
+// Parse a query string
+let query = Query::parse("author:john published:true").unwrap();
+let results = query.filter_items(&articles);
+```
+
+## Query Syntax
+
+### Free Text Search
+
+Matches items whose `full_text()` contains all given words (case-insensitive):
+
+```
+hello world          // Items containing both "hello" AND "world"
+rust programming     // Items containing both "rust" AND "programming"
+```
+
+### Field Match
+
+Exact field comparison (case-insensitive for strings):
+
+```
+author:john          // author equals "john"
+status:active        // status equals "active"
+active:true          // boolean field check
+age:30               // numeric equality
+```
+
+### Field Contains
+
+Substring match within a field:
+
+```
+title~rust           // title contains "rust"
+name~doe             // name contains "doe"
+```
+
+### Not Equal
+
+Negated equality:
+
+```
+status:!draft        // status is NOT "draft"
+published:!false     // published is NOT false
+```
+
+### Numeric Comparisons
+
+```
+age:>18              // age greater than 18
+price:<100           // price less than 100
+age:>=21             // age greater than or equal to 21
+price:<=50           // price less than or equal to 50
+```
+
+### Date Filters
+
+```
+after:2024-01-01     // date after 2024-01-01
+before:2024-12-31    // date before 2024-12-31
+```
+
+### Boolean Values
+
+```
+active:true          // Matches: true, yes, 1
+active:false         // Matches: false, no, 0
+```
+
+## Builder API
+
+Build queries programmatically:
+
+```rust
+use revue::query::{Query, Filter, SortBy};
+
+let query = Query::new()
+    .field_eq("status", "active")
+    .field_contains("title", "rust")
+    .sort_asc("date")
+    .limit(10)
+    .offset(20);
+```
+
+### Query Methods
+
+| Method | Description |
+|--------|-------------|
+| `Query::new()` | Empty query (matches everything) |
+| `Query::parse(input)` | Parse a query string |
+| `.filter(f)` | Add a `Filter` |
+| `.text(s)` | Add free-text search |
+| `.field_eq(field, value)` | Add equality filter |
+| `.field_contains(field, value)` | Add contains filter |
+| `.sort_by(sort)` | Set sort specification |
+| `.sort_asc(field)` | Sort ascending by field |
+| `.sort_desc(field)` | Sort descending by field |
+| `.limit(n)` | Limit to N results |
+| `.offset(n)` | Skip first N results |
+| `.matches(item)` | Check if item matches all filters |
+| `.filter_items(items)` | Filter, sort, and paginate a slice |
+| `.is_empty()` | True if no filters, sort, or limit set |
+
+## Filter Combinators
+
+Build complex filters with AND, OR, and NOT:
+
+```rust
+use revue::query::Filter;
+
+// AND: both conditions must match
+let filter = Filter::eq("status", "active")
+    .and(Filter::gt("age", "18"));
+
+// OR: either condition matches
+let filter = Filter::eq("role", "admin")
+    .or(Filter::eq("role", "moderator"));
+
+// NOT: negate a condition
+let filter = Filter::eq("status", "banned").negate();
+
+// Complex combinations
+let filter = Filter::eq("published", "true")
+    .and(
+        Filter::contains("title", "rust")
+            .or(Filter::contains("title", "cargo"))
+    );
+```
+
+### Filter Constructors
+
+| Constructor | Syntax Equivalent |
+|-------------|-------------------|
+| `Filter::text("hello")` | `hello` |
+| `Filter::eq("field", "value")` | `field:value` |
+| `Filter::ne("field", "value")` | `field:!value` |
+| `Filter::contains("field", "val")` | `field~val` |
+| `Filter::gt("field", "10")` | `field:>10` |
+| `Filter::lt("field", "10")` | `field:<10` |
+
+## QueryValue Types
+
+Fields return typed values for proper comparison:
+
+```rust
+use revue::query::QueryValue;
+
+QueryValue::string("hello")      // String comparison (case-insensitive)
+QueryValue::int(42)              // Integer comparison
+QueryValue::float(3.14)          // Float comparison
+QueryValue::bool(true)           // Boolean comparison
+QueryValue::Date("2024-01-01".into())  // Date comparison
+QueryValue::Null                 // Null value
+```
+
+## Implementing Queryable
+
+### Manual Implementation
+
+```rust
+use revue::query::{Queryable, QueryValue};
+
+struct User {
+    name: String,
+    email: String,
+    age: i64,
+    active: bool,
+}
+
+impl Queryable for User {
+    fn field_value(&self, field: &str) -> Option<QueryValue> {
+        match field {
+            "name" => Some(QueryValue::string(&self.name)),
+            "email" => Some(QueryValue::string(&self.email)),
+            "age" => Some(QueryValue::int(self.age)),
+            "active" => Some(QueryValue::bool(self.active)),
+            _ => None,
+        }
+    }
+
+    fn full_text(&self) -> String {
+        format!("{} {}", self.name, self.email)
+    }
+}
+```
+
+### Using the Macro
+
+```rust
+use revue::impl_queryable;
+
+impl_queryable!(User,
+    full_text: |u: &User| format!("{} {}", u.name, u.email),
+    fields: {
+        "name" => |u: &User| QueryValue::string(&u.name),
+        "email" => |u: &User| QueryValue::string(&u.email),
+        "age" => |u: &User| QueryValue::int(u.age),
+        "active" => |u: &User| QueryValue::bool(u.active),
+    }
+);
+```
+
+## Sorting
+
+Sort results by any queryable field:
+
+```rust
+let query = Query::new()
+    .filter(Filter::eq("active", "true"))
+    .sort_asc("name");    // A-Z
+
+let query = Query::new()
+    .sort_desc("created"); // Newest first
+```
+
+Sorting works with String, Int, Float, and Date values. Items with missing field values sort after items with values.
+
+## Pagination
+
+Combine `offset` and `limit` for pagination:
+
+```rust
+let page = 3;
+let per_page = 20;
+
+let query = Query::new()
+    .sort_asc("name")
+    .offset((page - 1) * per_page)
+    .limit(per_page);
+
+let results = query.filter_items(&all_items);
+```
+
+## Integration with Widgets
+
+### With DataGrid
+
+```rust
+use revue::query::Query;
+
+let query = Query::parse(&search_input).unwrap_or_default();
+let filtered: Vec<_> = query.filter_items(&data);
+
+let grid = DataGrid::new()
+    .rows(filtered.iter().map(|item| {
+        vec![item.name.clone(), item.age.to_string()]
+    }).collect());
+```
+
+### With VirtualList
+
+```rust
+let query = Query::new()
+    .text(&search_term)
+    .sort_asc("name");
+
+let items: Vec<_> = query.filter_items(&all_items)
+    .into_iter()
+    .cloned()
+    .collect();
+
+let list = VirtualList::new(items, |item, ctx| {
+    // render each item
+});
+```
+
+## Error Handling
+
+`Query::parse` returns a `Result<Query, ParseError>`:
+
+```rust
+match Query::parse("invalid:>:>syntax") {
+    Ok(query) => { /* use query */ }
+    Err(e) => eprintln!("Parse error: {}", e),
+}
+
+// Or use default (matches everything) on parse failure
+let query = Query::parse(&input).unwrap_or_default();
+```
+
+## See Also
+
+- [State Management Guide](state.md) - Reactive state with Signals
+- [Store Guide](store.md) - Centralized state management

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -1,0 +1,302 @@
+# Routing Guide
+
+Revue provides a declarative router for building multi-screen TUI applications with route-to-view mapping, reactive state, and navigation guards.
+
+## Overview
+
+The `DeclarativeRouter` wraps Revue's core `Router` (pattern matching, history, guards) with:
+
+- **Route-to-view mapping**: Associate routes with renderer functions
+- **Reactive state**: `Signal<ReactiveRouteState>` auto-updates on navigation
+- **Link widget**: Styled navigation links with active state
+- **Hook helpers**: Convenient functions for accessing route state
+
+## Quick Start
+
+```rust
+use revue::app::declarative_router::*;
+
+let mut router = DeclarativeRouter::new()
+    .route("/", "home", |ctx, render_ctx| {
+        // render home view
+    })
+    .route("/users/:id", "user", |ctx, render_ctx| {
+        let user_id = ctx.params.get("id").unwrap();
+        // render user view
+    })
+    .fallback(|ctx, render_ctx| {
+        // render 404 page
+    });
+
+router.push("/users/42");
+assert_eq!(router.param("id"), Some("42"));
+```
+
+## Defining Routes
+
+Register routes with a pattern, name, and renderer function:
+
+```rust
+let router = DeclarativeRouter::new()
+    .route("/", "home", |ctx, render_ctx| {
+        // Home page renderer
+    })
+    .route("/about", "about", |ctx, render_ctx| {
+        // About page renderer
+    })
+    .route("/users/:id", "user-detail", |ctx, render_ctx| {
+        // Dynamic route with parameter
+    })
+    .route("/posts/:category/:slug", "post", |ctx, render_ctx| {
+        // Multiple parameters
+    });
+```
+
+### Route Parameters
+
+Parameters are defined with `:name` syntax and accessed via `RouteContext`:
+
+```rust
+.route("/users/:id/posts/:post_id", "user-post", |ctx, render_ctx| {
+    let user_id = ctx.params.get("id").unwrap();
+    let post_id = ctx.params.get("post_id").unwrap();
+})
+```
+
+### Query Parameters
+
+Query strings are parsed automatically:
+
+```rust
+router.push("/search?q=hello&page=2");
+assert_eq!(router.query_param("q"), Some("hello"));
+assert_eq!(router.query_param("page"), Some("2"));
+```
+
+### Fallback Route
+
+Handle unmatched routes:
+
+```rust
+let router = DeclarativeRouter::new()
+    .route("/", "home", |_, _| {})
+    .fallback(|ctx, render_ctx| {
+        // Render 404 - ctx.path contains the attempted path
+    });
+```
+
+If no fallback is set, unmatched routes display "No route: /path".
+
+## Navigation
+
+### Push
+
+Navigate to a new route (adds to history):
+
+```rust
+router.push("/about");
+router.push("/users/42");
+router.push("/search?q=hello");
+```
+
+### Replace
+
+Replace the current route (no history entry):
+
+```rust
+router.replace("/login");
+// Cannot go back to previous route
+assert!(!router.can_go_back());
+```
+
+### Back / Forward
+
+Navigate through history:
+
+```rust
+router.push("/a");
+router.push("/b");
+
+router.back();     // Now at "/a"
+router.forward();  // Now at "/b"
+
+// Check availability
+if router.can_go_back() {
+    router.back();
+}
+```
+
+## Navigation Guards
+
+Guards can prevent navigation:
+
+```rust
+let router = DeclarativeRouter::new()
+    .route("/", "home", |_, _| {})
+    .route("/admin", "admin", |_, _| {})
+    .guard(|path, _params| {
+        // Return false to block navigation
+        path != "/admin" || is_authenticated()
+    });
+
+// Navigation blocked - returns false
+let navigated = router.push("/admin");
+assert!(!navigated);
+```
+
+Guards receive the target path and current route parameters. Multiple guards can be chained - all must return `true` for navigation to proceed.
+
+## Reactive State
+
+The router maintains a `Signal<ReactiveRouteState>` that updates on every navigation:
+
+```rust
+let signal = router.route_signal();
+let state = signal.get();
+
+// ReactiveRouteState fields:
+// state.path    - Current path (String)
+// state.params  - Route parameters (HashMap<String, String>)
+// state.query   - Query parameters (HashMap<String, String>)
+// state.name    - Route name if matched (Option<String>)
+```
+
+This integrates with Revue's reactive system - components that read the signal will automatically update when the route changes.
+
+## Hook Helpers
+
+Convenient functions for accessing route state:
+
+```rust
+use revue::app::declarative_router::*;
+
+// Get the reactive signal
+let signal = use_route(&router);
+
+// Get current path
+let path = use_path(&router); // String
+
+// Get all parameters
+let params = use_params(&router); // RouteParams
+
+// Get a specific parameter
+let id = use_param(&router, "id"); // Option<String>
+
+// Check if a path is active
+if is_active(&router, "/about") {
+    // Highlight navigation item
+}
+```
+
+## Link Widget
+
+The `Link` widget renders styled navigation text with active state support:
+
+```rust
+use revue::app::declarative_router::{Link, link};
+
+// Using constructor
+let nav = Link::new("/home", "Home")
+    .active(is_active(&router, "/home"));
+
+// Using helper function
+let nav = link("/about", "About")
+    .active(is_active(&router, "/about"));
+```
+
+### Styling Links
+
+```rust
+use revue::style::Color;
+
+let nav = Link::new("/settings", "Settings")
+    .fg(Color::CYAN)              // Normal text color
+    .active_fg(Color::WHITE)      // Active text color
+    .active_bg(Color::BLUE)       // Active background color
+    .underline(true)              // Underline when inactive
+    .active(true);                // Mark as active
+```
+
+Default styles:
+- **Inactive**: Cyan text, underlined
+- **Active**: White text on blue background, bold, no underline
+
+### Link Properties
+
+| Method | Default | Description |
+|--------|---------|-------------|
+| `.fg(color)` | Cyan | Text color |
+| `.active_fg(color)` | White | Active text color |
+| `.active_bg(color)` | Blue | Active background |
+| `.underline(bool)` | `true` | Underline inactive links |
+| `.active(bool)` | `false` | Active state |
+
+## View Integration
+
+`DeclarativeRouter` implements the `View` trait, so it can be composed into your widget tree:
+
+```rust
+impl View for MyApp {
+    fn render(&self, ctx: &mut RenderContext) {
+        // Render navigation bar
+        // ...
+
+        // Render current route
+        self.router.render(ctx);
+    }
+}
+```
+
+The router automatically calls the matched route's renderer function, or the fallback, or displays a default "No route" message.
+
+## Complete Example
+
+```rust
+use revue::app::declarative_router::*;
+use revue::style::Color;
+
+// Build router
+let mut router = DeclarativeRouter::new()
+    .route("/", "home", |_ctx, _render_ctx| {
+        // Render home page
+    })
+    .route("/users", "users", |_ctx, _render_ctx| {
+        // Render user list
+    })
+    .route("/users/:id", "user-detail", |ctx, _render_ctx| {
+        let _user_id = ctx.params.get("id").unwrap();
+        // Render user detail
+    })
+    .route("/settings", "settings", |_ctx, _render_ctx| {
+        // Render settings
+    })
+    .fallback(|ctx, _render_ctx| {
+        // Render 404 for unknown routes
+        let _ = format!("Page not found: {}", ctx.path);
+    })
+    .guard(|path, _| {
+        // Block access to /admin
+        !path.starts_with("/admin")
+    });
+
+// Build navigation links
+let nav_items = vec![
+    link("/", "Home").active(is_active(&router, "/")),
+    link("/users", "Users").active(is_active(&router, "/users")),
+    link("/settings", "Settings").active(is_active(&router, "/settings")),
+];
+
+// Navigate
+router.push("/users");
+router.push("/users/42");
+
+// Read reactive state
+let state = use_route(&router).get();
+assert_eq!(state.path, "/users/42");
+assert_eq!(state.name, Some("user-detail".to_string()));
+```
+
+## See Also
+
+- [State Management Guide](state.md) - Signals and reactive state
+- [Store Guide](store.md) - Centralized state management

--- a/docs/guides/state.md
+++ b/docs/guides/state.md
@@ -207,6 +207,10 @@ effect(move || {
 });
 ```
 
+## Stores
+
+For application-wide state management with actions and getters, see the [Store Guide](store.md). Stores build on Signals to provide a Pinia-inspired pattern for organizing related state into singleton containers with devtools integration.
+
 ## Example: Todo App State
 
 ```rust

--- a/docs/guides/store.md
+++ b/docs/guides/store.md
@@ -1,0 +1,307 @@
+# Store Guide
+
+Revue provides a Pinia-inspired centralized state management system using reactive signals with actions, getters, and devtools integration.
+
+## Overview
+
+Stores are singleton state containers that organize related state, actions, and getters into reusable units. They build on Revue's reactive primitives (`Signal`, `Computed`) to provide a scalable pattern for application-wide state.
+
+## Defining a Store
+
+Implement the `Store` trait to create a store:
+
+```rust
+use revue::reactive::{signal, Signal};
+use revue::reactive::store::{Store, StoreId};
+use std::collections::HashMap;
+
+struct CounterStore {
+    id: StoreId,
+    count: Signal<i32>,
+}
+
+impl Store for CounterStore {
+    fn id(&self) -> StoreId {
+        self.id
+    }
+
+    fn name(&self) -> &str {
+        "CounterStore"
+    }
+
+    fn get_state(&self) -> HashMap<String, String> {
+        let mut state = HashMap::new();
+        state.insert("count".to_string(), self.count.get().to_string());
+        state
+    }
+
+    fn get_getters(&self) -> HashMap<String, String> {
+        let mut getters = HashMap::new();
+        getters.insert("doubled".to_string(), (self.count.get() * 2).to_string());
+        getters
+    }
+}
+
+impl Default for CounterStore {
+    fn default() -> Self {
+        Self {
+            id: StoreId(1),
+            count: signal(0),
+        }
+    }
+}
+```
+
+### Store Trait Methods
+
+| Method | Purpose |
+|--------|---------|
+| `id()` | Unique identifier for this store instance |
+| `name()` | Human-readable name (used in devtools) |
+| `get_state()` | Snapshot of all state as string key-value pairs |
+| `get_getters()` | Snapshot of all computed/derived values |
+
+## Using a Store
+
+### Singleton Access with `use_store`
+
+`use_store` returns a singleton instance. The first call creates the store via `Default::default()`, and subsequent calls return the same `Arc<T>`:
+
+```rust
+use revue::reactive::store::use_store;
+
+// In any component - always returns the same instance
+let counter = use_store::<CounterStore>();
+counter.count.set(42);
+
+// Elsewhere in the app - same instance
+let counter2 = use_store::<CounterStore>();
+assert_eq!(counter2.count.get(), 42);
+```
+
+### Fresh Instances with `create_store`
+
+`create_store` always creates a new, independent instance:
+
+```rust
+use revue::reactive::store::create_store;
+
+let store1 = create_store::<CounterStore>();
+let store2 = create_store::<CounterStore>();
+// store1 and store2 are independent instances
+```
+
+This is useful for testing or when you need isolated state.
+
+## Actions
+
+Define actions as methods on your store struct:
+
+```rust
+impl CounterStore {
+    fn increment(&self) {
+        self.count.update(|c| *c += 1);
+    }
+
+    fn decrement(&self) {
+        self.count.update(|c| *c -= 1);
+    }
+
+    fn reset(&self) {
+        self.count.set(0);
+    }
+
+    fn add(&self, amount: i32) {
+        self.count.update(|c| *c += amount);
+    }
+}
+```
+
+Usage:
+
+```rust
+let counter = use_store::<CounterStore>();
+counter.increment();
+counter.add(10);
+```
+
+## Getters (Computed Values)
+
+Use `Computed` signals for derived values:
+
+```rust
+use revue::reactive::computed;
+
+impl CounterStore {
+    fn doubled(&self) -> i32 {
+        self.count.get() * 2
+    }
+
+    fn is_positive(&self) -> bool {
+        self.count.get() > 0
+    }
+}
+```
+
+## Store Registry
+
+The global `StoreRegistry` tracks all active stores for devtools and debugging:
+
+```rust
+use revue::reactive::store::{store_registry, StoreRegistry};
+use std::sync::Arc;
+
+// Register a store
+let store = Arc::new(CounterStore::default());
+store_registry().register(store.clone());
+
+// Find stores
+let found = store_registry().find_by_name("CounterStore");
+let all = store_registry().all();
+
+// Unregister
+store_registry().unregister(store.id());
+```
+
+### Registry Methods
+
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `register(store)` | `()` | Add a store to the registry |
+| `unregister(id)` | `()` | Remove a store by ID |
+| `get(id)` | `Option<Arc<dyn Store>>` | Find by ID |
+| `find_by_name(name)` | `Option<Arc<dyn Store>>` | Find by name |
+| `all()` | `Vec<Arc<dyn Store>>` | List all stores |
+
+## Subscriptions
+
+Subscribe to store changes using the `StoreExt` trait:
+
+```rust
+use revue::reactive::store::StoreExt;
+
+let counter = use_store::<CounterStore>();
+let subscription = counter.subscribe();
+
+// Subscription is automatically cleaned up when dropped
+drop(subscription);
+```
+
+## Real-World Example: Todo Store
+
+```rust
+use revue::reactive::{signal, Signal};
+use revue::reactive::store::{Store, StoreId};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug)]
+struct Todo {
+    id: usize,
+    text: String,
+    completed: bool,
+}
+
+struct TodoStore {
+    id: StoreId,
+    todos: Signal<Vec<Todo>>,
+    next_id: Signal<usize>,
+    filter: Signal<TodoFilter>,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum TodoFilter {
+    All,
+    Active,
+    Completed,
+}
+
+impl Default for TodoStore {
+    fn default() -> Self {
+        Self {
+            id: StoreId(100),
+            todos: signal(vec![]),
+            next_id: signal(1),
+            filter: signal(TodoFilter::All),
+        }
+    }
+}
+
+impl TodoStore {
+    // Actions
+    fn add(&self, text: String) {
+        let id = self.next_id.get();
+        self.next_id.update(|n| *n += 1);
+        self.todos.update(|todos| {
+            todos.push(Todo { id, text, completed: false });
+        });
+    }
+
+    fn toggle(&self, id: usize) {
+        self.todos.update(|todos| {
+            if let Some(todo) = todos.iter_mut().find(|t| t.id == id) {
+                todo.completed = !todo.completed;
+            }
+        });
+    }
+
+    fn remove(&self, id: usize) {
+        self.todos.update(|todos| {
+            todos.retain(|t| t.id != id);
+        });
+    }
+
+    fn set_filter(&self, filter: TodoFilter) {
+        self.filter.set(filter);
+    }
+
+    // Getters
+    fn filtered_todos(&self) -> Vec<Todo> {
+        let todos = self.todos.get();
+        let filter = self.filter.get();
+        todos.iter().filter(|t| match filter {
+            TodoFilter::All => true,
+            TodoFilter::Active => !t.completed,
+            TodoFilter::Completed => t.completed,
+        }).cloned().collect()
+    }
+
+    fn remaining_count(&self) -> usize {
+        self.todos.get().iter().filter(|t| !t.completed).count()
+    }
+}
+
+impl Store for TodoStore {
+    fn id(&self) -> StoreId { self.id }
+    fn name(&self) -> &str { "TodoStore" }
+
+    fn get_state(&self) -> HashMap<String, String> {
+        let mut state = HashMap::new();
+        state.insert("count".into(), self.todos.get().len().to_string());
+        state.insert("remaining".into(), self.remaining_count().to_string());
+        state
+    }
+
+    fn get_getters(&self) -> HashMap<String, String> {
+        let mut getters = HashMap::new();
+        getters.insert("filtered_count".into(), self.filtered_todos().len().to_string());
+        getters
+    }
+}
+```
+
+## DevTools Integration
+
+Stores expose their state via `get_state()` and `get_getters()`, which the devtools inspector uses to display live state. Enable devtools to inspect stores at runtime:
+
+```rust
+let app = App::builder()
+    .devtools(true)  // F12 to toggle
+    .build();
+```
+
+The **State Debugger** panel shows all registered stores with their current state and getter values.
+
+## See Also
+
+- [State Management Guide](state.md) - Signals, Computed, Effects
+- [Testing Guide](testing.md) - Testing stores with MockState

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -20,8 +20,8 @@ fn test_counter() {
 
     // Simulate interactions
     pilot
-        .press(Key::Up)
-        .press(Key::Up)
+        .press_key(Key::Up)
+        .press_key(Key::Up)
         .assert_contains("2");
 }
 ```
@@ -38,28 +38,82 @@ let config = TestConfig {
 let mut app = TestApp::with_config(MyWidget::new(), config);
 ```
 
+### Custom Size
+
+```rust
+let mut app = TestApp::with_size(MyWidget::new(), 120, 40);
+```
+
+## TestApp
+
+`TestApp` wraps a `View` widget with a virtual terminal buffer for testing.
+
+### Construction
+
+```rust
+TestApp::new(view)                          // 80x24 default
+TestApp::with_size(view, 120, 40)           // Custom size
+TestApp::with_config(view, config)          // Full config
+```
+
+### Event Handlers
+
+Register custom event handlers for testing interactive widgets:
+
+```rust
+let app = TestApp::new(MyWidget::new())
+    .on_key(|event, view| {
+        view.handle_key(event);
+        true
+    })
+    .on_mouse(|event, view| {
+        view.handle_mouse(event);
+        true
+    });
+```
+
+### Buffer Access
+
+```rust
+let text = app.screen_text();               // Full screen as string
+let line = app.get_line(0);                 // Single line
+let ch = app.get_cell(5, 3);               // Single character
+let found = app.find_text("hello");         // Find text position
+let has = app.contains("world");            // Check text exists
+```
+
 ## Simulating Input
 
 ### Keyboard
 
 ```rust
 pilot
-    .press(Key::Enter)           // Single key
-    .press(Key::Char('a'))       // Character
-    .type_text("hello world")    // Type string
-    .press_ctrl('c')             // Ctrl+C
-    .press_alt('x');             // Alt+X
+    .press_key(Key::Enter)           // Single key
+    .press_key(Key::Char('a'))       // Character
+    .type_text("hello world")        // Type string
+    .press_ctrl(Key::Char('c'))      // Ctrl+C
+    .press_alt(Key::Char('x'))       // Alt+X
+    .press_enter()                   // Convenience methods
+    .press_escape()
+    .press_tab()
+    .press_up()
+    .press_down();
 ```
 
 ### Mouse
 
 ```rust
 pilot
-    .click(10, 5)                // Click at position
+    .click(10, 5)                    // Click at position
     .double_click(10, 5)
-    .right_click(10, 5)
-    .scroll_up(10, 5)
-    .scroll_down(10, 5);
+    .scroll_up(10, 5, 1)
+    .scroll_down(10, 5, 1);
+```
+
+### Click on Text
+
+```rust
+pilot.click_text("Submit");          // Find and click text
 ```
 
 ## Assertions
@@ -68,19 +122,26 @@ pilot
 
 ```rust
 pilot
-    .assert_contains("Hello")           // Text exists
-    .assert_not_contains("Error")       // Text doesn't exist
-    .assert_line(0, "Title")            // Specific line
-    .assert_cell(0, 0, 'H');            // Specific cell
+    .assert_contains("Hello")               // Text exists
+    .assert_not_contains("Error")           // Text doesn't exist
+    .assert_line_contains(0, "Title")       // Line contains text
+    .assert_cell(0, 0, 'H');               // Specific cell character
 ```
 
-### State Assertions
+### Screen Comparison
 
 ```rust
-pilot
-    .assert_focused(".input")           // Focus check
-    .assert_visible("#modal")           // Visibility check
-    .assert_selected(2);                // Selection index
+pilot.assert_screen("expected full screen content");
+```
+
+### Querying
+
+```rust
+let text = pilot.screen();                  // Full screen text
+let line = pilot.line(3);                   // Specific line
+let ch = pilot.cell(5, 2);                 // Specific cell
+let found = pilot.find_text("hello");       // (x, y) position
+let has = pilot.screen_contains("world");   // Boolean check
 ```
 
 ## Snapshot Testing
@@ -95,42 +156,256 @@ fn test_widget_snapshot() {
 
     pilot.snapshot("my_widget_initial");
 
-    pilot.press(Key::Enter);
+    pilot.press_key(Key::Enter);
     pilot.snapshot("my_widget_after_enter");
 }
 ```
 
-Update snapshots with:
+Snapshots are stored in `tests/snapshots/` by default.
+
+Update snapshots when output intentionally changes:
 ```bash
 REVUE_UPDATE_SNAPSHOTS=1 cargo test
 ```
 
+### SnapshotManager
+
+For direct snapshot control:
+
+```rust
+use revue::testing::SnapshotManager;
+
+let manager = SnapshotManager::new();              // tests/snapshots/
+let manager = SnapshotManager::with_dir("custom"); // Custom directory
+
+manager.assert_snapshot("name", "content");
+manager.assert_buffer_snapshot("name", &buffer);
+
+// Query
+manager.snapshot_exists("name");
+manager.list_snapshots();
+manager.delete_snapshot("name");
+```
+
 ## Visual Regression Testing
 
-Capture and compare visual output:
+Capture and compare visual output including styles and colors:
 
 ```rust
 use revue::testing::{VisualTest, VisualTestConfig};
 
 #[test]
 fn test_visual_regression() {
-    let config = VisualTestConfig::new("tests/golden");
-    let mut test = VisualTest::new(config);
+    let test = VisualTest::new("dashboard_initial")
+        .group("dashboard");
 
     let mut app = TestApp::new(Dashboard::new());
-    let mut pilot = Pilot::new(&mut app);
-
-    // Capture visual state
-    let capture = pilot.capture();
+    let pilot = Pilot::new(&mut app);
 
     // Compare against golden file
-    test.assert_matches("dashboard_initial", &capture);
+    test.assert_matches(pilot.buffer());
 }
 ```
 
-Update golden files:
+### Configuration
+
+```rust
+let config = VisualTestConfig::with_dir("tests/golden")
+    .tolerance(5)               // Color tolerance (0=exact, 255=any)
+    .generate_diff(true)        // Generate diff output on failure
+    .include_styles(true)       // Compare bold, italic, underline
+    .include_colors(true);      // Compare fg/bg colors
+
+let test = VisualTest::with_config("widget_test", config);
+```
+
+Update golden files when visuals intentionally change:
 ```bash
 REVUE_UPDATE_VISUALS=1 cargo test
+```
+
+### Visual Capture
+
+Capture detailed visual state for comparison:
+
+```rust
+use revue::testing::VisualCapture;
+
+let capture = VisualCapture::from_buffer(&buffer, true, true);
+let cell = capture.get(5, 3);  // CapturedCell with symbol, colors, styles
+
+// Compare two captures
+let diff = capture.diff(&other_capture, 0);
+if diff.has_differences() {
+    println!("{}", diff.summary());
+}
+```
+
+## Action Sequences
+
+Create reusable sequences of test actions:
+
+```rust
+use revue::testing::ActionSequence;
+
+let login_sequence = ActionSequence::new()
+    .type_text("admin")
+    .press(Key::Tab)
+    .type_text("password")
+    .press(Key::Enter);
+
+// Reuse across tests
+let nav_sequence = ActionSequence::new()
+    .press(Key::Down)
+    .press(Key::Down)
+    .press(Key::Enter);
+```
+
+### Action Types
+
+```rust
+use revue::testing::{Action, KeyAction, MouseAction};
+
+// Key actions
+KeyAction::press(Key::Enter)
+KeyAction::press_ctrl(Key::Char('c'))
+KeyAction::press_alt(Key::Char('x'))
+KeyAction::type_text("hello")
+
+// Mouse actions
+MouseAction::click(10, 5)
+MouseAction::double_click(10, 5)
+MouseAction::right_click(10, 5)
+MouseAction::drag(0, 0, 10, 10)
+MouseAction::move_to(5, 5)
+
+// Timing
+Action::Wait(Duration::from_millis(100))
+Action::Resize(120, 40)
+```
+
+## Async Testing
+
+### AsyncPilot
+
+Test async views:
+
+```rust
+use revue::testing::AsyncPilot;
+
+#[tokio::test]
+async fn test_async_view() {
+    AsyncPilot::run(MyAsyncView::new(), |mut pilot| async move {
+        pilot.press_key(Key::Enter);
+        pilot.wait_until_async(|buf| buf.contains("Loaded")).await;
+        pilot.assert_contains("Data loaded");
+    }).await;
+}
+```
+
+### Waiting
+
+```rust
+// Wait fixed duration
+pilot.wait_ms(500);
+
+// Wait until condition
+pilot.wait_until(|buffer| buffer.contains("Ready"));
+```
+
+## Mock Utilities
+
+### MockTerminal
+
+Virtual terminal for testing without a real terminal:
+
+```rust
+use revue::testing::mock_terminal;
+
+let terminal = mock_terminal(80, 24);
+assert_eq!(terminal.size(), (80, 24));
+let buffer = terminal.buffer();
+terminal.resize(120, 40);
+```
+
+### MockTime
+
+Control time progression in tests:
+
+```rust
+use revue::testing::mock_time;
+
+let time = mock_time();
+assert_eq!(time.elapsed_ms(), 0);
+
+time.advance_ms(500);
+assert_eq!(time.elapsed_ms(), 500);
+
+time.advance_secs(2);
+assert_eq!(time.elapsed_ms(), 2500);
+
+time.reset();
+assert_eq!(time.elapsed_ms(), 0);
+```
+
+### MockState
+
+Track state changes:
+
+```rust
+use revue::testing::MockState;
+
+let state = MockState::new(0);
+assert_eq!(state.value(), 0);
+
+state.set(42);
+assert_eq!(state.value(), 42);
+assert_eq!(state.change_count(), 1);
+
+state.update(|v| *v += 1);
+assert_eq!(state.value(), 43);
+assert_eq!(state.change_count(), 2);
+
+state.reset_count();
+assert_eq!(state.change_count(), 0);
+```
+
+### EventSimulator
+
+Build event sequences fluently:
+
+```rust
+use revue::testing::simulate_user;
+
+let mut sim = simulate_user()
+    .type_text("hello")
+    .tab()
+    .type_text("world")
+    .enter()
+    .click(10, 5)
+    .wait_ms(100);
+
+while let Some(event) = sim.poll_event() {
+    // Process simulated events
+}
+```
+
+### RenderCapture
+
+Capture and inspect render output:
+
+```rust
+use revue::testing::capture_render;
+
+let mut capture = capture_render(80, 24);
+// ... render into capture.buffer_mut() ...
+
+assert!(capture.contains("Hello"));
+let pos = capture.find("World");
+let ch = capture.char_at(0, 0);
+
+// Diff two captures
+let changes = capture.diff(&other);
 ```
 
 ## CI Integration
@@ -140,23 +415,35 @@ Revue detects CI environments automatically:
 ```rust
 use revue::testing::{CiEnvironment, TestReport};
 
-#[test]
-fn test_with_ci_report() {
-    let ci = CiEnvironment::detect();
+let ci = CiEnvironment::detect();
+// ci.provider: GitHubActions, GitLabCi, CircleCi, etc.
+// ci.is_ci: true in CI, false locally
+// ci.branch: current branch name
+// ci.commit: commit SHA
+// ci.pr_number: PR number if applicable
+```
 
-    // Run tests
-    let results = run_tests();
+### Test Reports
 
-    // Generate report
-    let report = TestReport::new(results);
+Generate reports for CI:
 
-    if ci.is_github_actions() {
-        // Outputs GitHub Actions annotations
-        report.github_annotations();
-    }
+```rust
+let mut report = TestReport::new();
 
-    report.save_markdown("test-report.md");
-}
+report.add_passed("widget_render");
+report.add_failed("modal_close", "Expected 'Closed' but found 'Open'");
+report.add_metadata("duration", "1.5s");
+
+println!("{}", report.summary());
+// Passed: 1, Failed: 1, Total: 2
+
+// Output as markdown
+let md = report.to_markdown();
+
+// CI-specific output
+let ci = CiEnvironment::detect();
+report.write_summary(&ci);
+report.save_artifacts(&ci).ok();
 ```
 
 ## Testing Patterns
@@ -169,16 +456,11 @@ fn test_navigation() {
     let mut app = TestApp::new(List::new(items));
     let mut pilot = Pilot::new(&mut app);
 
-    // Initial state
-    pilot.assert_selected(0);
+    pilot.press_down();
+    pilot.assert_contains("Item 2");  // Second item highlighted
 
-    // Navigate down
-    pilot.press(Key::Down);
-    pilot.assert_selected(1);
-
-    // Navigate up
-    pilot.press(Key::Up);
-    pilot.assert_selected(0);
+    pilot.press_up();
+    pilot.assert_contains("Item 1");  // Back to first
 }
 ```
 
@@ -191,15 +473,15 @@ fn test_form_validation() {
     let mut pilot = Pilot::new(&mut app);
 
     // Empty submit shows error
-    pilot.press(Key::Enter);
+    pilot.press_enter();
     pilot.assert_contains("Required");
 
     // Fill form
     pilot
         .type_text("user@example.com")
-        .press(Key::Tab)
+        .press_tab()
         .type_text("password123")
-        .press(Key::Enter);
+        .press_enter();
 
     pilot.assert_contains("Success");
 }
@@ -213,14 +495,26 @@ fn test_async_loading() {
     let mut app = TestApp::new(DataLoader::new());
     let mut pilot = Pilot::new(&mut app);
 
-    // Shows loading state
     pilot.assert_contains("Loading");
-
-    // Wait for data
     pilot.wait_ms(1000);
-
-    // Shows loaded data
     pilot.assert_contains("Data loaded");
+}
+```
+
+### Testing Resize
+
+```rust
+#[test]
+fn test_responsive_layout() {
+    let mut app = TestApp::new(Dashboard::new());
+    let mut pilot = Pilot::new(&mut app);
+
+    // Full width
+    pilot.assert_contains("Sidebar");
+
+    // Narrow width - sidebar collapses
+    pilot.resize(40, 24);
+    pilot.assert_not_contains("Sidebar");
 }
 ```
 
@@ -239,6 +533,13 @@ DevTools panels:
 - **State Debugger**: Signal values
 - **Style Inspector**: Applied CSS
 - **Event Logger**: Event stream
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `REVUE_UPDATE_SNAPSHOTS=1` | Update snapshot files instead of comparing |
+| `REVUE_UPDATE_VISUALS=1` | Update visual golden files instead of comparing |
 
 ## Best Practices
 
@@ -269,7 +570,6 @@ pilot.snapshot("test1");
 fn test_empty_list() {
     let mut app = TestApp::new(List::new(vec![]));
     let mut pilot = Pilot::new(&mut app);
-
     pilot.assert_contains("No items");
 }
 
@@ -302,3 +602,23 @@ fn test_b() {
     // ...
 }
 ```
+
+### 5. Use MockTime for Timing-Dependent Tests
+
+```rust
+#[test]
+fn test_animation() {
+    let time = mock_time();
+    let mut app = TestApp::new(AnimatedWidget::new(&time));
+    let mut pilot = Pilot::new(&mut app);
+
+    pilot.assert_contains("Frame 1");
+    time.advance_ms(500);
+    pilot.assert_contains("Frame 2");
+}
+```
+
+## See Also
+
+- [State Management Guide](state.md) - Signals and reactive primitives
+- [Store Guide](store.md) - Testing stores with MockState


### PR DESCRIPTION
## Summary

- Add `docs/guides/store.md`: Pinia-inspired store system guide (Store trait, use_store/create_store, StoreRegistry, subscriptions, devtools integration)
- Add `docs/guides/query.md`: Query DSL guide (filters, sorting, pagination, Queryable trait, impl_queryable! macro, full syntax reference)
- Add `docs/guides/routing.md`: DeclarativeRouter guide (route-to-view mapping, reactive state, guards, Link widget, hook helpers)
- Enhance `docs/guides/testing.md`: add AsyncPilot, ActionSequence, MockTerminal/MockTime/MockState, EventSimulator, RenderCapture, SnapshotManager, VisualCapture, CI integration with TestReport
- Update `docs/guides/state.md`: add Store cross-reference section
- Fix CI: add `--tests` to `cargo llvm-cov` commands so integration tests from `tests/` directory are included in coverage reports

## Test plan

- [ ] CI passes (docs-only changes + CI config fix)
- [ ] Verify coverage job now includes `--tests` flag