### PR TITLE
test: add 157 tests for BiDi, validation, and syntax keywords

### DIFF
--- a/src/widget/syntax/mod.rs
+++ b/src/widget/syntax/mod.rs
@@ -8,7 +8,7 @@ mod go;
 mod html;
 mod javascript;
 mod json;
-mod keywords;
+pub mod keywords;
 mod markdown;
 mod python;
 mod rust;

--- a/tests/syntax_keywords_tests.rs
+++ b/tests/syntax_keywords_tests.rs
@@ -1,0 +1,236 @@
+//! Tests for syntax keyword detection functions
+
+use revue::widget::syntax::keywords::{
+    is_go_keyword, is_javascript_keyword, is_python_keyword, is_rust_keyword, is_shell_keyword,
+    is_sql_keyword,
+};
+
+// ============================================================
+// is_rust_keyword
+// ============================================================
+
+#[test]
+fn rust_keyword_fn() {
+    assert!(is_rust_keyword("fn"));
+}
+
+#[test]
+fn rust_keyword_let_mut_pub() {
+    assert!(is_rust_keyword("let"));
+    assert!(is_rust_keyword("mut"));
+    assert!(is_rust_keyword("pub"));
+}
+
+#[test]
+fn rust_keyword_struct_impl_trait() {
+    assert!(is_rust_keyword("struct"));
+    assert!(is_rust_keyword("impl"));
+    assert!(is_rust_keyword("trait"));
+}
+
+#[test]
+fn rust_keyword_async_match() {
+    assert!(is_rust_keyword("async"));
+    assert!(is_rust_keyword("match"));
+}
+
+#[test]
+fn rust_keyword_self_variants() {
+    assert!(is_rust_keyword("self"));
+    assert!(is_rust_keyword("Self"));
+}
+
+#[test]
+fn rust_not_keyword() {
+    assert!(!is_rust_keyword("println"));
+    assert!(!is_rust_keyword("String"));
+    assert!(!is_rust_keyword("Vec"));
+    assert!(!is_rust_keyword(""));
+}
+
+// ============================================================
+// is_python_keyword
+// ============================================================
+
+#[test]
+fn python_keyword_def_class_import() {
+    assert!(is_python_keyword("def"));
+    assert!(is_python_keyword("class"));
+    assert!(is_python_keyword("import"));
+}
+
+#[test]
+fn python_keyword_if_elif_lambda_yield() {
+    assert!(is_python_keyword("if"));
+    assert!(is_python_keyword("elif"));
+    assert!(is_python_keyword("lambda"));
+    assert!(is_python_keyword("yield"));
+}
+
+#[test]
+fn python_keyword_async_await() {
+    assert!(is_python_keyword("async"));
+    assert!(is_python_keyword("await"));
+}
+
+#[test]
+fn python_not_keyword() {
+    assert!(!is_python_keyword("print"));
+    assert!(!is_python_keyword("len"));
+    assert!(!is_python_keyword("self"));
+    assert!(!is_python_keyword(""));
+}
+
+// ============================================================
+// is_javascript_keyword
+// ============================================================
+
+#[test]
+fn javascript_keyword_function_const_let_var() {
+    assert!(is_javascript_keyword("function"));
+    assert!(is_javascript_keyword("const"));
+    assert!(is_javascript_keyword("let"));
+    assert!(is_javascript_keyword("var"));
+}
+
+#[test]
+fn javascript_keyword_class_async_await() {
+    assert!(is_javascript_keyword("class"));
+    assert!(is_javascript_keyword("async"));
+    assert!(is_javascript_keyword("await"));
+}
+
+#[test]
+fn javascript_keyword_this_typeof() {
+    assert!(is_javascript_keyword("this"));
+    assert!(is_javascript_keyword("typeof"));
+}
+
+#[test]
+fn javascript_not_keyword() {
+    assert!(!is_javascript_keyword("console"));
+    assert!(!is_javascript_keyword("undefined"));
+    assert!(!is_javascript_keyword("NaN"));
+    assert!(!is_javascript_keyword(""));
+}
+
+// ============================================================
+// is_shell_keyword
+// ============================================================
+
+#[test]
+fn shell_keyword_if_then_fi() {
+    assert!(is_shell_keyword("if"));
+    assert!(is_shell_keyword("then"));
+    assert!(is_shell_keyword("fi"));
+}
+
+#[test]
+fn shell_keyword_case_esac() {
+    assert!(is_shell_keyword("case"));
+    assert!(is_shell_keyword("esac"));
+}
+
+#[test]
+fn shell_keyword_for_while_do_done() {
+    assert!(is_shell_keyword("for"));
+    assert!(is_shell_keyword("while"));
+    assert!(is_shell_keyword("do"));
+    assert!(is_shell_keyword("done"));
+}
+
+#[test]
+fn shell_keyword_echo_cd_export() {
+    assert!(is_shell_keyword("echo"));
+    assert!(is_shell_keyword("cd"));
+    assert!(is_shell_keyword("export"));
+}
+
+#[test]
+fn shell_not_keyword() {
+    assert!(!is_shell_keyword("ls"));
+    assert!(!is_shell_keyword("grep"));
+    assert!(!is_shell_keyword("awk"));
+    assert!(!is_shell_keyword(""));
+}
+
+// ============================================================
+// is_sql_keyword
+// ============================================================
+
+#[test]
+fn sql_keyword_select_from_where() {
+    assert!(is_sql_keyword("SELECT"));
+    assert!(is_sql_keyword("FROM"));
+    assert!(is_sql_keyword("WHERE"));
+}
+
+#[test]
+fn sql_keyword_case_insensitive() {
+    assert!(is_sql_keyword("select"));
+    assert!(is_sql_keyword("Select"));
+    assert!(is_sql_keyword("FROM"));
+    assert!(is_sql_keyword("from"));
+}
+
+#[test]
+fn sql_keyword_join_group_order() {
+    assert!(is_sql_keyword("JOIN"));
+    assert!(is_sql_keyword("GROUP"));
+    assert!(is_sql_keyword("ORDER"));
+}
+
+#[test]
+fn sql_keyword_insert_update_delete() {
+    assert!(is_sql_keyword("INSERT"));
+    assert!(is_sql_keyword("UPDATE"));
+    assert!(is_sql_keyword("DELETE"));
+}
+
+#[test]
+fn sql_not_keyword() {
+    assert!(!is_sql_keyword("COLUMN_NAME"));
+    assert!(!is_sql_keyword("users"));
+    assert!(!is_sql_keyword("id"));
+    assert!(!is_sql_keyword(""));
+}
+
+// ============================================================
+// is_go_keyword
+// ============================================================
+
+#[test]
+fn go_keyword_func_package_import() {
+    assert!(is_go_keyword("func"));
+    assert!(is_go_keyword("package"));
+    assert!(is_go_keyword("import"));
+}
+
+#[test]
+fn go_keyword_go_chan_defer() {
+    assert!(is_go_keyword("go"));
+    assert!(is_go_keyword("chan"));
+    assert!(is_go_keyword("defer"));
+}
+
+#[test]
+fn go_keyword_interface_struct_type() {
+    assert!(is_go_keyword("interface"));
+    assert!(is_go_keyword("struct"));
+    assert!(is_go_keyword("type"));
+}
+
+#[test]
+fn go_keyword_select_range_map() {
+    assert!(is_go_keyword("select"));
+    assert!(is_go_keyword("range"));
+    assert!(is_go_keyword("map"));
+}
+
+#[test]
+fn go_not_keyword() {
+    assert!(!is_go_keyword("fmt"));
+    assert!(!is_go_keyword("Println"));
+    assert!(!is_go_keyword("main"));
+    assert!(!is_go_keyword(""));
+}

