### PR TITLE
test: add unicode/CJK regression tests for rendering bug fixes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,6 @@
       ]
     }
   },
-  "last-release-sha": "c91f162",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },

--- a/tests/autocomplete_unicode_tests.rs
+++ b/tests/autocomplete_unicode_tests.rs
@@ -1,0 +1,72 @@
+//! Autocomplete Unicode handling tests
+//!
+//! Tests for char-index-based cursor with multi-byte characters.
+//! Verifies fix for byte/char index confusion that caused panics.
+
+use revue::event::{Key, KeyEvent};
+use revue::widget::autocomplete::Autocomplete;
+
+#[test]
+fn test_autocomplete_value_with_emoji_sets_correct_cursor() {
+    let a = Autocomplete::new().value("Hello 🎉");
+    assert_eq!(a.get_value(), "Hello 🎉");
+}
+
+#[test]
+fn test_autocomplete_type_emoji_then_backspace_no_panic() {
+    let mut a = Autocomplete::new();
+    a.handle_key(KeyEvent::new(Key::Char('😀')));
+    assert_eq!(a.get_value(), "😀");
+
+    a.handle_key(KeyEvent::new(Key::Backspace));
+    assert_eq!(a.get_value(), "");
+}
+
+#[test]
+fn test_autocomplete_type_cjk_then_backspace() {
+    let mut a = Autocomplete::new();
+    a.handle_key(KeyEvent::new(Key::Char('한')));
+    a.handle_key(KeyEvent::new(Key::Char('글')));
+    assert_eq!(a.get_value(), "한글");
+
+    a.handle_key(KeyEvent::new(Key::Backspace));
+    assert_eq!(a.get_value(), "한");
+
+    a.handle_key(KeyEvent::new(Key::Backspace));
+    assert_eq!(a.get_value(), "");
+}
+
+#[test]
+fn test_autocomplete_delete_key_cjk() {
+    let mut a = Autocomplete::new();
+    a.handle_key(KeyEvent::new(Key::Char('가')));
+    a.handle_key(KeyEvent::new(Key::Char('나')));
+    assert_eq!(a.get_value(), "가나");
+
+    a.handle_key(KeyEvent::new(Key::Home));
+    a.handle_key(KeyEvent::new(Key::Delete));
+    assert_eq!(a.get_value(), "나");
+}
+
+#[test]
+fn test_autocomplete_arrow_keys_with_cjk() {
+    let mut a = Autocomplete::new();
+    a.handle_key(KeyEvent::new(Key::Char('A')));
+    a.handle_key(KeyEvent::new(Key::Char('한')));
+    a.handle_key(KeyEvent::new(Key::Char('B')));
+    assert_eq!(a.get_value(), "A한B");
+
+    a.handle_key(KeyEvent::new(Key::Left));
+    a.handle_key(KeyEvent::new(Key::Left));
+    a.handle_key(KeyEvent::new(Key::Char('X')));
+    assert_eq!(a.get_value(), "AX한B");
+}
+
+#[test]
+fn test_autocomplete_end_key_with_multibyte() {
+    let mut a = Autocomplete::new().value("안녕🎉");
+    a.handle_key(KeyEvent::new(Key::Home));
+    a.handle_key(KeyEvent::new(Key::End));
+    a.handle_key(KeyEvent::new(Key::Char('!')));
+    assert_eq!(a.get_value(), "안녕🎉!");
+}

--- a/tests/combobox_safety_tests.rs
+++ b/tests/combobox_safety_tests.rs
@@ -1,0 +1,20 @@
+//! Combobox safety tests for edge cases
+//!
+//! Verifies bounds checking when options are empty or filtered to zero.
+
+use revue::widget::combobox::Combobox;
+
+#[test]
+fn test_select_current_with_empty_options_no_panic() {
+    let mut c = Combobox::new();
+    let result = c.select_current();
+    assert!(!result);
+}
+
+#[test]
+fn test_select_current_with_empty_filtered_no_panic() {
+    let mut c = Combobox::new().options(["Apple", "Banana"]);
+    c.set_input("zzzzz");
+    let result = c.select_current();
+    assert!(!result);
+}

