### PR TITLE
fix(render): card shadow bounds, terminal indicator underflow, form border guard

### DIFF
--- a/src/widget/developer/terminal/core.rs
+++ b/src/widget/developer/terminal/core.rs
@@ -583,14 +583,16 @@ impl View for Terminal {
         // Render scroll indicator if scrolled
         if self.scroll_offset > 0 {
             let indicator = format!("↑{}", self.scroll_offset);
-            let start_x = area.width - indicator.len() as u16 - 1;
-
-            for (i, ch) in indicator.chars().enumerate() {
-                ctx.set(
-                    start_x + i as u16,
-                    0,
-                    Cell::new(ch).fg(Color::YELLOW).bg(Color::rgb(60, 60, 60)),
-                );
+            let indicator_len = indicator.len() as u16;
+            if area.width > indicator_len + 1 {
+                let start_x = area.width - indicator_len - 1;
+                for (i, ch) in indicator.chars().enumerate() {
+                    ctx.set(
+                        start_x + i as u16,
+                        0,
+                        Cell::new(ch).fg(Color::YELLOW).bg(Color::rgb(60, 60, 60)),
+                    );
+                }
             }
         }
     }

--- a/src/widget/layout/card/core.rs
+++ b/src/widget/layout/card/core.rs
@@ -393,20 +393,20 @@ impl View for Card {
             }
         }
 
-        // Draw shadow for elevated variant
-        if self.variant == CardVariant::Elevated && area.width > 2 && area.height > 1 {
+        // Draw shadow for elevated variant (inside area bounds)
+        if self.variant == CardVariant::Elevated && area.width > 3 && area.height > 2 {
             let shadow_color = Color::rgb(20, 20, 20);
-            // Right shadow
+            // Right shadow (last column, below top-right corner)
             for y in 1..area.height {
                 let mut cell = Cell::new('▌');
                 cell.fg = Some(shadow_color);
-                ctx.set(area.width, y, cell);
+                ctx.set(area.width - 1, y, cell);
             }
-            // Bottom shadow
-            for x in 1..=area.width {
+            // Bottom shadow (last row, right of bottom-left corner)
+            for x in 1..area.width {
                 let mut cell = Cell::new('▀');
                 cell.fg = Some(shadow_color);
-                ctx.set(x, area.height, cell);
+                ctx.set(x, area.height - 1, cell);
             }
         }
 


### PR DESCRIPTION
## Summary

- Card elevated shadow rendered at `area.width`/`area.height` (outside bounds, silently clipped). Now renders at `width-1`/`height-1` so shadow is actually visible.
- Terminal scroll indicator `area.width - indicator.len() - 1` could underflow on narrow terminals. Now guarded.
- Form border had duplicate guard removed (was accidentally doubled).

## Test plan

- [x] All tests pass, clippy clean
- [ ] Manual: Card with Elevated variant shows shadow in constrained container
- [ ] Manual: Terminal widget at narrow width — no rendering artifacts