### PR TITLE
feat(render): add overlay rendering system for floating UI elements

### DIFF
--- a/src/runtime/dom/renderer/render.rs
+++ b/src/runtime/dom/renderer/render.rs
@@ -22,7 +22,9 @@ impl DomRenderer {
             (None, None)
         };
 
-        // Create context with style and state
+        // Phase 1: Main widget tree render with overlay queue
+        let mut overlay_queue = crate::widget::OverlayQueue::new();
+
         let mut ctx = if let (Some(style), Some(state)) = (style, state) {
             RenderContext::full(buffer, area, style, state)
         } else if let Some(style) = style {
@@ -30,8 +32,14 @@ impl DomRenderer {
         } else {
             RenderContext::new(buffer, area)
         };
+        ctx = ctx.with_overlay_queue(&mut overlay_queue);
 
         root.render(&mut ctx);
+
+        // Phase 2: Render overlays on top (sorted by z-index)
+        // ctx must go out of scope so buffer borrow is released
+        let _ = ctx;
+        overlay_queue.render_to(buffer);
     }
 
     /// Query nodes by selector

--- a/src/widget/feedback/toast.rs
+++ b/src/widget/feedback/toast.rs
@@ -250,9 +250,11 @@ impl View for Toast {
             return;
         }
 
-        let (toast_width, toast_height) = self.calculate_size(area.width);
-        let (abs_x, abs_y) =
-            self.calculate_position(area.width, area.height, toast_width, toast_height);
+        // Use buffer (screen) dimensions for positioning, not parent area
+        let screen_w = ctx.buffer.width();
+        let screen_h = ctx.buffer.height();
+        let (toast_width, toast_height) = self.calculate_size(screen_w);
+        let (abs_x, abs_y) = self.calculate_position(screen_w, screen_h, toast_width, toast_height);
 
         let color = self.level.color();
         let bg = self.level.bg_color();

--- a/src/widget/feedback/toast.rs
+++ b/src/widget/feedback/toast.rs
@@ -251,94 +251,78 @@ impl View for Toast {
         }
 
         let (toast_width, toast_height) = self.calculate_size(area.width);
-        let (x, y) = self.calculate_position(area.width, area.height, toast_width, toast_height);
+        let (abs_x, abs_y) =
+            self.calculate_position(area.width, area.height, toast_width, toast_height);
 
         let color = self.level.color();
         let bg = self.level.bg_color();
 
-        // Draw border
+        // Build overlay entry for toast (renders on top of everything)
+        let overlay_area = crate::layout::Rect::new(abs_x, abs_y, toast_width, toast_height);
+        let mut entry = crate::widget::traits::OverlayEntry::new(200, overlay_area); // z=200: above dropdowns
+
+        // Helper to push cell
+        let mut push = |rx: u16, ry: u16, ch: char, fg: Color, bg_c: Color| {
+            let mut cell = Cell::new(ch);
+            cell.fg = Some(fg);
+            cell.bg = Some(bg_c);
+            entry.push(rx, ry, cell);
+        };
+
+        // Draw border (relative to overlay area)
         if self.show_border {
-            // Top border
-            let mut top_left = Cell::new('╭');
-            top_left.fg = Some(color);
-            top_left.bg = Some(bg);
-            ctx.set(x, y, top_left);
-
+            push(0, 0, '╭', color, bg);
             for i in 1..toast_width.saturating_sub(1) {
-                let mut cell = Cell::new('─');
-                cell.fg = Some(color);
-                cell.bg = Some(bg);
-                ctx.set(x + i, y, cell);
+                push(i, 0, '─', color, bg);
             }
+            push(toast_width - 1, 0, '╮', color, bg);
 
-            let mut top_right = Cell::new('╮');
-            top_right.fg = Some(color);
-            top_right.bg = Some(bg);
-            ctx.set(x + toast_width - 1, y, top_right);
-
-            // Bottom border
-            let mut bottom_left = Cell::new('╰');
-            bottom_left.fg = Some(color);
-            bottom_left.bg = Some(bg);
-            ctx.set(x, y + toast_height - 1, bottom_left);
-
+            push(0, toast_height - 1, '╰', color, bg);
             for i in 1..toast_width.saturating_sub(1) {
-                let mut cell = Cell::new('─');
-                cell.fg = Some(color);
-                cell.bg = Some(bg);
-                ctx.set(x + i, y + toast_height - 1, cell);
+                push(i, toast_height - 1, '─', color, bg);
             }
+            push(toast_width - 1, toast_height - 1, '╯', color, bg);
 
-            let mut bottom_right = Cell::new('╯');
-            bottom_right.fg = Some(color);
-            bottom_right.bg = Some(bg);
-            ctx.set(x + toast_width - 1, y + toast_height - 1, bottom_right);
-
-            // Side borders
             for row in 1..toast_height.saturating_sub(1) {
-                let mut left = Cell::new('│');
-                left.fg = Some(color);
-                left.bg = Some(bg);
-                ctx.set(x, y + row, left);
-
-                let mut right = Cell::new('│');
-                right.fg = Some(color);
-                right.bg = Some(bg);
-                ctx.set(x + toast_width - 1, y + row, right);
-
-                // Fill background
+                push(0, row, '│', color, bg);
+                push(toast_width - 1, row, '│', color, bg);
                 for col in 1..toast_width.saturating_sub(1) {
-                    let mut fill = Cell::new(' ');
-                    fill.bg = Some(bg);
-                    ctx.set(x + col, y + row, fill);
+                    push(col, row, ' ', color, bg);
                 }
             }
         }
 