--- a/tests/text_bidi_tests.rs
+++ b/tests/text_bidi_tests.rs
@@ -1,0 +1,597 @@
+//! Tests for BiDi text handling (helpers.rs and types.rs)
+
+use revue::text::{
+    contains_rtl, detect_direction, is_rtl_char, mirror_char, reverse_graphemes, BidiClass,
+    BidiInfo, BidiRun, ResolvedDirection, RtlLayout, TextAlign, TextDirection,
+};
+
+// ============================================================
+// helpers.rs — detect_direction
+// ============================================================
+
+#[test]
+fn detect_direction_latin_text_returns_ltr() {
+    assert_eq!(detect_direction("Hello world"), ResolvedDirection::Ltr);
+}
+
+#[test]
+fn detect_direction_arabic_text_returns_rtl() {
+    assert_eq!(detect_direction("مرحبا"), ResolvedDirection::Rtl);
+}
+
+#[test]
+fn detect_direction_hebrew_text_returns_rtl() {
+    assert_eq!(detect_direction("שלום"), ResolvedDirection::Rtl);
+}
+
+#[test]
+fn detect_direction_mixed_latin_first_returns_ltr() {
+    assert_eq!(detect_direction("Hello مرحبا"), ResolvedDirection::Ltr);
+}
+
+#[test]
+fn detect_direction_mixed_arabic_first_returns_rtl() {
+    assert_eq!(detect_direction("مرحبا Hello"), ResolvedDirection::Rtl);
+}
+
+#[test]
+fn detect_direction_empty_string_returns_ltr() {
+    assert_eq!(detect_direction(""), ResolvedDirection::Ltr);
+}
+
+#[test]
+fn detect_direction_digits_only_returns_ltr() {
+    assert_eq!(detect_direction("12345"), ResolvedDirection::Ltr);
+}
+
+#[test]
+fn detect_direction_spaces_only_returns_ltr() {
+    assert_eq!(detect_direction("   "), ResolvedDirection::Ltr);
+}
+
+// ============================================================
+// helpers.rs — is_rtl_char
+// ============================================================
+
+#[test]
+fn is_rtl_char_arabic_returns_true() {
+    assert!(is_rtl_char('م'));
+}
+
+#[test]
+fn is_rtl_char_hebrew_returns_true() {
+    assert!(is_rtl_char('ש'));
+}
+
+#[test]
+fn is_rtl_char_latin_returns_false() {
+    assert!(!is_rtl_char('A'));
+}
+
+#[test]
+fn is_rtl_char_cjk_returns_false() {
+    assert!(!is_rtl_char('漢'));
+}
+
+#[test]
+fn is_rtl_char_digit_returns_false() {
+    assert!(!is_rtl_char('5'));
+}
+
+// ============================================================
+// helpers.rs — contains_rtl
+// ============================================================
+
+#[test]
+fn contains_rtl_with_arabic_returns_true() {
+    assert!(contains_rtl("Hello مرحبا world"));
+}
+
+#[test]
+fn contains_rtl_latin_only_returns_false() {
+    assert!(!contains_rtl("Hello world"));
+}
+
+#[test]
+fn contains_rtl_empty_returns_false() {
+    assert!(!contains_rtl(""));
+}
+
+// ============================================================
+// helpers.rs — mirror_char
+// ============================================================
+
+#[test]
+fn mirror_char_parentheses() {
+    assert_eq!(mirror_char('('), ')');
+    assert_eq!(mirror_char(')'), '(');
+}
+
+#[test]
+fn mirror_char_square_brackets() {
+    assert_eq!(mirror_char('['), ']');
+    assert_eq!(mirror_char(']'), '[');
+}
+
+#[test]
+fn mirror_char_curly_braces() {
+    assert_eq!(mirror_char('{'), '}');
+    assert_eq!(mirror_char('}'), '{');
+}
+
+#[test]
+fn mirror_char_angle_brackets() {
+    assert_eq!(mirror_char('<'), '>');
+    assert_eq!(mirror_char('>'), '<');
+}
+
+#[test]
+fn mirror_char_guillemets() {
+    assert_eq!(mirror_char('«'), '»');
+    assert_eq!(mirror_char('»'), '«');
+}
+
+#[test]
+fn mirror_char_single_guillemets() {
+    assert_eq!(mirror_char('‹'), '›');
+    assert_eq!(mirror_char('›'), '‹');
+}
+
+#[test]
+fn mirror_char_math_angle_brackets() {
+    assert_eq!(mirror_char('⟨'), '⟩');
+    assert_eq!(mirror_char('⟩'), '⟨');
+    assert_eq!(mirror_char('⟪'), '⟫');
+    assert_eq!(mirror_char('⟫'), '⟪');
+}
+
+#[test]
+fn mirror_char_square_lenticular() {
+    assert_eq!(mirror_char('⁅'), '⁆');
+    assert_eq!(mirror_char('⁆'), '⁅');
+}
+
+#[test]
+fn mirror_char_no_mirror_returns_same() {
+    assert_eq!(mirror_char('a'), 'a');
+    assert_eq!(mirror_char('Z'), 'Z');
+    assert_eq!(mirror_char('5'), '5');
+}
+
+// ============================================================
+// helpers.rs — reverse_graphemes
+// ============================================================
+
+#[test]
+fn reverse_graphemes_ascii() {
+    assert_eq!(reverse_graphemes("hello"), "olleh");
+}
+
+#[test]
+fn reverse_graphemes_multibyte() {
+    assert_eq!(reverse_graphemes("가나다"), "다나가");
+}
+
+#[test]
+fn reverse_graphemes_empty() {
+    assert_eq!(reverse_graphemes(""), "");
+}
+
+#[test]
+fn reverse_graphemes_single_char() {
+    assert_eq!(reverse_graphemes("x"), "x");
+}
+
+// ============================================================
+// types.rs — TextDirection
+// ============================================================
+
+#[test]
+fn text_direction_is_rtl() {
+    assert!(TextDirection::Rtl.is_rtl());
+    assert!(!TextDirection::Ltr.is_rtl());
+    assert!(!TextDirection::Auto.is_rtl());
+}
+
+#[test]
+fn text_direction_is_ltr() {
+    assert!(TextDirection::Ltr.is_ltr());
+    assert!(!TextDirection::Rtl.is_ltr());
+    assert!(!TextDirection::Auto.is_ltr());
+}
+
+#[test]
+fn text_direction_is_auto() {
+    assert!(TextDirection::Auto.is_auto());
+    assert!(!TextDirection::Ltr.is_auto());
+    assert!(!TextDirection::Rtl.is_auto());
+}
+
+#[test]
+fn text_direction_default_is_ltr() {
+    assert_eq!(TextDirection::default(), TextDirection::Ltr);
+}
+
+#[test]
+fn text_direction_resolve_ltr() {
+    assert_eq!(TextDirection::Ltr.resolve("مرحبا"), ResolvedDirection::Ltr);
+}
+
+#[test]
+fn text_direction_resolve_rtl() {
+    assert_eq!(TextDirection::Rtl.resolve("Hello"), ResolvedDirection::Rtl);
+}
+
+#[test]
+fn text_direction_resolve_auto_latin() {
+    assert_eq!(TextDirection::Auto.resolve("Hello"), ResolvedDirection::Ltr);
+}
+
+#[test]
+fn text_direction_resolve_auto_arabic() {
+    assert_eq!(TextDirection::Auto.resolve("مرحبا"), ResolvedDirection::Rtl);
+}
+
+// ============================================================
+// types.rs — ResolvedDirection
+// ============================================================
+
+#[test]
+fn resolved_direction_is_rtl() {
+    assert!(ResolvedDirection::Rtl.is_rtl());
+    assert!(!ResolvedDirection::Ltr.is_rtl());
+}
+
+#[test]
+fn resolved_direction_is_ltr() {
+    assert!(ResolvedDirection::Ltr.is_ltr());
+    assert!(!ResolvedDirection::Rtl.is_ltr());
+}
+
+#[test]
+fn resolved_direction_opposite() {
+    assert_eq!(ResolvedDirection::Ltr.opposite(), ResolvedDirection::Rtl);
+    assert_eq!(ResolvedDirection::Rtl.opposite(), ResolvedDirection::Ltr);
+}
+
+#[test]
+fn resolved_direction_default_is_ltr() {
+    assert_eq!(ResolvedDirection::default(), ResolvedDirection::Ltr);
+}
+
+// ============================================================
+// types.rs — BidiClass::of
+// ============================================================
+
+#[test]
+fn bidi_class_of_latin_is_l() {
+    assert_eq!(BidiClass::of('A'), BidiClass::L);
+    assert_eq!(BidiClass::of('z'), BidiClass::L);
+}
+
+#[test]
+fn bidi_class_of_hebrew_is_r() {
+    assert_eq!(BidiClass::of('א'), BidiClass::R);
+    assert_eq!(BidiClass::of('ש'), BidiClass::R);
+}
+
+#[test]
+fn bidi_class_of_arabic_is_al() {
+    assert_eq!(BidiClass::of('م'), BidiClass::AL);
+    assert_eq!(BidiClass::of('ع'), BidiClass::AL);
+}
+
+#[test]
+fn bidi_class_of_digit_is_en() {
+    assert_eq!(BidiClass::of('0'), BidiClass::EN);
+    assert_eq!(BidiClass::of('9'), BidiClass::EN);
+}
+
+#[test]
+fn bidi_class_of_arabic_number_is_an() {
+    assert_eq!(BidiClass::of('٠'), BidiClass::AN); // U+0660
+    assert_eq!(BidiClass::of('٩'), BidiClass::AN); // U+0669
+}
+
+#[test]
+fn bidi_class_of_whitespace_is_ws() {
+    assert_eq!(BidiClass::of(' '), BidiClass::WS);
+}
+
+#[test]
+fn bidi_class_of_punctuation_is_on() {
+    assert_eq!(BidiClass::of('!'), BidiClass::ON);
+    assert_eq!(BidiClass::of('('), BidiClass::ON);
+}
+
+#[test]
+fn bidi_class_of_plus_minus_is_es() {
+    assert_eq!(BidiClass::of('+'), BidiClass::ES);
+    assert_eq!(BidiClass::of('-'), BidiClass::ES);
+}
+
+#[test]
+fn bidi_class_of_number_sign_is_et() {
+    assert_eq!(BidiClass::of('#'), BidiClass::ET);
+    assert_eq!(BidiClass::of('$'), BidiClass::ET);
+    assert_eq!(BidiClass::of('%'), BidiClass::ET);
+}
+
+#[test]
+fn bidi_class_of_comma_is_cs() {
+    assert_eq!(BidiClass::of(','), BidiClass::CS);
+    assert_eq!(BidiClass::of('.'), BidiClass::CS);
+    assert_eq!(BidiClass::of(':'), BidiClass::CS);
+}
+
+#[test]
+fn bidi_class_of_newline_is_b() {
+    assert_eq!(BidiClass::of('\n'), BidiClass::B);
+    assert_eq!(BidiClass::of('\r'), BidiClass::B);
+}
+
+#[test]
+fn bidi_class_of_tab_is_s() {
+    assert_eq!(BidiClass::of('\t'), BidiClass::S);
+}
+
+#[test]
+fn bidi_class_of_lre_formatting() {
+    assert_eq!(BidiClass::of('\u{202A}'), BidiClass::LRE);
+    assert_eq!(BidiClass::of('\u{202B}'), BidiClass::RLE);
+    assert_eq!(BidiClass::of('\u{202C}'), BidiClass::PDF);
+    assert_eq!(BidiClass::of('\u{202D}'), BidiClass::LRO);
+    assert_eq!(BidiClass::of('\u{202E}'), BidiClass::RLO);
+}
+
+#[test]
+fn bidi_class_of_isolate_formatting() {
+    assert_eq!(BidiClass::of('\u{2066}'), BidiClass::LRI);
+    assert_eq!(BidiClass::of('\u{2067}'), BidiClass::RLI);
+    assert_eq!(BidiClass::of('\u{2068}'), BidiClass::FSI);
+    assert_eq!(BidiClass::of('\u{2069}'), BidiClass::PDI);
+}
+
+// ============================================================
+// types.rs — BidiClass methods
+// ============================================================
+
+#[test]
+fn bidi_class_is_strong() {
+    assert!(BidiClass::L.is_strong());
+    assert!(BidiClass::R.is_strong());
+    assert!(BidiClass::AL.is_strong());
+    assert!(!BidiClass::EN.is_strong());
+    assert!(!BidiClass::WS.is_strong());
+}
+
+#[test]
+fn bidi_class_is_strong_rtl() {
+    assert!(BidiClass::R.is_strong_rtl());
+    assert!(BidiClass::AL.is_strong_rtl());
+    assert!(!BidiClass::L.is_strong_rtl());
+    assert!(!BidiClass::EN.is_strong_rtl());
+}
+
+#[test]
+fn bidi_class_is_weak() {
+    assert!(BidiClass::EN.is_weak());
+    assert!(BidiClass::ES.is_weak());
+    assert!(BidiClass::ET.is_weak());
+    assert!(BidiClass::AN.is_weak());
+    assert!(BidiClass::CS.is_weak());
+    assert!(BidiClass::NSM.is_weak());
+    assert!(BidiClass::BN.is_weak());
+    assert!(!BidiClass::L.is_weak());
+    assert!(!BidiClass::WS.is_weak());
+}
+
+#[test]
+fn bidi_class_is_neutral() {
+    assert!(BidiClass::B.is_neutral());
+    assert!(BidiClass::S.is_neutral());
+    assert!(BidiClass::WS.is_neutral());
+    assert!(BidiClass::ON.is_neutral());
+    assert!(!BidiClass::L.is_neutral());
+    assert!(!BidiClass::EN.is_neutral());
+}
+
+// ============================================================
+// types.rs — BidiRun
+// ============================================================
+
+#[test]
+fn bidi_run_new_even_level_is_ltr() {
+    let run = BidiRun::new("hello".to_string(), 0..5, 0);
+    assert_eq!(run.direction, ResolvedDirection::Ltr);
+    assert_eq!(run.text, "hello");
+    assert_eq!(run.range, 0..5);
+    assert_eq!(run.level, 0);
+}
+
+#[test]
+fn bidi_run_new_odd_level_is_rtl() {
+    let run = BidiRun::new("مرحبا".to_string(), 0..10, 1);
+    assert_eq!(run.direction, ResolvedDirection::Rtl);
+}
+
+#[test]
+fn bidi_run_even_level_2_is_ltr() {
+    let run = BidiRun::new("abc".to_string(), 5..8, 2);
+    assert_eq!(run.direction, ResolvedDirection::Ltr);
+}
+
+#[test]
+fn bidi_run_char_count_ascii() {
+    let run = BidiRun::new("hello".to_string(), 0..5, 0);
+    assert_eq!(run.char_count(), 5);
+}
+
+#[test]
+fn bidi_run_char_count_multibyte() {
+    let run = BidiRun::new("가나다".to_string(), 0..9, 0);
+    assert_eq!(run.char_count(), 3);
+}
+
+// ============================================================
+// types.rs — BidiInfo
+// ============================================================
+
+#[test]
+fn bidi_info_new_ltr_text() {
+    let info = BidiInfo::new("Hello", TextDirection::Ltr);
+    assert_eq!(info.base_direction, ResolvedDirection::Ltr);
+    assert_eq!(info.text, "Hello");
+}
+
+#[test]
+fn bidi_info_new_rtl_direction() {
+    let info = BidiInfo::new("Hello", TextDirection::Rtl);
+    assert_eq!(info.base_direction, ResolvedDirection::Rtl);
+}
+
+#[test]
+fn bidi_info_new_auto_with_arabic() {
+    let info = BidiInfo::new("مرحبا", TextDirection::Auto);
+    assert_eq!(info.base_direction, ResolvedDirection::Rtl);
+}
+
+#[test]
+fn bidi_info_has_rtl_for_rtl_base() {
+    let info = BidiInfo::new("مرحبا", TextDirection::Rtl);
+    assert!(info.has_rtl());
+}
+
+#[test]
+fn bidi_info_has_rtl_false_for_ltr_base() {
+    let info = BidiInfo::new("Hello", TextDirection::Ltr);
+    assert!(!info.has_rtl());
+}
+
+#[test]
+fn bidi_info_is_pure_ltr() {
+    let info = BidiInfo::new("Hello", TextDirection::Ltr);
+    assert!(info.is_pure_ltr());
+}
+
+#[test]
+fn bidi_info_is_pure_ltr_false_for_rtl() {
+    let info = BidiInfo::new("مرحبا", TextDirection::Rtl);
+    assert!(!info.is_pure_ltr());
+}
+
+#[test]
+fn bidi_info_is_pure_rtl_with_no_runs() {
+    // With empty runs vec, all() returns true vacuously
+    let info = BidiInfo::new("مرحبا", TextDirection::Rtl);
+    assert!(info.is_pure_rtl());
+}
+
+#[test]
+fn bidi_info_visual_text() {
+    let info = BidiInfo::new("Hello", TextDirection::Ltr);
+    assert_eq!(info.visual_text(), "Hello");
+}
+
+// ============================================================
+// types.rs — RtlLayout
+// ============================================================
+
+#[test]
+fn rtl_layout_new() {
+    let layout = RtlLayout::new(80, ResolvedDirection::Ltr);
+    assert_eq!(layout.width, 80);
+    assert_eq!(layout.direction, ResolvedDirection::Ltr);
+    assert_eq!(layout.align, TextAlign::Start);
+}
+
+#[test]
+fn rtl_layout_align_builder() {
+    let layout = RtlLayout::new(80, ResolvedDirection::Ltr).align(TextAlign::Center);
+    assert_eq!(layout.align, TextAlign::Center);
+}
+
+#[test]
+fn rtl_layout_position_start_ltr() {
+    let layout = RtlLayout::new(80, ResolvedDirection::Ltr);
+    assert_eq!(layout.position(40), 0);
+}
+
+#[test]
+fn rtl_layout_position_start_rtl() {
+    let layout = RtlLayout::new(80, ResolvedDirection::Rtl);
+    assert_eq!(layout.position(40), 40); // padding = 80 - 40 = 40
+}
+
+#[test]
+fn rtl_layout_position_end_ltr() {
+    let layout = RtlLayout::new(80, ResolvedDirection::Ltr).align(TextAlign::End);
+    assert_eq!(layout.position(40), 40);
+}
+
+#[test]
+fn rtl_layout_position_end_rtl() {
+    let layout = RtlLayout::new(80, ResolvedDirection::Rtl).align(TextAlign::End);
+    assert_eq!(layout.position(40), 0);
+}
+
+#[test]
+fn rtl_layout_position_left() {
+    let layout = RtlLayout::new(80, ResolvedDirection::Rtl).align(TextAlign::Left);
+    assert_eq!(layout.position(40), 0);
+}
+
+#[test]
+fn rtl_layout_position_right() {
+    let layout = RtlLayout::new(80, ResolvedDirection::Ltr).align(TextAlign::Right);
+    assert_eq!(layout.position(40), 40);
+}
+
+#[test]
+fn rtl_layout_position_center() {
+    let layout = RtlLayout::new(80, ResolvedDirection::Ltr).align(TextAlign::Center);
+    assert_eq!(layout.position(40), 20);
+}
+
+#[test]
+fn rtl_layout_position_text_wider_than_layout() {
+    let layout = RtlLayout::new(40, ResolvedDirection::Ltr);
+    assert_eq!(layout.position(80), 0);
+}
+
+#[test]
+fn rtl_layout_pad_ltr_start() {
+    let layout = RtlLayout::new(10, ResolvedDirection::Ltr);
+    let result = layout.pad("hello", 5);
+    assert_eq!(result, "hello     ");
+    assert_eq!(result.len(), 10);
+}
+
+#[test]
+fn rtl_layout_pad_rtl_start() {
+    let layout = RtlLayout::new(10, ResolvedDirection::Rtl);
+    let result = layout.pad("hello", 5);
+    assert_eq!(result, "     hello");
+    assert_eq!(result.len(), 10);
+}
+
+#[test]
+fn rtl_layout_pad_center() {
+    let layout = RtlLayout::new(10, ResolvedDirection::Ltr).align(TextAlign::Center);
+    let result = layout.pad("hi", 2);
+    assert_eq!(result, "    hi    ");
+}
+
+#[test]
+fn rtl_layout_pad_text_fills_width() {
+    let layout = RtlLayout::new(5, ResolvedDirection::Ltr);
+    let result = layout.pad("hello", 5);
+    assert_eq!(result, "hello");
+}
+
+#[test]
+fn rtl_layout_pad_text_exceeds_width() {
+    let layout = RtlLayout::new(3, ResolvedDirection::Ltr);
+    let result = layout.pad("hello", 5);
+    assert_eq!(result, "hello");
+}

