### PR TITLE
fix(api): add Combobox get_value getter, clamp Select selected index

### DIFF
--- a/src/widget/input/input_widgets/combobox/state.rs
+++ b/src/widget/input/input_widgets/combobox/state.rs
@@ -12,6 +12,11 @@ impl Combobox {
         &self.input
     }
 
+    /// Get the current input value (what the user typed or selected)
+    pub fn get_value(&self) -> &str {
+        &self.input
+    }
+
     /// Get the selected value (for single-select mode)
     pub fn selected_value(&self) -> Option<&str> {
         if self.multi_select {

--- a/src/widget/input/input_widgets/select.rs
+++ b/src/widget/input/input_widgets/select.rs
@@ -95,8 +95,9 @@ impl Select {
         self
     }
 
-    /// Set selected index
+    /// Set selected index, clamped to the valid range
     pub fn selected(mut self, index: usize) -> Self {
+        let index = index.min(self.options.len().saturating_sub(1));
         self.selection.set(index);
         self
     }
@@ -152,6 +153,11 @@ impl Select {
     /// Get selected value
     pub fn value(&self) -> Option<&str> {
         self.options.get(self.selection.index).map(|s| s.as_str())
+    }
+
+    /// Get selected value (alias for [`value`](Self::value))
+    pub fn get_value(&self) -> Option<&str> {
+        self.value()
     }
 
     /// Check if dropdown is open


### PR DESCRIPTION
## Summary
- Add `Combobox::get_value()` getter returning `&str` (was missing — `.value()` is a setter)
- Add `Select::get_value()` as consistent alias for `.value()`
- Clamp `Select::selected(index)` to valid range instead of silent OOB