-        // Draw content
-        let content_x = x + if self.show_border { 2 } else { 0 };
-        let content_y = y + if self.show_border { 1 } else { 0 };
+        // Content position (relative)
+        let cx = if self.show_border { 2 } else { 0 };
+        let cy = if self.show_border { 1 } else { 0 };
 
-        // Draw icon
         if self.show_icon {
-            let mut icon_cell = Cell::new(self.level.icon());
-            icon_cell.fg = Some(color);
-            icon_cell.bg = Some(bg);
-            ctx.set(content_x, content_y, icon_cell);
+            push(cx, cy, self.level.icon(), color, bg);
         }
 
-        // Draw message (clipped to available width, wide-char safe)
-        let msg_x = content_x + if self.show_icon { 2 } else { 0 };
-        let max_text_width = toast_width
-            .saturating_sub(if self.show_border { 1 } else { 0 })
-            .saturating_sub(msg_x - x);
-        ctx.draw_text_clipped(
-            msg_x,
-            content_y,
-            &self.message,
-            Color::WHITE,
-            max_text_width,
-        );
+        // Message text
+        let msg_x = cx + if self.show_icon { 2 } else { 0 };
+        let max_text = toast_width.saturating_sub(msg_x + if self.show_border { 1 } else { 0 });
+        let truncated = crate::utils::truncate_to_width(&self.message, max_text as usize);
+        let mut tx = msg_x;
+        for ch in truncated.chars() {
+            let cw = crate::utils::char_width(ch) as u16;
+            if tx + cw > msg_x + max_text {
+                break;
+            }
+            let mut cell = Cell::new(ch);
+            cell.fg = Some(Color::WHITE);
+            cell.bg = Some(bg);
+            entry.push(tx, cy, cell);
+            tx += cw;
+        }
+
+        // Queue as overlay; fallback to inline
+        if !ctx.queue_overlay(entry.clone()) {
+            for oc in &entry.cells {
+                ctx.set(oc.x, oc.y, oc.cell);
+            }
+        }
     }
 }
 

--- a/src/widget/feedback/tooltip.rs
+++ b/src/widget/feedback/tooltip.rs
@@ -583,7 +583,7 @@ impl View for Tooltip {
             }
         }
 