--- a/tests/datagrid_filter_tests.rs
+++ b/tests/datagrid_filter_tests.rs
@@ -1,0 +1,63 @@
+//! DataGrid filter + selection interaction tests
+//!
+//! Verifies that filtering resets selection to prevent OOB access.
+
+use revue::widget::datagrid::{DataGrid, GridColumn, GridRow};
+
+fn make_grid() -> DataGrid {
+    DataGrid::new()
+        .column(GridColumn::new("name", "Name"))
+        .column(GridColumn::new("value", "Value"))
+        .row(GridRow::new().cell("name", "Apple").cell("value", "100"))
+        .row(GridRow::new().cell("name", "Banana").cell("value", "200"))
+        .row(GridRow::new().cell("name", "Cherry").cell("value", "300"))
+        .row(GridRow::new().cell("name", "Date").cell("value", "400"))
+        .row(
+            GridRow::new()
+                .cell("name", "Elderberry")
+                .cell("value", "500"),
+        )
+}
+
+#[test]
+fn test_filter_resets_selection_to_zero() {
+    let mut grid = make_grid();
+
+    grid.select_next();
+    grid.select_next();
+    grid.select_next();
+    assert_eq!(grid.selected_row, 3);
+
+    grid.set_filter("a");
+    assert_eq!(grid.selected_row, 0);
+}
+
+#[test]
+fn test_filter_resets_scroll_to_zero() {
+    let mut grid = make_grid();
+    grid.scroll_row = 3;
+
+    grid.set_filter("cherry");
+    assert_eq!(grid.scroll_row, 0);
+}
+
+#[test]
+fn test_filter_then_navigate_works() {
+    let mut grid = make_grid();
+    grid.set_filter("a");
+
+    let count = grid.filtered_count();
+    assert!(count > 0);
+
+    grid.select_next();
+    assert_eq!(grid.selected_row, 1);
+}
+
+#[test]
+fn test_filter_empty_result() {
+    let mut grid = make_grid();
+    grid.set_filter("zzzzz");
+
+    assert_eq!(grid.filtered_count(), 0);
+    assert_eq!(grid.selected_row, 0);
+}

--- a/tests/textarea_unicode_tests.rs
+++ b/tests/textarea_unicode_tests.rs
@@ -1,0 +1,128 @@
+//! TextArea Unicode/CJK handling tests
+//!
+//! Tests for char-index-based cursor operations with multi-byte characters.
+//! Verifies fixes from fix/textarea-unicode-width PR.
+
+use revue::event::Key;
+use revue::widget::textarea;
+
+#[test]
+fn test_textarea_insert_cjk_and_get_content() {
+    let mut t = textarea();
+    t.insert_char('한');
+    t.insert_char('글');
+    assert_eq!(t.get_content(), "한글");
+}
+
+#[test]
+fn test_textarea_insert_emoji_cursor_position() {
+    let mut t = textarea();
+    t.insert_char('😀');
+    t.insert_char('!');
+    assert_eq!(t.get_content(), "😀!");
+    let (_, col) = t.cursor_position();
+    assert_eq!(col, 2);
+}
+
+#[test]
+fn test_textarea_backspace_cjk() {
+    let mut t = textarea();
+    t.insert_char('가');
+    t.insert_char('나');
+    t.insert_char('다');
+    assert_eq!(t.get_content(), "가나다");
+
+    t.delete_char_before();
+    assert_eq!(t.get_content(), "가나");
+
+    t.delete_char_before();
+    assert_eq!(t.get_content(), "가");
+}
+
+#[test]
+fn test_textarea_backspace_emoji() {
+    let mut t = textarea();
+    t.insert_char('🎉');
+    t.insert_char('🔥');
+    assert_eq!(t.get_content(), "🎉🔥");
+
+    t.delete_char_before();
+    assert_eq!(t.get_content(), "🎉");
+}
+
+#[test]
+fn test_textarea_delete_at_cjk() {
+    let mut t = textarea().content("한글테스트");
+    t.set_cursor(0, 0);
+
+    t.delete_char_at();
+    assert_eq!(t.get_content(), "글테스트");
+
+    t.delete_char_at();
+    assert_eq!(t.get_content(), "테스트");
+}
+
+#[test]
+fn test_textarea_insert_str_cjk_cursor() {
+    let mut t = textarea();
+    t.insert_str("안녕하세요");
+    assert_eq!(t.get_content(), "안녕하세요");
+    let (_, col) = t.cursor_position();
+    assert_eq!(col, 5); // 5 chars, not 15 bytes
+}
+
+#[test]
+fn test_textarea_mixed_ascii_cjk() {
+    let mut t = textarea();
+    t.insert_str("Hello");
+    t.insert_char('世');
+    t.insert_char('界');
+    assert_eq!(t.get_content(), "Hello世界");
+    let (_, col) = t.cursor_position();
+    assert_eq!(col, 7);
+}
+
+#[test]
+fn test_textarea_cursor_navigation_cjk() {
+    let mut t = textarea().content("가나다라");
+    t.set_cursor(0, 4);
+
+    t.handle_key(&Key::Left);
+    let (_, col) = t.cursor_position();
+    assert_eq!(col, 3);
+
+    t.handle_key(&Key::Home);
+    let (_, col) = t.cursor_position();
+    assert_eq!(col, 0);
+
+    t.handle_key(&Key::End);
+    let (_, col) = t.cursor_position();
+    assert_eq!(col, 4);
+}
+
+#[test]
+fn test_textarea_insert_in_middle_cjk() {
+    let mut t = textarea().content("가다");
+    t.set_cursor(0, 1);
+
+    t.insert_char('나');
+    assert_eq!(t.get_content(), "가나다");
+}
+
+#[test]
+fn test_textarea_newline_with_cjk() {
+    let mut t = textarea().content("안녕하세요");
+    t.set_cursor(0, 2);
+
+    t.insert_char('\n');
+    assert_eq!(t.get_content(), "안녕\n하세요");
+    assert_eq!(t.line_count(), 2);
+}
+
+#[test]
+fn test_textarea_multiline_insert_cjk() {
+    let mut t = textarea();
+    t.insert_str("첫째줄\n둘째줄");
+    assert_eq!(t.get_content(), "첫째줄\n둘째줄");
+    assert_eq!(t.line_count(), 2);
+}

