### PR TITLE
fix(render): tooltip arrow overlap, input CJK clipping, modal content layout

### DIFF
--- a/src/widget/feedback/modal/mod.rs
+++ b/src/widget/feedback/modal/mod.rs
@@ -392,13 +392,19 @@ impl View for Modal {
         if !self.title.is_empty() && modal_width > 4 {
             let title_x = x + 2;
             let title_width = modal_width.saturating_sub(4) as usize;
-            let title: String = self.title.chars().take(title_width).collect();
+            let title = crate::utils::truncate_to_width(&self.title, title_width);
 
-            for (i, ch) in title.chars().enumerate() {
+            let mut tx: u16 = 0;
+            for ch in title.chars() {
+                let cw = crate::utils::char_width(ch) as u16;
+                if tx + cw > title_width as u16 {
+                    break;
+                }
                 let mut cell = Cell::new(ch);
                 cell.fg = self.title_fg;
                 cell.modifier |= crate::render::Modifier::BOLD;
-                ctx.set(title_x + i as u16, y + 1, cell);
+                ctx.set(title_x + tx, y + 1, cell);
+                tx += cw;
             }
 
             // Title separator
@@ -409,10 +415,16 @@ impl View for Modal {
             ctx.set(x + modal_width.saturating_sub(1), y + 2, Cell::new('┤'));
         }
 
-        // Draw content
-        let content_y = y + 3;
+        // Draw content — adjust for title presence
+        let has_title = !self.title.is_empty() && modal_width > 4;
+        let content_y = if has_title { y + 3 } else { y + 1 };
         let content_width = modal_width.saturating_sub(4);
-        let content_height = modal_height.saturating_sub(6); // title + separator + padding + buttons + borders
+        // borders(2) + buttons(1) + padding(1) + title+separator(2 if present)
+        let content_height = if has_title {
+            modal_height.saturating_sub(6)
+        } else {
+            modal_height.saturating_sub(4)
+        };
 
         if let Some(ref body_widget) = self.body {
             // Render child widget
@@ -426,9 +438,15 @@ impl View for Modal {
                 if cy >= y + modal_height - 2 {
                     break;
                 }
-                let truncated: String = line.chars().take(content_width as usize).collect();
-                for (j, ch) in truncated.chars().enumerate() {
-                    ctx.set(x + 2 + j as u16, cy, Cell::new(ch));
+                let truncated = crate::utils::truncate_to_width(line, content_width as usize);
+                let mut cx: u16 = 0;
+                for ch in truncated.chars() {
+                    let cw = crate::utils::char_width(ch) as u16;
+                    if cx + cw > content_width {
+                        break;
+                    }
+                    ctx.set(x + 2 + cx, cy, Cell::new(ch));
+                    cx += cw;
                 }
             }
         }

--- a/src/widget/feedback/tooltip.rs
+++ b/src/widget/feedback/tooltip.rs
@@ -616,7 +616,7 @@ impl View for Tooltip {
             }
         }
 
-        // Draw arrow
+        // Draw arrow (only if it doesn't overlap the tooltip body)
         if !matches!(self.arrow, TooltipArrow::None) {
             let (arrow_char, _) = self.arrow.chars(actual_position);
             let (arrow_x, arrow_y) = match actual_position {
@@ -624,12 +624,16 @@ impl View for Tooltip {
                 TooltipPosition::Bottom => (self.anchor.0, tooltip_y.saturating_sub(1)),
                 TooltipPosition::Left => (tooltip_x + tooltip_w, self.anchor.1),
                 TooltipPosition::Right => (tooltip_x.saturating_sub(1), self.anchor.1),
-                // Auto is already resolved to a concrete position in calculate_position
-                // This case should never be reached, but use Top as fallback
                 TooltipPosition::Auto => (self.anchor.0, tooltip_y + tooltip_h),
             };
 
-            if arrow_x < area.width && arrow_y < area.height {
+            // Only draw if within bounds AND not overlapping the tooltip body
+            let inside_tooltip = arrow_x >= tooltip_x
+                && arrow_x < tooltip_x + tooltip_w
+                && arrow_y >= tooltip_y
+                && arrow_y < tooltip_y + tooltip_h;
+
+            if arrow_x < area.width && arrow_y < area.height && !inside_tooltip {
                 let mut cell = Cell::new(arrow_char);
                 cell.fg = Some(fg);
                 ctx.set(arrow_x, arrow_y, cell);

--- a/src/widget/input/input_widgets/input/mod.rs
+++ b/src/widget/input/input_widgets/input/mod.rs
@@ -1526,7 +1526,8 @@ impl View for Input {
 
         let mut x: u16 = 0;
         for (i, ch) in display_text.chars().enumerate() {
-            if x >= area.width {
+            let char_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(1) as u16;
+            if x + char_width > area.width {
                 break;
             }
 
@@ -1548,8 +1549,6 @@ impl View for Input {
             }
 
             ctx.set(x, 0, cell);
-
-            let char_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(1) as u16;
             x += char_width;
         }
 


### PR DESCRIPTION
## Summary

- Fix tooltip arrow rendering when tooltip is at screen edge (arrow overlapping body)
- Fix Input widget wide character (CJK/emoji) overflow past area boundary
- Fix Modal content area off-by-one when title is empty
- Fix Modal title/content text rendering to use unicode-aware truncation

## Changes

| Widget | Issue | Fix |
|--------|-------|-----|
| Tooltip | Arrow at edge overlaps tooltip body | Skip arrow if position is inside tooltip rect |
| Input | `x >= area.width` checked before render, but wide char still overflows | Check `x + char_width > area.width` before rendering |
| Modal | `content_height = modal_height - 6` regardless of title | Subtract 4 (no title) or 6 (with title) |
| Modal | Title/content use `.chars().take()` | Use `truncate_to_width` + `char_width` advancement |

## Test plan

- [x] All tests pass
- [x] clippy + fmt clean
- [ ] Manual: tooltip near top edge — arrow doesn't corrupt tooltip text
- [ ] Manual: Input with Korean text at exact width boundary — no half-character overflow
- [ ] Manual: Modal without title — content fills available space correctly