### PR TITLE
feat: add Interactive trait and focus indicators to Switch, Link, Select

### DIFF
--- a/src/widget/link.rs
+++ b/src/widget/link.rs
@@ -20,8 +20,10 @@
 //! let home = link("https://example.com", "Home Page");
 //! ```
 
+use crate::event::{Key, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
+use crate::layout::Rect;
 use crate::style::Color;
-use crate::widget::{RenderContext, View, WidgetProps};
+use crate::widget::traits::{EventResult, Interactive, RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -275,6 +277,55 @@ impl View for Link {
         }
 
         text.render(ctx);
+    }
+}
+
+impl Interactive for Link {
+    fn handle_key(&mut self, event: &KeyEvent) -> EventResult {
+        if self.disabled {
+            return EventResult::Ignored;
+        }
+
+        match event.key {
+            Key::Enter | Key::Char(' ') => {
+                // Open the link - return Consumed to let the app handle opening
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    let _ = self.open();
+                }
+                EventResult::ConsumedAndRender
+            }
+            _ => EventResult::Ignored,
+        }
+    }
+
+    fn handle_mouse(&mut self, event: &MouseEvent, _area: Rect) -> EventResult {
+        if self.disabled {
+            return EventResult::Ignored;
+        }
+
+        match event.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    let _ = self.open();
+                }
+                EventResult::ConsumedAndRender
+            }
+            _ => EventResult::Ignored,
+        }
+    }
+
+    fn focusable(&self) -> bool {
+        !self.disabled
+    }
+
+    fn on_focus(&mut self) {
+        self.focused = true;
+    }
+
+    fn on_blur(&mut self) {
+        self.focused = false;
     }
 }
 


### PR DESCRIPTION
## Summary

- Implement Interactive trait for Switch, Link, and Select widgets
- Add visible focus indicators (brackets) to Switch and Select
- Add focused/disabled state fields to Select widget
- Improve keyboard navigation and accessibility

## Changes

### Switch
- Added `Interactive` trait implementation with keyboard (Enter/Space) and mouse support
- Added focus indicator rendering with cyan brackets
- Integrated with focus management system

### Link
- Added `Interactive` trait implementation
- Enter/Space keys now open the link in browser
- Mouse click support

### Select
- Added `focused` and `disabled` state fields
- Added `Interactive` trait with full keyboard navigation
- Added focus indicator rendering with cyan brackets
- Added disabled state visual styling (grayed out)
- Auto-close dropdown on blur

## Testing
- All 5119 tests pass
- Coverage check passes
- Clippy passes