### PR TITLE
fix(ux): add modal button focus indicator and select empty state message

### DIFF
--- a/src/widget/feedback/modal/mod.rs
+++ b/src/widget/feedback/modal/mod.rs
@@ -467,6 +467,9 @@ impl View for Modal {
                     let mut cell = Cell::new(ch);
                     cell.fg = fg;
                     cell.bg = bg;
+                    if is_selected {
+                        cell.modifier |= crate::render::Modifier::BOLD;
+                    }
                     ctx.set(btn_x, button_y, cell);
                     btn_x += cw;
                 }

--- a/src/widget/input/input_widgets/select.rs
+++ b/src/widget/input/input_widgets/select.rs
@@ -487,6 +487,10 @@ impl View for Select {
                     .collect()
             };
 
+            if visible_options.is_empty() && !self.query.is_empty() {
+                ctx.draw_text(2, 1, "No results", Color::rgb(128, 128, 128));
+            }
+
             for (row, (option_idx, option)) in visible_options.iter().enumerate().take(max_visible)
             {
                 let y = 1 + row as u16;


### PR DESCRIPTION
## Summary

Fix two UX issues where users get confused by missing visual feedback.

### Modal button focus
- Selected button now renders with BOLD modifier
- Users can see which button Enter will activate

### Select empty search results
- When searchable Select has no matching options, shows "No results" message
- Previously showed blank dropdown, leaving users unsure if search was working