### PR TITLE
fix(render): barchart negative values, heatmap contrast, checkbox disabled state

### DIFF
--- a/src/widget/data/chart/barchart.rs
+++ b/src/widget/data/chart/barchart.rs
@@ -167,13 +167,13 @@ impl BarChart {
         self
     }
 
-    /// Calculate the maximum value in the data
+    /// Calculate the maximum absolute value in the data for scaling
     fn calculate_max(&self) -> f64 {
         self.max.unwrap_or_else(|| {
             self.bars
                 .iter()
-                .map(|b| b.value)
-                .fold(0.0, f64::max)
+                .map(|b| b.value.abs())
+                .fold(f64::NEG_INFINITY, f64::max)
                 .max(1.0)
         })
     }
@@ -191,7 +191,7 @@ impl BarChart {
         let label_width = self.label_width.unwrap_or_else(|| {
             self.bars
                 .iter()
-                .map(|b| b.label.len() as u16)
+                .map(|b| crate::utils::display_width(&b.label) as u16)
                 .max()
                 .unwrap_or(0)
                 .min(area.width / 3)
@@ -207,9 +207,9 @@ impl BarChart {
                 break;
             }
 
-            // Calculate bar length
+            // Calculate bar length (use absolute value for rendering)
             let bar_length = if max_value > 0.0 {
-                ((bar.value / max_value) * bar_area_width as f64) as u16
+                ((bar.value.abs() / max_value) * bar_area_width as f64) as u16
             } else {
                 0
             };
@@ -224,10 +224,15 @@ impl BarChart {
 
                 // Draw label (only on first row)
                 if row == 0 {
-                    let label: String = if bar.label.len() > label_width as usize {
-                        bar.label.chars().take(label_width as usize).collect()
+                    let label_dw = crate::utils::display_width(&bar.label);
+                    let label: String = if label_dw > label_width as usize {
+                        crate::utils::truncate_to_width(&bar.label, label_width as usize)
+                            .to_string()
                     } else {
-                        format!("{:>width$}", bar.label, width = label_width as usize)
+                        crate::utils::unicode::right_align_to_width(
+                            &bar.label,
+                            label_width as usize,
+                        )
                     };
 
                     for (i, ch) in label.chars().enumerate() {

--- a/src/widget/data/chart/heatmap/view.rs
+++ b/src/widget/data/chart/heatmap/view.rs
@@ -24,11 +24,7 @@ impl View for HeatMap {
             col_header = col_header.child(Text::new(" ".repeat(label_offset)));
 
             for label in labels.iter().take(self.cols) {
-                let truncated = if label.len() > self.cell_width {
-                    &label[..self.cell_width]
-                } else {
-                    label
-                };
+                let truncated = crate::utils::truncate_to_width(label, self.cell_width);
                 col_header = col_header.child(
                     Text::new(format!("{:^width$}", truncated, width = self.cell_width))
                         .fg(Color::rgb(150, 150, 150)),
@@ -45,7 +41,7 @@ impl View for HeatMap {
                 // Row label
                 if let Some(labels) = &self.row_labels {
                     if let Some(label) = labels.get(row_idx) {
-                        let truncated = if label.len() > 6 { &label[..6] } else { label };
+                        let truncated = crate::utils::truncate_to_width(label, 6);
                         row_view = row_view.child(
                             Text::new(format!("{:>6} ", truncated)).fg(Color::rgb(150, 150, 150)),
                         );
@@ -64,9 +60,11 @@ impl View for HeatMap {
                     if self.show_values {
                         // Show value with colored background
                         cell_text = cell_text.bg(color);
-                        // Contrast text color
-                        let brightness = (color.r as u32 + color.g as u32 + color.b as u32) / 3;
-                        if brightness > 128 {
+                        // Contrast text color using perceptual luminance (ITU-R BT.601)
+                        let luminance =
+                            (299 * color.r as u32 + 587 * color.g as u32 + 114 * color.b as u32)
+                                / 1000;
+                        if luminance > 128 {
                             cell_text = cell_text.fg(Color::BLACK);
                         } else {
                             cell_text = cell_text.fg(Color::WHITE);

--- a/src/widget/input/input_widgets/checkbox.rs
+++ b/src/widget/input/input_widgets/checkbox.rs
@@ -141,7 +141,11 @@ impl View for Checkbox {
         let label_fg = self.state.resolve_fg(ctx.style, Color::WHITE);
 
         let check_fg = if self.state.disabled {
-            Color::rgb(100, 100, 100)
+            if self.checked {
+                Color::rgb(120, 120, 120) // Brighter gray for disabled+checked
+            } else {
+                Color::rgb(70, 70, 70) // Darker gray for disabled+unchecked
+            }
         } else if self.checked {
             self.check_fg.unwrap_or(Color::GREEN)
         } else {


### PR DESCRIPTION
## Summary

- Fix BarChart not rendering negative values (all-negative data showed empty chart)
- Fix HeatMap text contrast using perceptual luminance instead of simple average
- Fix Checkbox disabled state: checked vs unchecked now visually distinguishable
- Fix label truncation in BarChart/HeatMap from byte slicing to unicode-aware

## Changes

| Widget | Issue | Fix |
|--------|-------|-----|
| BarChart | `fold(0.0, f64::max)` ignored negative values | Use `abs()` for bar length, `f64::NEG_INFINITY` as fold init |
| BarChart | `b.label.len()` for width | `display_width()` + `truncate_to_width()` |
| HeatMap | `(r+g+b)/3` brightness | ITU-R BT.601: `0.299r + 0.587g + 0.114b` |
| HeatMap | `&label[..6]` byte slice | `truncate_to_width(label, 6)` |
| Checkbox | Same gray for disabled+checked and disabled+unchecked | Brighter (120) vs darker (70) gray |

## Test plan

- [x] All tests pass
- [x] clippy + fmt clean
- [ ] Manual: BarChart with `[-100, -50, -75]` renders bars
- [ ] Manual: HeatMap with bright green background shows readable black text
- [ ] Manual: Disabled checkbox — checked vs unchecked visually distinct