### PR TITLE
fix(render): use unicode display width for CJK/emoji in widgets

### DIFF
--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -180,32 +180,7 @@ pub fn remove_char_range(s: &mut String, start: usize, end: usize) {
 /// assert_eq!(short, "Hello…");
 /// ```
 pub fn truncate(text: &str, max_width: usize) -> String {
-    let char_count = text.chars().count();
-
-    if char_count <= max_width {
-        // Fast path: no truncation needed
-        // Pre-allocate exact capacity to avoid reallocation
-        let mut result = String::with_capacity(text.len());
-        result.push_str(text);
-        result
-    } else if max_width <= 1 {
-        // Edge case: just the ellipsis
-        String::from("…")
-    } else {
-        // Pre-allocate capacity for truncated text + ellipsis
-        // Estimate: (max_width - 1) chars * 3 bytes/char (UTF-8 worst case) + 3 bytes for ellipsis
-        let capacity = (max_width.saturating_sub(1)) * 3 + 3;
-        let mut result = String::with_capacity(capacity);
-
-        for (i, c) in text.chars().enumerate() {
-            if i >= max_width.saturating_sub(1) {
-                break;
-            }
-            result.push(c);
-        }
-        result.push('…');
-        result
-    }
+    crate::utils::unicode::truncate_with_ellipsis(text, max_width)
 }
 
 /// Truncate text from the start, adding ellipsis at beginning
@@ -216,33 +191,33 @@ pub fn truncate(text: &str, max_width: usize) -> String {
 /// assert_eq!(short, "…ments/file.txt");
 /// ```
 pub fn truncate_start(text: &str, max_width: usize) -> String {
-    let char_count = text.chars().count();
-
-    if char_count <= max_width {
-        // Fast path: no truncation needed
-        let mut result = String::with_capacity(text.len());
-        result.push_str(text);
-        result
-    } else if max_width <= 1 {
-        // Edge case: just the ellipsis
-        String::from("…")
-    } else {
-        // Pre-allocate capacity
-        let keep = max_width.saturating_sub(1);
-        let capacity = keep * 3 + 3; // Estimate for UTF-8 + ellipsis
-        let mut result = String::with_capacity(capacity);
-
-        result.push('…');
-
-        let skip = char_count - keep;
-        for (i, c) in text.chars().enumerate() {
-            if i >= skip {
-                result.push(c);
-            }
-        }
-
-        result
+    use crate::utils::unicode::display_width as dw;
+    let width = dw(text);
+    if width <= max_width {
+        return text.to_string();
     }
+    if max_width <= 1 {
+        return String::from("…");
+    }
+    // Walk from the end, accumulating display width
+    let keep_width = max_width.saturating_sub(1); // reserve 1 for "…"
+    let mut kept = Vec::new();
+    let mut acc_width = 0;
+    for c in text.chars().rev() {
+        let cw = crate::utils::unicode::char_width(c);
+        if acc_width + cw > keep_width {
+            break;
+        }
+        acc_width += cw;
+        kept.push(c);
+    }
+    kept.reverse();
+    let mut result = String::with_capacity(acc_width * 3 + 3);
+    result.push('…');
+    for c in kept {
+        result.push(c);
+    }
+    result
 }
 
 /// Center text within given width
@@ -254,73 +229,17 @@ pub fn truncate_start(text: &str, max_width: usize) -> String {
 /// # Returns
 /// Centered string padded with spaces
 pub fn center(text: &str, width: usize) -> String {
-    let text_len = text.chars().count();
-    if text_len >= width {
-        // Fast path: no padding needed
-        let mut result = String::with_capacity(text.len());
-        result.push_str(text);
-        result
-    } else {
-        // Pre-allocate exact capacity
-        let padding = width - text_len;
-        let left_pad = padding / 2;
-        let right_pad = padding - left_pad;
-        let capacity = text.len() + left_pad + right_pad;
-
-        let mut result = String::with_capacity(capacity);
-        for _ in 0..left_pad {
-            result.push(' ');
-        }
-        result.push_str(text);
-        for _ in 0..right_pad {
-            result.push(' ');
-        }
-        result
-    }
+    crate::utils::unicode::center_to_width(text, width)
 }
 
 /// Pad text on the left to reach target width
 pub fn pad_left(text: &str, width: usize) -> String {
-    let text_len = text.chars().count();
-    if text_len >= width {
-        // Fast path: no padding needed
-        let mut result = String::with_capacity(text.len());
-        result.push_str(text);
-        result
-    } else {
-        // Pre-allocate exact capacity
-        let padding = width - text_len;
-        let capacity = text.len() + padding;
-
-        let mut result = String::with_capacity(capacity);
-        for _ in 0..padding {
-            result.push(' ');
-        }
-        result.push_str(text);
-        result
-    }
+    crate::utils::unicode::right_align_to_width(text, width)
 }
 
 /// Pad text on the right to reach target width
 pub fn pad_right(text: &str, width: usize) -> String {
-    let text_len = text.chars().count();
-    if text_len >= width {
-        // Fast path: no padding needed
-        let mut result = String::with_capacity(text.len());
-        result.push_str(text);
-        result
-    } else {
-        // Pre-allocate exact capacity
-        let padding = width - text_len;
-        let capacity = text.len() + padding;
-
-        let mut result = String::with_capacity(capacity);
-        result.push_str(text);
-        for _ in 0..padding {
-            result.push(' ');
-        }
-        result
-    }
+    crate::utils::unicode::pad_to_width(text, width)
 }
 
 /// Wrap text to fit within max_width
@@ -335,63 +254,18 @@ pub fn wrap_text(text: &str, max_width: usize) -> Vec<String> {
     if max_width == 0 || text.is_empty() {
         return vec![];
     }
-
+    // Handle multiple paragraphs (newlines)
     let mut lines = Vec::new();
-
     for paragraph in text.lines() {
         if paragraph.is_empty() {
             lines.push(String::new());
             continue;
         }
-
-        let words: Vec<&str> = paragraph.split_whitespace().collect();
-        if words.is_empty() {
-            lines.push(String::new());
-            continue;
-        }
-
-        let mut current_line = String::new();
-
-        for word in words {
-            let word_len = word.chars().count();
-
-            // If word is longer than max_width, split it
-            if word_len > max_width {
-                // Flush current line if not empty
-                if !current_line.is_empty() {
-                    lines.push(current_line);
-                    current_line = String::new();
-                }
-
-                // Split long word
-                let mut chars = word.chars().peekable();
-                while chars.peek().is_some() {
-                    let chunk: String = chars.by_ref().take(max_width).collect();
-                    if chars.peek().is_some() {
-                        lines.push(chunk);
-                    } else {
-                        current_line = chunk;
-                    }
-                }
-                continue;
-            }
-
-            if current_line.is_empty() {
-                current_line = word.to_string();
-            } else if current_line.chars().count() + 1 + word_len <= max_width {
-                current_line.push(' ');
-                current_line.push_str(word);
-            } else {
-                lines.push(current_line);
-                current_line = word.to_string();
-            }
-        }
-
-        if !current_line.is_empty() {
-            lines.push(current_line);
-        }
+        lines.extend(crate::utils::unicode::wrap_to_width(paragraph, max_width));
     }
-
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
     lines
 }
 
@@ -402,11 +276,16 @@ pub fn split_fixed_width(text: &str, width: usize) -> Vec<String> {
     }
 
     let mut chunks = Vec::new();
-    let mut chars = text.chars().peekable();
+    let mut remaining = text;
 
-    while chars.peek().is_some() {
-        let chunk: String = chars.by_ref().take(width).collect();
-        chunks.push(chunk);
+    while !remaining.is_empty() {
+        let (chunk, rest) = crate::utils::unicode::split_at_width(remaining, width);
+        if chunk.is_empty() {
+            // Can't fit even a single character (e.g., wide char in narrow width)
+            break;
+        }
+        chunks.push(chunk.to_string());
+        remaining = rest;
     }
 
     if chunks.is_empty() {
@@ -418,10 +297,9 @@ pub fn split_fixed_width(text: &str, width: usize) -> Vec<String> {
 
 /// Get display width of a string (accounting for wide characters)
 ///
-/// Note: This is a simplified version that counts chars.
-/// For proper Unicode width handling, consider using unicode-width crate.
+/// Delegates to [`crate::utils::unicode::display_width`] for proper Unicode handling.
 pub fn display_width(text: &str) -> usize {
-    text.chars().count()
+    crate::utils::unicode::display_width(text)
 }
 
 /// Repeat a character to create a string

--- a/src/widget/input/input_widgets/combobox/input.rs
+++ b/src/widget/input/input_widgets/combobox/input.rs
@@ -159,9 +159,9 @@ impl Combobox {
         let max_option_len = self
             .options
             .iter()
-            .map(|o| o.label.len())
+            .map(|o| crate::utils::display_width(&o.label))
             .max()
-            .unwrap_or(self.placeholder.len());
+            .unwrap_or(crate::utils::display_width(&self.placeholder));
 
         // +4 for padding and borders
         ((max_option_len.max(20) + 4) as u16).min(max_width)

--- a/src/widget/input/input_widgets/combobox/render.rs
+++ b/src/widget/input/input_widgets/combobox/render.rs
@@ -48,9 +48,10 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
     };
 
     let is_placeholder = combobox.input.is_empty();
-    let truncated: String = display_text.chars().take(text_width).collect();
+    let truncated = crate::utils::truncate_to_width(display_text, text_width);
 
-    for (i, ch) in truncated.chars().enumerate() {
+    let mut cx: u16 = 1;
+    for ch in truncated.chars() {
         let mut cell = crate::render::Cell::new(ch);
         cell.fg = if is_placeholder {
             combobox.disabled_fg
@@ -58,12 +59,19 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
             input_fg
         };
         cell.bg = input_bg;
-        ctx.set(1 + i as u16, 0, cell);
+        ctx.set(cx, 0, cell);
+        cx += crate::utils::char_width(ch) as u16;
     }
 
     // Draw cursor (if not placeholder)
     if !is_placeholder && combobox.cursor <= truncated.chars().count() {
-        let cursor_x = 1 + combobox.cursor as u16;
+        // Calculate cursor x from display widths of characters before cursor
+        let cursor_display_width: usize = truncated
+            .chars()
+            .take(combobox.cursor)
+            .map(crate::utils::char_width)
+            .sum();
+        let cursor_x = 1 + cursor_display_width as u16;
         if cursor_x < width - 2 {
             if let Some(cell) = ctx.get_mut(cursor_x, 0) {
                 cell.bg = Some(crate::style::Color::WHITE);
@@ -92,11 +100,14 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
             cell.bg = combobox.bg;
             ctx.set(x, y, cell);
         }
-        for (i, ch) in combobox.loading_text.chars().take(text_width).enumerate() {
+        let loading_truncated = crate::utils::truncate_to_width(&combobox.loading_text, text_width);
+        let mut cx: u16 = 1;
+        for ch in loading_truncated.chars() {
             let mut cell = crate::render::Cell::new(ch);
             cell.fg = combobox.disabled_fg;
             cell.bg = combobox.bg;
-            ctx.set(1 + i as u16, y, cell);
+            ctx.set(cx, y, cell);
+            cx += crate::utils::char_width(ch) as u16;
         }
         return;
     }
@@ -110,11 +121,14 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
             cell.bg = combobox.bg;
             ctx.set(x, y, cell);
         }
-        for (i, ch) in combobox.empty_text.chars().take(text_width).enumerate() {
+        let empty_truncated = crate::utils::truncate_to_width(&combobox.empty_text, text_width);
+        let mut cx: u16 = 1;
+        for ch in empty_truncated.chars() {
             let mut cell = crate::render::Cell::new(ch);
             cell.fg = combobox.disabled_fg;
             cell.bg = combobox.bg;
-            ctx.set(1 + i as u16, y, cell);
+            ctx.set(cx, y, cell);
+            cx += crate::utils::char_width(ch) as u16;
         }
         return;
     }
@@ -174,7 +188,9 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
             .unwrap_or_default();
 
         // Draw option text with highlighting
-        let truncated: String = option.label.chars().take(text_width - 1).collect();
+        let truncated =
+            crate::utils::truncate_to_width(&option.label, text_width.saturating_sub(1));
+        let mut cx: u16 = 2;
         for (j, ch) in truncated.chars().enumerate() {
             let mut cell = crate::render::Cell::new(ch);
             cell.bg = bg;
@@ -187,7 +203,8 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
                 cell.fg = fg;
             }
 
-            ctx.set(2 + j as u16, y, cell);
+            ctx.set(cx, y, cell);
+            cx += crate::utils::char_width(ch) as u16;
         }
     }
 

--- a/src/widget/input/input_widgets/select.rs
+++ b/src/widget/input/input_widgets/select.rs
@@ -4,7 +4,7 @@ use crate::event::{Key, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use crate::layout::Rect;
 use crate::render::Cell;
 use crate::style::Color;
-use crate::utils::{fuzzy_match, FuzzyMatch, Selection};
+use crate::utils::{display_width, fuzzy_match, truncate_to_width, FuzzyMatch, Selection};
 use crate::widget::traits::{EventResult, Interactive, RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -383,9 +383,9 @@ impl Select {
         let max_option_len = self
             .options
             .iter()
-            .map(|o| o.len())
+            .map(|o| display_width(o))
             .max()
-            .unwrap_or(self.placeholder.len());
+            .unwrap_or(display_width(&self.placeholder));
 
         // +4 for "▼ " prefix and " " suffix and border
         ((max_option_len + 4) as u16).min(max_width)
@@ -463,12 +463,14 @@ impl View for Select {
         ctx.set(0, 0, cell);
 
         // Draw text
-        let truncated: String = display_text.chars().take(text_width).collect();
-        for (i, ch) in truncated.chars().enumerate() {
+        let truncated = truncate_to_width(display_text, text_width);
+        let mut cx: u16 = 2;
+        for ch in truncated.chars() {
             let mut cell = Cell::new(ch);
             cell.fg = fg;
             cell.bg = bg;
-            ctx.set(2 + i as u16, 0, cell);
+            ctx.set(cx, 0, cell);
+            cx += crate::utils::char_width(ch) as u16;
         }
 
         // If open, render dropdown options
@@ -518,7 +520,8 @@ impl View for Select {
                     .unwrap_or_default();
 
                 // Draw option text with highlighting
-                let truncated: String = option.chars().take(text_width).collect();
+                let truncated = truncate_to_width(option, text_width);
+                let mut cx: u16 = 2;
                 for (j, ch) in truncated.chars().enumerate() {
                     let mut cell = Cell::new(ch);
                     cell.bg = bg;
@@ -530,7 +533,8 @@ impl View for Select {
                         cell.fg = fg;
                     }
 
-                    ctx.set(2 + j as u16, y, cell);
+                    ctx.set(cx, y, cell);
+                    cx += crate::utils::char_width(ch) as u16;
                 }
             }
         }

--- a/src/widget/multi_select/render.rs
+++ b/src/widget/multi_select/render.rs
@@ -48,7 +48,7 @@ impl View for MultiSelect {
 
                 if let Some(opt) = self.options.get(opt_idx) {
                     let label = &opt.label;
-                    let tag_len = (label.chars().count() + 3) as u16; // "[label] "
+                    let tag_len = (crate::utils::display_width(label) + 3) as u16; // "[label] "
 
                     if x + tag_len > max_x {
                         // Draw overflow indicator
@@ -73,11 +73,12 @@ impl View for MultiSelect {
                     x += 1;
 
                     for ch in label.chars() {
-                        if x >= max_x - 1 {
+                        let cw = crate::utils::char_width(ch) as u16;
+                        if x + cw > max_x - 1 {
                             break;
                         }
                         ctx.draw_char_bg(x, 0, ch, tag_fg, tag_bg_color);
-                        x += 1;
+                        x += cw;
                     }
 
                     ctx.draw_char_bg(x, 0, ']', tag_fg, tag_bg_color);
@@ -131,9 +132,10 @@ impl View for MultiSelect {
                         .map(|m| m.indices)
                         .unwrap_or_default();
 
-                    let label_x: u16 = 4;
+                    let mut cx: u16 = 4;
                     for (j, ch) in opt.label.chars().enumerate() {
-                        if label_x + j as u16 >= width {
+                        let cw = crate::utils::char_width(ch) as u16;
+                        if cx + cw > width {
                             break;
                         }
 
@@ -145,7 +147,8 @@ impl View for MultiSelect {
                             row_fg
                         };
 
-                        ctx.draw_char_bg(label_x + j as u16, y, ch, char_fg, row_bg);
+                        ctx.draw_char_bg(cx, y, ch, char_fg, row_bg);
+                        cx += cw;
                     }
                 }
             }

--- a/src/widget/multi_select/types.rs
+++ b/src/widget/multi_select/types.rs
@@ -279,9 +279,9 @@ impl MultiSelect {
         let max_option_len = self
             .options
             .iter()
-            .map(|o| o.label.len())
+            .map(|o| crate::utils::display_width(&o.label))
             .max()
-            .unwrap_or(self.placeholder.len());
+            .unwrap_or(crate::utils::display_width(&self.placeholder));
 
         ((max_option_len + 4) as u16).min(max_width)
     }

--- a/tests/utils_text_tests.rs
+++ b/tests/utils_text_tests.rs
@@ -330,7 +330,7 @@ fn truncate_width_1() {
 
 #[test]
 fn truncate_width_0() {
-    assert_eq!(truncate("hello", 0), "…");
+    assert_eq!(truncate("hello", 0), "");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Deduplicate broken `utils/text.rs` width functions by delegating to `utils/unicode.rs` (-196 lines)
- Fix Select, Combobox, MultiSelect dropdown width calculation: `.len()` (bytes) → `display_width()` (terminal columns)
- Fix text truncation and character rendering to respect CJK/emoji display width (2 columns)
- Fix combobox cursor position for wide characters

## Problem

Multiple widgets used `.len()` (byte length) or `.chars().count()` (character count) instead of proper terminal display width. This caused:
- Dropdowns too narrow for Korean/CJK/emoji text
- Text truncated at wrong positions
- Characters overlapping or leaving gaps when rendering wide chars

The correct `unicode::display_width()` already existed but wasn't used consistently.

## Test plan

- [x] All existing tests pass (5208 unit + integration)
- [x] `cargo clippy --all-features` clean
- [x] `cargo fmt` clean
- [x] Coverage check passed
- [ ] Manual: verify Select/Combobox/MultiSelect with Korean text (e.g. "김치찌개", "불고기")
- [ ] Manual: verify emoji options render without overlap (e.g. "🔥 Hot", "🎉 Party")