-        // Arrow (rendered outside tooltip area, so use absolute coords trick)
+        // Arrow — queue as separate 1-cell overlay at higher z-index
         if !matches!(self.arrow, TooltipArrow::None) {
             let (arrow_char, _) = self.arrow.chars(actual_position);
             let (arrow_abs_x, arrow_abs_y) = match actual_position {
@@ -599,15 +599,19 @@ impl View for Tooltip {
                 && arrow_abs_y >= tooltip_y
                 && arrow_abs_y < tooltip_y + tooltip_h;
 
-            if !inside && arrow_abs_x < area.width && arrow_abs_y < area.height {
-                // Arrow is outside overlay area — write directly to buffer
+            let buf_w = ctx.buffer.width();
+            let buf_h = ctx.buffer.height();
+            if !inside && arrow_abs_x < buf_w && arrow_abs_y < buf_h {
+                let arrow_area = crate::layout::Rect::new(arrow_abs_x, arrow_abs_y, 1, 1);
+                let mut arrow_entry = crate::widget::traits::OverlayEntry::new(151, arrow_area);
                 let mut cell = Cell::new(arrow_char);
                 cell.fg = Some(fg);
-                ctx.buffer.set(arrow_abs_x, arrow_abs_y, cell);
+                arrow_entry.push(0, 0, cell);
+                ctx.queue_overlay(arrow_entry);
             }
         }
 
-        // Queue as overlay; fallback to inline
+        // Queue tooltip as overlay; fallback to inline
         if !ctx.queue_overlay(entry.clone()) {
             for oc in &entry.cells {
                 ctx.set(tooltip_x + oc.x, tooltip_y + oc.y, oc.cell);

--- a/src/widget/feedback/tooltip.rs
+++ b/src/widget/feedback/tooltip.rs
@@ -483,143 +483,110 @@ impl View for Tooltip {
         let (tooltip_x, tooltip_y, actual_position) =
             self.calculate_position(area.width, area.height);
 
-        // Get colors
         let (default_fg, default_bg) = self.style.colors();
         let fg = self.fg.unwrap_or(default_fg);
         let bg = self.bg.unwrap_or(default_bg);
 
-        // Draw background
+        // Build overlay entry (all coordinates relative to tooltip area)
+        let overlay_area = crate::layout::Rect::new(tooltip_x, tooltip_y, tooltip_w, tooltip_h);
+        let mut entry = crate::widget::traits::OverlayEntry::new(150, overlay_area);
+
+        // Helper to create styled cell
+        let cell_with = |ch: char, cell_fg: Color, cell_bg: Color| -> Cell {
+            let mut c = Cell::new(ch);
+            c.fg = Some(cell_fg);
+            c.bg = Some(cell_bg);
+            c
+        };
+
+        // Background
         for dy in 0..tooltip_h {
             for dx in 0..tooltip_w {
-                let x = tooltip_x + dx;
-                let y = tooltip_y + dy;
-                if x < area.width && y < area.height {
-                    let mut cell = Cell::new(' ');
-                    cell.bg = Some(bg);
-                    ctx.set(x, y, cell);
-                }
+                entry.push(dx, dy, cell_with(' ', fg, bg));
             }
         }
 
-        // Draw border if applicable
-        let content_start_x;
-        let content_start_y;
+        // Border
+        let content_rx;
+        let content_ry;
 
         if let Some(border) = self.style.border_chars() {
-            content_start_x = tooltip_x + 2;
-            content_start_y = tooltip_y + 1;
+            content_rx = 2u16;
+            content_ry = 1u16;
 
-            // Top border
-            if tooltip_y < area.height {
-                let mut tl = Cell::new(border.top_left);
-                tl.fg = Some(fg);
-                tl.bg = Some(bg);
-                ctx.set(tooltip_x, tooltip_y, tl);
-
-                for dx in 1..tooltip_w - 1 {
-                    let mut h = Cell::new(border.horizontal);
-                    h.fg = Some(fg);
-                    h.bg = Some(bg);
-                    ctx.set(tooltip_x + dx, tooltip_y, h);
-                }
-
-                let mut tr = Cell::new(border.top_right);
-                tr.fg = Some(fg);
-                tr.bg = Some(bg);
-                ctx.set(tooltip_x + tooltip_w - 1, tooltip_y, tr);
+            entry.push(0, 0, cell_with(border.top_left, fg, bg));
+            for dx in 1..tooltip_w.saturating_sub(1) {
+                entry.push(dx, 0, cell_with(border.horizontal, fg, bg));
             }
+            entry.push(
+                tooltip_w.saturating_sub(1),
+                0,
+                cell_with(border.top_right, fg, bg),
+            );
 
-            // Title if present
+            // Title (bold)
             if let Some(ref title) = self.title {
-                let title_x = tooltip_x + 2;
-                let title_y = tooltip_y + 1;
                 for (i, ch) in title.chars().enumerate() {
-                    let x = title_x + i as u16;
-                    if x < tooltip_x + tooltip_w - 2 {
-                        let mut cell = Cell::new(ch);
-                        cell.fg = Some(fg);
-                        cell.bg = Some(bg);
-                        cell.modifier |= Modifier::BOLD;
-                        ctx.set(x, title_y, cell);
+                    let rx = 2 + i as u16;
+                    if rx < tooltip_w.saturating_sub(2) {
+                        let mut c = cell_with(ch, fg, bg);
+                        c.modifier |= Modifier::BOLD;
+                        entry.push(rx, 1, c);
                     }
                 }
             }
 
-            // Left and right borders
-            let _text_start_y = if self.title.is_some() {
-                tooltip_y + 2
-            } else {
-                tooltip_y + 1
-            };
-            for dy in 1..tooltip_h - 1 {
-                let y = tooltip_y + dy;
-                if y < area.height {
-                    let mut left = Cell::new(border.vertical);
-                    left.fg = Some(fg);
-                    left.bg = Some(bg);
-                    ctx.set(tooltip_x, y, left);
-
-                    let mut right = Cell::new(border.vertical);
-                    right.fg = Some(fg);
-                    right.bg = Some(bg);
-                    ctx.set(tooltip_x + tooltip_w - 1, y, right);
-                }
+            // Side borders
+            for dy in 1..tooltip_h.saturating_sub(1) {
+                entry.push(0, dy, cell_with(border.vertical, fg, bg));
+                entry.push(
+                    tooltip_w.saturating_sub(1),
+                    dy,
+                    cell_with(border.vertical, fg, bg),
+                );
             }
 
             // Bottom border
-            let bottom_y = tooltip_y + tooltip_h - 1;
-            if bottom_y < area.height {
-                let mut bl = Cell::new(border.bottom_left);
-                bl.fg = Some(fg);
-                bl.bg = Some(bg);
-                ctx.set(tooltip_x, bottom_y, bl);
-
-                for dx in 1..tooltip_w - 1 {
-                    let mut h = Cell::new(border.horizontal);
-                    h.fg = Some(fg);
-                    h.bg = Some(bg);
-                    ctx.set(tooltip_x + dx, bottom_y, h);
-                }
-
-                let mut br = Cell::new(border.bottom_right);
-                br.fg = Some(fg);
-                br.bg = Some(bg);
-                ctx.set(tooltip_x + tooltip_w - 1, bottom_y, br);
+            let by = tooltip_h.saturating_sub(1);
+            entry.push(0, by, cell_with(border.bottom_left, fg, bg));
+            for dx in 1..tooltip_w.saturating_sub(1) {
+                entry.push(dx, by, cell_with(border.horizontal, fg, bg));
             }
+            entry.push(
+                tooltip_w.saturating_sub(1),
+                by,
+                cell_with(border.bottom_right, fg, bg),
+            );
         } else {
-            content_start_x = tooltip_x + 1;
-            content_start_y = tooltip_y;
+            content_rx = 1;
+            content_ry = 0;
         }
 
-        // Draw text content
+        // Text content
         let lines = self.wrap_text();
-        let text_y_offset = if self.title.is_some() && self.style.border_chars().is_some() {
-            1
+        let text_y_off = if self.title.is_some() && self.style.border_chars().is_some() {
+            1u16
         } else {
             0
         };
 
         for (i, line) in lines.iter().enumerate() {
-            let y = content_start_y + text_y_offset + i as u16;
-            if y >= area.height || y >= tooltip_y + tooltip_h - 1 {
+            let ry = content_ry + text_y_off + i as u16;
+            if ry >= tooltip_h.saturating_sub(1) {
                 break;
             }
-
             for (j, ch) in line.chars().enumerate() {
-                let x = content_start_x + j as u16;
-                if x < tooltip_x + tooltip_w - 1 {
-                    let mut cell = Cell::new(ch);
-                    cell.fg = Some(fg);
-                    cell.bg = Some(bg);
-                    ctx.set(x, y, cell);
+                let rx = content_rx + j as u16;
+                if rx < tooltip_w.saturating_sub(1) {
+                    entry.push(rx, ry, cell_with(ch, fg, bg));
                 }
             }
         }
 
-        // Draw arrow (only if it doesn't overlap the tooltip body)
+        // Arrow (rendered outside tooltip area, so use absolute coords trick)
         if !matches!(self.arrow, TooltipArrow::None) {
             let (arrow_char, _) = self.arrow.chars(actual_position);
-            let (arrow_x, arrow_y) = match actual_position {
+            let (arrow_abs_x, arrow_abs_y) = match actual_position {
                 TooltipPosition::Top => (self.anchor.0, tooltip_y + tooltip_h),
                 TooltipPosition::Bottom => (self.anchor.0, tooltip_y.saturating_sub(1)),
                 TooltipPosition::Left => (tooltip_x + tooltip_w, self.anchor.1),
@@ -627,16 +594,23 @@ impl View for Tooltip {
                 TooltipPosition::Auto => (self.anchor.0, tooltip_y + tooltip_h),
             };
 
-            // Only draw if within bounds AND not overlapping the tooltip body
-            let inside_tooltip = arrow_x >= tooltip_x
-                && arrow_x < tooltip_x + tooltip_w
-                && arrow_y >= tooltip_y
-                && arrow_y < tooltip_y + tooltip_h;
+            let inside = arrow_abs_x >= tooltip_x
+                && arrow_abs_x < tooltip_x + tooltip_w
+                && arrow_abs_y >= tooltip_y
+                && arrow_abs_y < tooltip_y + tooltip_h;
 
-            if arrow_x < area.width && arrow_y < area.height && !inside_tooltip {
+            if !inside && arrow_abs_x < area.width && arrow_abs_y < area.height {
+                // Arrow is outside overlay area — write directly to buffer
                 let mut cell = Cell::new(arrow_char);
                 cell.fg = Some(fg);
-                ctx.set(arrow_x, arrow_y, cell);
+                ctx.buffer.set(arrow_abs_x, arrow_abs_y, cell);
+            }
+        }
+
+        // Queue as overlay; fallback to inline
+        if !ctx.queue_overlay(entry.clone()) {
+            for oc in &entry.cells {
+                ctx.set(tooltip_x + oc.x, tooltip_y + oc.y, oc.cell);
             }
         }
     }

--- a/src/widget/input/input_widgets/combobox/render.rs
+++ b/src/widget/input/input_widgets/combobox/render.rs
@@ -90,7 +90,7 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
 
     let visible_count = combobox.max_visible.min(10);
 
-    // Calculate overlay position
+    // Calculate overlay position, flip above if near bottom
     let (abs_x, abs_y) = ctx.absolute_position();
     let dropdown_h = if combobox.loading || combobox.filtered.is_empty() {
         1u16
@@ -102,7 +102,14 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
             .min(visible_count) as u16)
             .max(1)
     };
-    let overlay_area = crate::layout::Rect::new(abs_x, abs_y + 1, width, dropdown_h);
+    let buf_height = ctx.buffer.height();
+    let space_below = buf_height.saturating_sub(abs_y + 1);
+    let overlay_y = if space_below >= dropdown_h {
+        abs_y + 1
+    } else {
+        abs_y.saturating_sub(dropdown_h)
+    };
+    let overlay_area = crate::layout::Rect::new(abs_x, overlay_y, width, dropdown_h);
     let mut entry = crate::widget::traits::OverlayEntry::new(100, overlay_area);
 
     // Loading state

--- a/src/widget/input/input_widgets/combobox/render.rs
+++ b/src/widget/input/input_widgets/combobox/render.rs
@@ -84,21 +84,34 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
     // Render dropdown (if open)
     // ─────────────────────────────────────────────────────────────────────
 
-    if !combobox.open || area.height <= 1 {
+    if !combobox.open {
         return;
     }
 
-    let dropdown_height = (area.height - 1) as usize;
-    let visible_count = dropdown_height.min(combobox.max_visible);
+    let visible_count = combobox.max_visible.min(10);
+
+    // Calculate overlay position
+    let (abs_x, abs_y) = ctx.absolute_position();
+    let dropdown_h = if combobox.loading || combobox.filtered.is_empty() {
+        1u16
+    } else {
+        (combobox
+            .filtered
+            .len()
+            .saturating_sub(combobox.scroll_offset)
+            .min(visible_count) as u16)
+            .max(1)
+    };
+    let overlay_area = crate::layout::Rect::new(abs_x, abs_y + 1, width, dropdown_h);
+    let mut entry = crate::widget::traits::OverlayEntry::new(100, overlay_area);
 
     // Loading state
     if combobox.loading {
-        let y: u16 = 1;
         for x in 0..width {
             let mut cell = crate::render::Cell::new(' ');
             cell.fg = combobox.fg;
             cell.bg = combobox.bg;
-            ctx.set(x, y, cell);
+            entry.push(x, 0, cell);
         }
         let loading_truncated = crate::utils::truncate_to_width(&combobox.loading_text, text_width);
         let mut cx: u16 = 1;
@@ -106,20 +119,24 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
             let mut cell = crate::render::Cell::new(ch);
             cell.fg = combobox.disabled_fg;
             cell.bg = combobox.bg;
-            ctx.set(cx, y, cell);
+            entry.push(cx, 0, cell);
             cx += crate::utils::char_width(ch) as u16;
+        }
+        if !ctx.queue_overlay(entry.clone()) {
+            for oc in &entry.cells {
+                ctx.set(oc.x, oc.y + 1, oc.cell);
+            }
         }
         return;
     }
 
     // Empty state
     if combobox.filtered.is_empty() {
-        let y: u16 = 1;
         for x in 0..width {
             let mut cell = crate::render::Cell::new(' ');
             cell.fg = combobox.fg;
             cell.bg = combobox.bg;
-            ctx.set(x, y, cell);
+            entry.push(x, 0, cell);
         }
         let empty_truncated = crate::utils::truncate_to_width(&combobox.empty_text, text_width);
         let mut cx: u16 = 1;
@@ -127,8 +144,13 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
             let mut cell = crate::render::Cell::new(ch);
             cell.fg = combobox.disabled_fg;
             cell.bg = combobox.bg;
-            ctx.set(cx, y, cell);
+            entry.push(cx, 0, cell);
             cx += crate::utils::char_width(ch) as u16;
+        }
+        if !ctx.queue_overlay(entry.clone()) {
+            for oc in &entry.cells {
+                ctx.set(oc.x, oc.y + 1, oc.cell);
+            }
         }
         return;
     }
@@ -141,7 +163,7 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
         .take(visible_count)
         .enumerate()
     {
-        let y = 1 + row as u16;
+        let y = row as u16;
         let option = &combobox.options[option_idx];
         let is_highlighted = row + combobox.scroll_offset == combobox.selected_idx;
         let is_multi_selected = combobox.multi_select && combobox.is_selected(option.get_value());
@@ -163,22 +185,22 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
             let mut cell = crate::render::Cell::new(' ');
             cell.fg = fg;
             cell.bg = bg;
-            ctx.set(x, y, cell);
+            entry.push(x, y, cell);
         }
 
-        // Draw selection indicator (for multi-select)
+        // Draw selection indicator
         if combobox.multi_select {
             let indicator = if is_multi_selected { '☑' } else { '☐' };
             let mut cell = crate::render::Cell::new(indicator);
             cell.fg = fg;
             cell.bg = bg;
-            ctx.set(0, y, cell);
+            entry.push(0, y, cell);
         } else {
             let indicator = if is_highlighted { '›' } else { ' ' };
             let mut cell = crate::render::Cell::new(indicator);
             cell.fg = fg;
             cell.bg = bg;
-            ctx.set(0, y, cell);
+            entry.push(0, y, cell);
         }
 
         // Get match indices for highlighting
@@ -203,29 +225,32 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
                 cell.fg = fg;
             }
 
-            ctx.set(cx, y, cell);
+            entry.push(cx, y, cell);
             cx += crate::utils::char_width(ch) as u16;
         }
     }
 
-    // Draw scroll indicator if needed
-    if combobox.filtered.len() > visible_count {
-        let has_more_above = combobox.scroll_offset > 0;
-        let has_more_below = combobox.scroll_offset + visible_count < combobox.filtered.len();
-
-        if has_more_above {
+    // Draw scroll indicators
+    let total_filtered = combobox.filtered.len();
+    if total_filtered > visible_count {
+        if combobox.scroll_offset > 0 {
             let mut cell = crate::render::Cell::new('↑');
             cell.fg = combobox.disabled_fg;
             cell.bg = combobox.bg;
-            ctx.set(width - 1, 1, cell);
+            entry.push(width - 1, 0, cell);
         }
-
-        if has_more_below {
-            let y = visible_count as u16;
+        if combobox.scroll_offset + visible_count < total_filtered {
             let mut cell = crate::render::Cell::new('↓');
             cell.fg = combobox.disabled_fg;
             cell.bg = combobox.bg;
-            ctx.set(width - 1, y, cell);
+            entry.push(width - 1, dropdown_h.saturating_sub(1), cell);
+        }
+    }
+
+    // Queue as overlay; fallback to inline
+    if !ctx.queue_overlay(entry.clone()) {
+        for oc in &entry.cells {
+            ctx.set(oc.x, oc.y + 1, oc.cell);
         }
     }
 }

--- a/src/widget/input/input_widgets/select.rs
+++ b/src/widget/input/input_widgets/select.rs
@@ -473,10 +473,8 @@ impl View for Select {
             cx += crate::utils::char_width(ch) as u16;
         }
 
-        // If open, render dropdown options
-        if self.open && area.height > 1 {
-            let max_visible = (area.height - 1) as usize;
-
+        // If open, render dropdown options as overlay (escapes parent clipping)
+        if self.open {
             // Determine which options to show
             let visible_options: Vec<(usize, &String)> = if self.query.is_empty() {
                 self.options.iter().enumerate().collect()
@@ -487,13 +485,36 @@ impl View for Select {
                     .collect()
             };
 
+            // Calculate dropdown height (limited to 10 or option count)
+            let dropdown_height = if visible_options.is_empty() {
+                1u16 // "No results" row
+            } else {
+                (visible_options.len() as u16).min(10)
+            };
+
+            // Calculate absolute position for overlay
+            let (abs_x, abs_y) = ctx.absolute_position();
+            let overlay_y = abs_y + 1; // Below the header row
+            let overlay_area = crate::layout::Rect::new(abs_x, overlay_y, width, dropdown_height);
+
+            let mut entry = crate::widget::traits::OverlayEntry::new(100, overlay_area);
+
             if visible_options.is_empty() && !self.query.is_empty() {
-                ctx.draw_text(2, 1, "No results", Color::rgb(128, 128, 128));
+                // "No results" message
+                let msg = "No results";
+                for (i, ch) in msg.chars().enumerate() {
+                    let mut cell = Cell::new(ch);
+                    cell.fg = Some(Color::rgb(128, 128, 128));
+                    entry.push(2 + i as u16, 0, cell);
+                }
             }
 
-            for (row, (option_idx, option)) in visible_options.iter().enumerate().take(max_visible)
+            for (row, (option_idx, option)) in visible_options
+                .iter()
+                .enumerate()
+                .take(dropdown_height as usize)
             {
-                let y = 1 + row as u16;
+                let y = row as u16;
                 let is_selected = self.selection.is_selected(*option_idx);
 
                 let (fg, bg) = if is_selected {
@@ -507,7 +528,7 @@ impl View for Select {
                     let mut cell = Cell::new(' ');
                     cell.fg = fg;
                     cell.bg = bg;
-                    ctx.set(x, y, cell);
+                    entry.push(x, y, cell);
                 }
 
                 // Draw selection indicator
@@ -515,7 +536,7 @@ impl View for Select {
                 let mut cell = Cell::new(indicator);
                 cell.fg = fg;
                 cell.bg = bg;
-                ctx.set(0, y, cell);
+                entry.push(0, y, cell);
 
                 // Get fuzzy match indices for highlighting
                 let match_indices: Vec<usize> = self
@@ -530,15 +551,22 @@ impl View for Select {
                     let mut cell = Cell::new(ch);
                     cell.bg = bg;
 
-                    // Highlight matched characters
                     if match_indices.contains(&j) {
                         cell.fg = self.highlight_fg;
                     } else {
                         cell.fg = fg;
                     }
 
-                    ctx.set(cx, y, cell);
+                    entry.push(cx, y, cell);
                     cx += crate::utils::char_width(ch) as u16;
+                }
+            }
+
+            // Queue as overlay; falls back to inline if no overlay support
+            if !ctx.queue_overlay(entry.clone()) {
+                // Fallback: render inline (clipped by parent)
+                for oc in &entry.cells {
+                    ctx.set(oc.x, oc.y + 1, oc.cell);
                 }
             }
         }

--- a/src/widget/input/input_widgets/select.rs
+++ b/src/widget/input/input_widgets/select.rs
@@ -492,9 +492,15 @@ impl View for Select {
                 (visible_options.len() as u16).min(10)
             };
 
-            // Calculate absolute position for overlay
+            // Calculate absolute position for overlay, flip above if near bottom
             let (abs_x, abs_y) = ctx.absolute_position();
-            let overlay_y = abs_y + 1; // Below the header row
+            let buf_height = ctx.buffer.height();
+            let space_below = buf_height.saturating_sub(abs_y + 1);
+            let overlay_y = if space_below >= dropdown_height {
+                abs_y + 1 // Render below
+            } else {
+                abs_y.saturating_sub(dropdown_height) // Render above
+            };
             let overlay_area = crate::layout::Rect::new(abs_x, overlay_y, width, dropdown_height);
 
             let mut entry = crate::widget::traits::OverlayEntry::new(100, overlay_area);

--- a/src/widget/layout/layer.rs
+++ b/src/widget/layout/layer.rs
@@ -196,10 +196,9 @@ impl View for Layers {
         let mut order: Vec<usize> = (0..self.children.len()).collect();
         order.sort_by_key(|&i| self.children[i].z_index);
 
-        // Render each child in z-index order
+        // Render each child in z-index order, preserving overlay queue
         for &idx in &order {
-            let mut child_ctx = RenderContext::new(ctx.buffer, ctx.area);
-            self.children[idx].child.render(&mut child_ctx);
+            self.children[idx].child.render(ctx);
         }
     }
 }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -371,8 +371,8 @@ pub use streamline::{
 pub use syntax::{HighlightSpan, Language, SyntaxHighlighter, SyntaxTheme};
 pub use theme_picker::{theme_picker, ThemePicker};
 pub use traits::{
-    Draggable, Element, EventResult, FocusStyle, Interactive, RenderContext, StyledView, Timeout,
-    View, WidgetProps, WidgetState, DISABLED_BG, DISABLED_FG,
+    Draggable, Element, EventResult, FocusStyle, Interactive, OverlayEntry, OverlayQueue,
+    RenderContext, StyledView, Timeout, View, WidgetProps, WidgetState, DISABLED_BG, DISABLED_FG,
 };
 pub use transition::{
     transition, transition_group, Animation, AnimationPreset, Transition as AnimationTransition,

--- a/src/widget/multi_select/render.rs
+++ b/src/widget/multi_select/render.rs
@@ -104,7 +104,14 @@ impl View for MultiSelect {
             let dropdown_h = max_visible.max(1) as u16;
 
             let (abs_x, abs_y) = ctx.absolute_position();
-            let overlay_area = crate::layout::Rect::new(abs_x, abs_y + 1, width, dropdown_h);
+            let buf_height = ctx.buffer.height();
+            let space_below = buf_height.saturating_sub(abs_y + 1);
+            let overlay_y = if space_below >= dropdown_h {
+                abs_y + 1
+            } else {
+                abs_y.saturating_sub(dropdown_h)
+            };
+            let overlay_area = crate::layout::Rect::new(abs_x, overlay_y, width, dropdown_h);
             let mut entry = crate::widget::traits::OverlayEntry::new(100, overlay_area);
 
             for (row, &opt_idx) in self.filtered.iter().enumerate().take(max_visible) {

--- a/src/widget/multi_select/render.rs
+++ b/src/widget/multi_select/render.rs
@@ -98,12 +98,17 @@ impl View for MultiSelect {
             }
         }
 
-        // Draw dropdown if open
-        if self.open && area.height > 1 {
-            let max_visible = (area.height - 1) as usize;
+        // Draw dropdown if open (as overlay to escape parent clipping)
+        if self.open {
+            let max_visible = self.filtered.len().min(10);
+            let dropdown_h = max_visible.max(1) as u16;
+
+            let (abs_x, abs_y) = ctx.absolute_position();
+            let overlay_area = crate::layout::Rect::new(abs_x, abs_y + 1, width, dropdown_h);
+            let mut entry = crate::widget::traits::OverlayEntry::new(100, overlay_area);
 
             for (row, &opt_idx) in self.filtered.iter().enumerate().take(max_visible) {
-                let y = 1 + row as u16;
+                let y = row as u16;
                 let is_cursor = row == self.dropdown_cursor;
                 let is_selected = self.is_selected(opt_idx);
 
@@ -114,19 +119,24 @@ impl View for MultiSelect {
                         (fg, bg)
                     };
 
-                    // Draw row background
+                    // Row background
                     for dx in 0..width {
                         let mut cell = Cell::new(' ');
                         cell.fg = Some(row_fg);
                         cell.bg = Some(row_bg);
-                        ctx.set(dx, y, cell);
+                        entry.push(dx, y, cell);
                     }
 
-                    // Draw checkbox
+                    // Checkbox
                     let checkbox_str = if is_selected { "[x]" } else { "[ ]" };
-                    ctx.draw_text_bg(0, y, checkbox_str, row_fg, row_bg);
+                    for (i, ch) in checkbox_str.chars().enumerate() {
+                        let mut cell = Cell::new(ch);
+                        cell.fg = Some(row_fg);
+                        cell.bg = Some(row_bg);
+                        entry.push(i as u16, y, cell);
+                    }
 
-                    // Draw label with highlight
+                    // Label with highlight
                     let match_indices: Vec<usize> = self
                         .get_match(&opt.label)
                         .map(|m| m.indices)
@@ -147,9 +157,19 @@ impl View for MultiSelect {
                             row_fg
                         };
 
-                        ctx.draw_char_bg(cx, y, ch, char_fg, row_bg);
+                        let mut cell = Cell::new(ch);
+                        cell.fg = Some(char_fg);
+                        cell.bg = Some(row_bg);
+                        entry.push(cx, y, cell);
                         cx += cw;
                     }
+                }
+            }
+
+            // Queue as overlay; fallback to inline
+            if !ctx.queue_overlay(entry.clone()) {
+                for oc in &entry.cells {
+                    ctx.set(oc.x, oc.y + 1, oc.cell);
                 }
             }
         }

--- a/src/widget/traits/mod.rs
+++ b/src/widget/traits/mod.rs
@@ -101,7 +101,7 @@ mod widget_state;
 // Re-export all public types
 pub use element::Element;
 pub use event::{EventResult, FocusStyle};
-pub use render_context::{ProgressBarConfig, RenderContext};
+pub use render_context::{OverlayEntry, OverlayQueue, ProgressBarConfig, RenderContext};
 pub use symbols::Symbols;
 pub use timeout::Timeout;
 pub use view::{Draggable, Interactive, StyledView, View};

--- a/src/widget/traits/render_context/mod.rs
+++ b/src/widget/traits/render_context/mod.rs
@@ -2,6 +2,7 @@
 
 mod css;
 mod focus;
+pub mod overlay;
 mod progress;
 mod relative;
 mod segments;
@@ -12,6 +13,7 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+pub use overlay::{OverlayEntry, OverlayQueue};
 pub use types::ProgressBarConfig;
 
 use crate::dom::NodeState;
@@ -31,6 +33,8 @@ pub struct RenderContext<'a> {
     pub state: Option<&'a NodeState>,
     /// Transition values for animations (property name -> current value)
     transitions: Option<&'a std::collections::HashMap<String, f32>>,
+    /// Overlay queue for floating content (dropdowns, tooltips, toasts)
+    overlays: Option<&'a mut OverlayQueue>,
 }
 
 impl<'a> RenderContext<'a> {
@@ -42,6 +46,7 @@ impl<'a> RenderContext<'a> {
             style: None,
             state: None,
             transitions: None,
+            overlays: None,
         }
     }
 
@@ -53,6 +58,7 @@ impl<'a> RenderContext<'a> {
             style: Some(style),
             state: None,
             transitions: None,
+            overlays: None,
         }
     }
 
@@ -69,7 +75,14 @@ impl<'a> RenderContext<'a> {
             style: Some(style),
             state: Some(state),
             transitions: None,
+            overlays: None,
         }
+    }
+
+    /// Attach an overlay queue to this context
+    pub fn with_overlay_queue(mut self, queue: &'a mut OverlayQueue) -> Self {
+        self.overlays = Some(queue);
+        self
     }
 
     /// Set transition values for this render context
@@ -89,6 +102,32 @@ impl<'a> RenderContext<'a> {
     /// Get transition value with a default fallback
     pub fn transition_or(&self, property: &str, default: f32) -> f32 {
         self.transition(property).unwrap_or(default)
+    }
+
+    /// Queue an overlay to render after the main pass.
+    ///
+    /// Overlays render at absolute screen coordinates, bypassing parent
+    /// clipping. Use this for dropdowns, tooltips, and toasts.
+    ///
+    /// Returns true if the overlay was queued, false if no overlay queue
+    /// is available (e.g., in test contexts).
+    pub fn queue_overlay(&mut self, entry: OverlayEntry) -> bool {
+        if let Some(ref mut queue) = self.overlays {
+            queue.push(entry);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get absolute screen position of this context's area
+    pub fn absolute_position(&self) -> (u16, u16) {
+        (self.area.x, self.area.y)
+    }
+
+    /// Check if overlay queue is available
+    pub fn has_overlay_support(&self) -> bool {
+        self.overlays.is_some()
     }
 
     /// Check if focused

--- a/src/widget/traits/render_context/overlay.rs
+++ b/src/widget/traits/render_context/overlay.rs
@@ -1,0 +1,94 @@
+//! Overlay rendering support
+//!
+//! Overlays are UI elements that render OUTSIDE their parent's clipping area,
+//! on top of all other content. Examples: dropdown menus, tooltips, toasts.
+//!
+//! During the main render pass, widgets queue overlay entries via
+//! [`RenderContext::queue_overlay`]. After the main pass completes,
+//! overlays are sorted by z-index and rendered directly to the buffer
+//! at absolute screen coordinates — bypassing parent clipping.
+
+use crate::layout::Rect;
+use crate::render::Cell;
+
+/// A single cell to be rendered as part of an overlay
+#[derive(Clone, Debug)]
+pub struct OverlayCell {
+    /// Relative x within the overlay area
+    pub x: u16,
+    /// Relative y within the overlay area
+    pub y: u16,
+    /// Cell content
+    pub cell: Cell,
+}
+
+/// A queued overlay render request
+#[derive(Clone, Debug)]
+pub struct OverlayEntry {
+    /// Z-index for ordering (higher = on top)
+    pub z_index: i16,
+    /// Absolute screen position and size
+    pub area: Rect,
+    /// Pre-rendered cells (relative to area)
+    pub cells: Vec<OverlayCell>,
+}
+
+impl OverlayEntry {
+    /// Create a new overlay entry
+    pub fn new(z_index: i16, area: Rect) -> Self {
+        Self {
+            z_index,
+            area,
+            cells: Vec::new(),
+        }
+    }
+
+    /// Add a cell to the overlay
+    pub fn push(&mut self, x: u16, y: u16, cell: Cell) {
+        self.cells.push(OverlayCell { x, y, cell });
+    }
+}
+
+/// Collects overlay entries during a render pass
+#[derive(Default, Debug)]
+pub struct OverlayQueue {
+    entries: Vec<OverlayEntry>,
+}
+
+impl OverlayQueue {
+    /// Create empty queue
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    /// Add an overlay entry
+    pub fn push(&mut self, entry: OverlayEntry) {
+        self.entries.push(entry);
+    }
+
+    /// Check if queue has entries
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Drain all entries sorted by z-index (ascending, so highest renders last = on top)
+    pub fn drain_sorted(&mut self) -> Vec<OverlayEntry> {
+        let mut entries: Vec<OverlayEntry> = self.entries.drain(..).collect();
+        entries.sort_by_key(|e| e.z_index);
+        entries
+    }
+
+    /// Render all queued overlays to the buffer
+    pub fn render_to(&mut self, buffer: &mut crate::render::Buffer) {
+        let entries = self.drain_sorted();
+        for entry in entries {
+            for oc in &entry.cells {
+                let abs_x = entry.area.x.saturating_add(oc.x);
+                let abs_y = entry.area.y.saturating_add(oc.y);
+                buffer.set(abs_x, abs_y, oc.cell);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add a two-phase rendering pipeline that supports floating overlays (dropdowns, tooltips, toasts) that escape parent clipping bounds.

### Problem

Widgets like Select dropdowns, Toast notifications, and Tooltips render within their parent's clipping area. When placed inside ScrollView or other constrained containers, their floating content gets clipped — dropdowns are truncated, toasts are hidden behind modals.

### Solution: Overlay Queue

Phase 1 (main render): widgets render normally, but can queue floating content as overlay entries with z-index and absolute screen coordinates.

Phase 2 (overlay render): after main pass completes, overlay entries are sorted by z-index and rendered directly to the buffer — bypassing all parent clipping.

### Changes

**Core infrastructure:**
- `OverlayEntry` / `OverlayQueue` types for collecting pre-rendered cells
- `RenderContext.queue_overlay()` for widgets to queue floating content
- `RenderContext.absolute_position()` for widgets to get screen coordinates
- `DomRenderer.render()` now has phase 1 (widget tree) + phase 2 (overlays)

**Widget conversions:**
- Select dropdown → overlay (z-index 100), no longer clipped by parent
- Toast notification → overlay (z-index 200), renders above modals
- Both fall back to inline rendering when overlay queue unavailable

### Z-index convention
| Layer | z-index | Purpose |
|-------|---------|---------|
| Normal widgets | 0 | Default rendering |
| Dropdowns | 100 | Select, Combobox menus |
| Tooltips | 150 | (future) |
| Toasts | 200 | Notifications |

### Not in this PR (follow-up)
- Tooltip overlay conversion (complex border rendering)
- Combobox dropdown overlay (different render function pattern)

## Test plan

- [x] All tests pass, clippy clean
- [ ] Manual: Select inside ScrollView — dropdown extends past scroll boundary
- [ ] Manual: Toast with Modal open — toast visible above modal