--- a/tests/utils_text_tests.rs
+++ b/tests/utils_text_tests.rs
@@ -540,6 +540,57 @@ fn display_width_empty() {
     assert_eq!(display_width(""), 0);
 }
 
+#[test]
+fn display_width_cjk() {
+    // text.rs display_width should now delegate to unicode.rs
+    assert_eq!(display_width("한글"), 4); // 2 chars × 2 width
+    assert_eq!(display_width("Hello한글"), 9); // 5 + 4
+}
+
+#[test]
+fn display_width_emoji() {
+    assert_eq!(display_width("🎉"), 2);
+}
+
+#[test]
+fn truncate_cjk() {
+    // truncate should respect display width, not char count
+    let result = truncate("안녕하세요", 5);
+    // "안녕" = 4 width, "하" would make 6 > 5, so truncate with ellipsis
+    assert_eq!(display_width(&result), 5); // "안녕…" = 4 + 1
+}
+
+#[test]
+fn center_cjk() {
+    let result = center("한", 6); // "한" is width 2, center in 6
+    assert_eq!(display_width(&result), 6);
+    assert!(result.contains("한"));
+}
+
+#[test]
+fn pad_right_cjk() {
+    let result = pad_right("한글", 8); // width 4, pad to 8
+    assert_eq!(display_width(&result), 8);
+    assert!(result.starts_with("한글"));
+}
+
+#[test]
+fn pad_left_cjk() {
+    let result = pad_left("한글", 8); // width 4, pad to 8
+    assert_eq!(display_width(&result), 8);
+    assert!(result.ends_with("한글"));
+}
+
+#[test]
+fn wrap_text_cjk() {
+    let result = wrap_text("가나다라마바사", 5);
+    // Each char is width 2, so max 2 chars per line (width 4), "마" starts new line
+    assert!(result.len() >= 2);
+    for line in &result {
+        assert!(display_width(line) <= 5);
+    }
+}
+
 // =============================================================================
 // repeat_char
 // =============================================================================

--- a/tests/widget/combobox/mod.rs
+++ b/tests/widget/combobox/mod.rs
@@ -1,3 +1,3 @@
 pub mod basic;
-pub mod selection;
 pub mod rendering;
+pub mod selection;


### PR DESCRIPTION
## Summary

Add **30 new tests** covering all recently fixed runtime and rendering bugs. These tests prevent regressions for the unicode/CJK fixes across 8 previous PRs.

## New Tests

| File | Tests | Coverage |
|------|-------|----------|
| `textarea_unicode_tests.rs` | 11 | CJK/emoji insert, delete, cursor navigation, newline |
| `autocomplete_unicode_tests.rs` | 6 | Emoji/CJK input + backspace (was panic), arrow keys |
| `datagrid_filter_tests.rs` | 4 | Filter resets selection/scroll (was desync) |
| `combobox_safety_tests.rs` | 2 | select_current with empty/filtered options (was panic) |
| `utils_text_tests.rs` | +7 | display_width, truncate, center, pad, wrap with CJK |

Also removes stale `last-release-sha` from release-please config (tags now exist for all versions).

## Test plan

- [x] All 30 new tests pass
- [x] All 5205 existing tests still pass
- [x] clippy + fmt clean