### PR TITLE
docs(widgets): add keyboard shortcut documentation to interactive widgets

### DIFF
--- a/src/widget/input/input_widgets/combobox/mod.rs
+++ b/src/widget/input/input_widgets/combobox/mod.rs
@@ -23,6 +23,23 @@ use crate::widget::traits::WidgetProps;
 use crate::{impl_props_builders, impl_styled_view};
 
 /// A combobox widget with text input and searchable dropdown
+///
+/// # Keyboard Shortcuts
+///
+/// | Key | Action |
+/// |-----|--------|
+/// | `Char` | Insert character at cursor and open dropdown |
+/// | `Backspace` | Delete character before cursor |
+/// | `Delete` | Delete character at cursor |
+/// | `Left` | Move cursor left |
+/// | `Right` | Move cursor right |
+/// | `Home` | Move cursor to start of input |
+/// | `End` | Move cursor to end of input |
+/// | `Down` | Move to next option (when dropdown open) / Open dropdown (when closed) |
+/// | `Up` | Move to previous option (when dropdown open) |
+/// | `Enter` | Confirm highlighted option (when open) / Accept custom value (when closed, allow_custom mode) |
+/// | `Escape` | Close dropdown |
+/// | `Tab` | Complete input with highlighted option text (when dropdown open) |
 #[derive(Clone, Debug)]
 pub struct Combobox {
     /// Available options

--- a/src/widget/input/input_widgets/input/types.rs
+++ b/src/widget/input/input_widgets/input/types.rs
@@ -32,6 +32,43 @@ impl Default for Input {
 ///
 /// All cursor positions are character-based (not byte-based) to properly
 /// handle UTF-8 multi-byte characters like emoji and CJK characters.
+///
+/// # Keyboard Shortcuts
+///
+/// ## Basic editing
+///
+/// | Key | Action |
+/// |-----|--------|
+/// | `Char` | Insert character at cursor (or replace selection) |
+/// | `Backspace` | Delete character before cursor (or delete selection) |
+/// | `Delete` | Delete character at cursor (or delete selection) |
+/// | `Left` | Move cursor left (clears selection) |
+/// | `Right` | Move cursor right (clears selection) |
+/// | `Home` | Move cursor to start of input (clears selection) |
+/// | `End` | Move cursor to end of input (clears selection) |
+///
+/// ## Ctrl combinations (via `handle_key_event`)
+///
+/// | Key | Action |
+/// |-----|--------|
+/// | `Ctrl+A` | Select all text |
+/// | `Ctrl+C` | Copy selection to clipboard |
+/// | `Ctrl+X` | Cut selection to clipboard |
+/// | `Ctrl+V` | Paste from clipboard |
+/// | `Ctrl+Z` | Undo last edit |
+/// | `Ctrl+Y` | Redo last undone edit |
+/// | `Ctrl+Left` | Move cursor to previous word |
+/// | `Ctrl+Right` | Move cursor to next word |
+/// | `Ctrl+Backspace` | Delete word to the left of cursor |
+///
+/// ## Shift combinations (via `handle_key_event`)
+///
+/// | Key | Action |
+/// |-----|--------|
+/// | `Shift+Left` | Extend selection one character to the left |
+/// | `Shift+Right` | Extend selection one character to the right |
+/// | `Shift+Home` | Extend selection to start of input |
+/// | `Shift+End` | Extend selection to end of input |
 #[derive(Clone, Debug)]
 pub struct Input {
     pub(super) value: String,

--- a/src/widget/input/input_widgets/select.rs
+++ b/src/widget/input/input_widgets/select.rs
@@ -9,6 +9,22 @@ use crate::widget::traits::{EventResult, Interactive, RenderContext, View, Widge
 use crate::{impl_props_builders, impl_styled_view};
 
 /// A select/dropdown widget with optional fuzzy search
+///
+/// # Keyboard Shortcuts
+///
+/// | Key | Action |
+/// |-----|--------|
+/// | `Enter` | Open dropdown (when closed) / Confirm selection (when open) |
+/// | `Space` | Toggle dropdown open/close (non-searchable mode only) |
+/// | `Up` / `k` | Move to previous option (when open, non-searchable mode) |
+/// | `Down` / `j` | Move to next option (when open, non-searchable mode) |
+/// | `Up` | Move to previous option (when open, searchable mode) |
+/// | `Down` | Move to next option (when open, searchable mode) |
+/// | `Home` | Jump to first option (when open) |
+/// | `End` | Jump to last option (when open) |
+/// | `Escape` | Close dropdown and clear search query (when open) |
+/// | `Backspace` | Delete last character from search query (when open, searchable mode) |
+/// | `Char` | Append character to search query (when open, searchable mode) |
 #[derive(Clone, Debug)]
 pub struct Select {
     options: Vec<String>,

--- a/src/widget/input/input_widgets/textarea/mod.rs
+++ b/src/widget/input/input_widgets/textarea/mod.rs
@@ -51,6 +51,24 @@ pub(super) const MAX_UNDO_HISTORY: usize = 100;
 /// // Handle key events
 /// editor.handle_key(&Key::Char('a'));
 /// ```
+///
+/// # Keyboard Shortcuts
+///
+/// | Key | Action |
+/// |-----|--------|
+/// | `Char` | Insert character at cursor |
+/// | `Enter` | Insert newline |
+/// | `Tab` | Insert tab (rendered as spaces based on `tab_width`) |
+/// | `Backspace` | Delete character before cursor (or merge with previous line) |
+/// | `Delete` | Delete character at cursor (or merge with next line) |
+/// | `Left` | Move cursor left (clears selection) |
+/// | `Right` | Move cursor right (clears selection) |
+/// | `Up` | Move cursor up one line (clears selection) |
+/// | `Down` | Move cursor down one line (clears selection) |
+/// | `Home` | Move cursor to start of line (clears selection) |
+/// | `End` | Move cursor to end of line (clears selection) |
+/// | `PageUp` | Move cursor up 10 lines |
+/// | `PageDown` | Move cursor down 10 lines |
 pub struct TextArea {
     /// Lines of text
     pub(super) lines: Vec<String>,

--- a/src/widget/multi_select/types.rs
+++ b/src/widget/multi_select/types.rs
@@ -63,6 +63,31 @@ impl MultiSelectOption {
 /// let fruits = vec!["Apple", "Banana", "Cherry", "Date"];
 /// let select = multi_select_from(fruits);
 /// ```
+///
+/// # Keyboard Shortcuts
+///
+/// ## Dropdown navigation
+///
+/// | Key | Action |
+/// |-----|--------|
+/// | `Enter` | Toggle selection of highlighted option (when open) / Open dropdown (when closed) |
+/// | `Escape` | Close dropdown (when open) / Deselect tag cursor (when closed) |
+/// | `Space` | Toggle selection of highlighted option (when open, non-searchable mode) |
+/// | `Down` / `j` | Move highlight down in dropdown (when open) |
+/// | `Up` / `k` | Move highlight up in dropdown (when open) |
+/// | `Char` | Append character to search query (when open, searchable mode) |
+/// | `Backspace` | Delete last character from search query (when open, searchable mode) |
+///
+/// ## Tag management (when dropdown is closed)
+///
+/// | Key | Action |
+/// |-----|--------|
+/// | `Left` | Move tag cursor left |
+/// | `Right` | Move tag cursor right |
+/// | `Backspace` | Remove tag at cursor (if cursor active) / Remove last tag |
+/// | `Delete` | Remove tag at cursor (if cursor active) |
+/// | `a` | Select all options |
+/// | `c` | Clear all selections |
 #[derive(Debug, Clone)]
 pub struct MultiSelect {
     /// Available options


### PR DESCRIPTION
## Summary
Add `# Keyboard Shortcuts` tables to rustdoc for 5 interactive widgets:
- Select (11 bindings)
- Combobox (11 bindings)
- TextArea (13 bindings)
- Input (15+ bindings including Ctrl/Shift combos)
- MultiSelect (dropdown + tag management)

No logic changes — documentation only.