--- a/tests/widget_validation_tests.rs
+++ b/tests/widget_validation_tests.rs
@@ -1,0 +1,317 @@
+//! Tests for widget validation (ValidationError and validators module)
+
+use revue::widget::{validators, ValidationError};
+
+// ============================================================
+// ValidationError — new()
+// ============================================================
+
+#[test]
+fn validation_error_new_custom() {
+    let err = ValidationError::new("custom message", "CUSTOM");
+    assert_eq!(err.message, "custom message");
+    assert_eq!(err.code, "CUSTOM");
+}
+
+#[test]
+fn validation_error_new_from_string() {
+    let err = ValidationError::new(String::from("owned message"), "CODE");
+    assert_eq!(err.message, "owned message");
+}
+
+// ============================================================
+// ValidationError — factory methods
+// ============================================================
+
+#[test]
+fn validation_error_required() {
+    let err = ValidationError::required("Name");
+    assert_eq!(err.message, "Name is required");
+    assert_eq!(err.code, "REQUIRED");
+}
+
+#[test]
+fn validation_error_min_length() {
+    let err = ValidationError::min_length("Password", 8);
+    assert_eq!(err.message, "Password must be at least 8 characters");
+    assert_eq!(err.code, "MIN_LENGTH");
+}
+
+#[test]
+fn validation_error_max_length() {
+    let err = ValidationError::max_length("Username", 20);
+    assert_eq!(err.message, "Username must be at most 20 characters");
+    assert_eq!(err.code, "MAX_LENGTH");
+}
+
+#[test]
+fn validation_error_pattern() {
+    let err = ValidationError::pattern("Phone", r"\d{3}-\d{4}");
+    assert_eq!(err.message, r"Phone must match pattern: \d{3}-\d{4}");
+    assert_eq!(err.code, "PATTERN");
+}
+
+#[test]
+fn validation_error_range() {
+    let err = ValidationError::range("Age", 0, 150);
+    assert_eq!(err.message, "Age must be between 0 and 150");
+    assert_eq!(err.code, "RANGE");
+}
+
+#[test]
+fn validation_error_email() {
+    let err = ValidationError::email("notanemail");
+    assert_eq!(err.message, "'notanemail' is not a valid email address");
+    assert_eq!(err.code, "EMAIL");
+}
+
+// ============================================================
+// ValidationError — Display and Error traits
+// ============================================================
+
+#[test]
+fn validation_error_display() {
+    let err = ValidationError::required("Email");
+    assert_eq!(format!("{}", err), "Email is required");
+}
+
+#[test]
+fn validation_error_is_std_error() {
+    let err = ValidationError::new("test", "TEST");
+    let _: &dyn std::error::Error = &err;
+}
+
+// ============================================================
+// validators::require
+// ============================================================
+
+#[test]
+fn require_empty_returns_err() {
+    let result = validators::require(&"", "Name");
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().code, "REQUIRED");
+}
+
+#[test]
+fn require_non_empty_returns_ok() {
+    let result = validators::require(&"John", "Name");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn require_whitespace_only_returns_ok() {
+    // whitespace is not considered empty by to_string().is_empty()
+    let result = validators::require(&" ", "Name");
+    assert!(result.is_ok());
+}
+
+// ============================================================
+// validators::min_length
+// ============================================================
+
+#[test]
+fn min_length_below_minimum_returns_err() {
+    let result = validators::min_length("ab", 3, "Password");
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().code, "MIN_LENGTH");
+}
+
+#[test]
+fn min_length_at_minimum_returns_ok() {
+    let result = validators::min_length("abc", 3, "Password");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn min_length_above_minimum_returns_ok() {
+    let result = validators::min_length("abcdef", 3, "Password");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn min_length_empty_with_zero_min_returns_ok() {
+    let result = validators::min_length("", 0, "Field");
+    assert!(result.is_ok());
+}
+
+// ============================================================
+// validators::max_length
+// ============================================================
+
+#[test]
+fn max_length_above_maximum_returns_err() {
+    let result = validators::max_length("abcdef", 3, "Username");
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().code, "MAX_LENGTH");
+}
+
+#[test]
+fn max_length_at_maximum_returns_ok() {
+    let result = validators::max_length("abc", 3, "Username");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn max_length_below_maximum_returns_ok() {
+    let result = validators::max_length("ab", 3, "Username");
+    assert!(result.is_ok());
+}
+
+// ============================================================
+// validators::email
+// ============================================================
+
+#[test]
+fn email_valid_returns_ok() {
+    let result = validators::email("user@example.com");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn email_missing_at_returns_err() {
+    let result = validators::email("userexample.com");
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().code, "EMAIL");
+}
+
+#[test]
+fn email_missing_dot_returns_err() {
+    let result = validators::email("user@examplecom");
+    assert!(result.is_err());
+}
+
+#[test]
+fn email_empty_returns_err() {
+    let result = validators::email("");
+    assert!(result.is_err());
+}
+
+#[test]
+fn email_at_and_dot_present_returns_ok() {
+    let result = validators::email("a@b.c");
+    assert!(result.is_ok());
+}
+
+// ============================================================
+// validators::range
+// ============================================================
+
+#[test]
+fn range_below_min_returns_err() {
+    let result = validators::range(5, 10, 100, "Age");
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().code, "RANGE");
+}
+
+#[test]
+fn range_above_max_returns_err() {
+    let result = validators::range(200, 10, 100, "Age");
+    assert!(result.is_err());
+}
+
+#[test]
+fn range_within_returns_ok() {
+    let result = validators::range(50, 10, 100, "Age");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn range_at_min_boundary_returns_ok() {
+    let result = validators::range(10, 10, 100, "Age");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn range_at_max_boundary_returns_ok() {
+    let result = validators::range(100, 10, 100, "Age");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn range_with_floats() {
+    let result = validators::range(3.14, 0.0, 10.0, "Value");
+    assert!(result.is_ok());
+}
+
+// ============================================================
+// validators::pattern
+// ============================================================
+
+#[test]
+fn pattern_match_returns_ok() {
+    let result = validators::pattern("hello world", "hello", "Text");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn pattern_no_match_returns_err() {
+    let result = validators::pattern("goodbye", "hello", "Text");
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().code, "PATTERN");
+}
+
+#[test]
+fn pattern_empty_pattern_always_matches() {
+    let result = validators::pattern("anything", "", "Text");
+    assert!(result.is_ok());
+}
+
+// ============================================================
+// validators::custom
+// ============================================================
+
+#[test]
+fn custom_predicate_true_returns_ok() {
+    let result = validators::custom(
+        &42,
+        |v| *v > 0,
+        || ValidationError::new("must be positive", "POSITIVE"),
+    );
+    assert!(result.is_ok());
+}
+
+#[test]
+fn custom_predicate_false_returns_err() {
+    let result = validators::custom(
+        &-1,
+        |v| *v > 0,
+        || ValidationError::new("must be positive", "POSITIVE"),
+    );
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().code, "POSITIVE");
+}
+
+#[test]
+fn custom_with_string_validation() {
+    let result = validators::custom(
+        &"test@example.com".to_string(),
+        |v| v.contains('@') && v.len() > 5,
+        || ValidationError::new("invalid email", "EMAIL"),
+    );
+    assert!(result.is_ok());
+}
+
+// ============================================================
+// ValidationError — equality
+// ============================================================
+
+#[test]
+fn validation_error_eq() {
+    let a = ValidationError::new("msg", "CODE");
+    let b = ValidationError::new("msg", "CODE");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn validation_error_ne_different_message() {
+    let a = ValidationError::new("msg1", "CODE");
+    let b = ValidationError::new("msg2", "CODE");
+    assert_ne!(a, b);
+}
+
+#[test]
+fn validation_error_ne_different_code() {
+    let a = ValidationError::new("msg", "CODE1");
+    let b = ValidationError::new("msg", "CODE2");
+    assert_ne!(a, b);
+}


### PR DESCRIPTION
## Summary

- Add 88 integration tests for BiDi text handling (`helpers.rs` + `types.rs`: direction detection, RTL checks, character mirroring, `BidiClass`, `BidiRun`, `BidiInfo`, `RtlLayout`)
- Add 40 integration tests for widget validation (`ValidationError` factories, `validators` module: require, min/max length, email, range, pattern, custom)
- Add 29 integration tests for syntax keyword detection (Rust, Python, JavaScript, Shell, SQL, Go)
- Make `syntax::keywords` module public for integration test access

## Test plan

- [x] `cargo test --tests` — all 7,823 tests pass
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Pre-push hooks (doc, coverage, test) pass