### PR TITLE
docs: clarify coordinate terminology in RenderContext doc comments

### DIFF
--- a/src/widget/traits/render_context/focus.rs
+++ b/src/widget/traits/render_context/focus.rs
@@ -58,8 +58,9 @@ impl RenderContext<'_> {
 
     /// Draw a focus indicator on the left side of an item
     ///
-    /// Special case: draws in the column just before the area (absolute position).
-    /// Falls back to first column of area if area starts at x=0.
+    /// `y` is relative to the area. The marker is drawn one column before
+    /// the area using absolute buffer access. Falls back to column 0 of the
+    /// area if it starts at x=0.
     pub fn draw_focus_marker_left(&mut self, y: u16, color: Color) {
         if self.area.x > 0 {
             // Draw outside the area — use absolute buffer access

--- a/src/widget/traits/render_context/mod.rs
+++ b/src/widget/traits/render_context/mod.rs
@@ -106,9 +106,10 @@ impl<'a> RenderContext<'a> {
         self.state.map(|s| s.disabled).unwrap_or(false)
     }
 
-    /// Create a sub-area in absolute coordinates from relative position and size.
+    /// Create a child `Rect` from relative position and size.
     ///
-    /// Use this when creating child `Rect` for sub-contexts:
+    /// Input `x`/`y` are relative to this area; the returned `Rect` contains
+    /// absolute buffer coordinates suitable for constructing a child context:
     /// ```ignore
     /// let inner = ctx.sub_area(1, 1, w - 2, h - 2);
     /// let mut child_ctx = RenderContext::new(ctx.buffer, inner);


### PR DESCRIPTION
## Summary

- `sub_area()`: clarify that input x/y are relative, returned Rect contains absolute buffer coordinates
- `draw_focus_marker_left()`: clarify that y parameter is relative, marker uses absolute buffer access to draw outside the widget area

## Context

Follow-up to the relative coordinate conversion. These two doc comments had ambiguous wording about which coordinates are relative vs absolute.