### PR TITLE
fix(input): skip key events when widget is not focused

### DIFF
--- a/src/widget/input/input_widgets/input/handler.rs
+++ b/src/widget/input/input_widgets/input/handler.rs
@@ -51,8 +51,12 @@ impl Input {
         }
     }
 
-    /// Handle key event with modifiers, returns true if needs redraw
+    /// Handle key event with modifiers, returns true if needs redraw.
+    /// Returns false immediately if the widget is not focused.
     pub fn handle_key_event(&mut self, event: &KeyEvent) -> bool {
+        if !self.focused {
+            return false;
+        }
         // Try Ctrl combinations first
         if event.ctrl {
             if let Some(handled) = self.handle_ctrl_key(event) {

--- a/src/widget/input/input_widgets/select.rs
+++ b/src/widget/input/input_widgets/select.rs
@@ -628,7 +628,7 @@ impl View for Select {
 
 impl Interactive for Select {
     fn handle_key(&mut self, event: &KeyEvent) -> EventResult {
-        if self.disabled {
+        if self.disabled || !self.focused {
             return EventResult::Ignored;
         }
 

--- a/src/widget/input/input_widgets/textarea/mod.rs
+++ b/src/widget/input/input_widgets/textarea/mod.rs
@@ -270,6 +270,9 @@ impl TextArea {
 
     /// Handle key event
     pub fn handle_key(&mut self, key: &Key) -> bool {
+        if !self.focused {
+            return false;
+        }
         match key {
             Key::Char(ch) => {
                 self.insert_char(*ch);
@@ -558,105 +561,105 @@ mod tests {
 
     #[test]
     fn test_textarea_handle_key_char() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::Char('a'));
         assert!(handled);
     }
 
     #[test]
     fn test_textarea_handle_key_enter() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::Enter);
         assert!(handled);
     }
 
     #[test]
     fn test_textarea_handle_key_tab() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::Tab);
         assert!(handled);
     }
 
     #[test]
     fn test_textarea_handle_key_backspace() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::Backspace);
         assert!(handled);
     }
 
     #[test]
     fn test_textarea_handle_key_delete() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::Delete);
         assert!(handled);
     }
 
     #[test]
     fn test_textarea_handle_key_left() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::Left);
         assert!(handled);
     }
 
     #[test]
     fn test_textarea_handle_key_right() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::Right);
         assert!(handled);
     }
 
     #[test]
     fn test_textarea_handle_key_up() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::Up);
         assert!(handled);
     }
 
     #[test]
     fn test_textarea_handle_key_down() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::Down);
         assert!(handled);
     }
 
     #[test]
     fn test_textarea_handle_key_home() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::Home);
         assert!(handled);
     }
 
     #[test]
     fn test_textarea_handle_key_end() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::End);
         assert!(handled);
     }
 
     #[test]
     fn test_textarea_handle_key_page_up() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::PageUp);
         assert!(handled);
     }
 
     #[test]
     fn test_textarea_handle_key_page_down() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::PageDown);
         assert!(handled);
     }
 
     #[test]
     fn test_textarea_handle_key_unknown() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::Escape);
         assert!(!handled);
     }
 
     #[test]
     fn test_textarea_handle_key_f1() {
-        let mut textarea = TextArea::new();
+        let mut textarea = TextArea::new().focused(true);
         let handled = textarea.handle_key(&Key::F(1));
         assert!(!handled);
     }

--- a/tests/textarea_unicode_tests.rs
+++ b/tests/textarea_unicode_tests.rs
@@ -8,7 +8,7 @@ use revue::widget::textarea;
 
 #[test]
 fn test_textarea_insert_cjk_and_get_content() {
-    let mut t = textarea();
+    let mut t = textarea().focused(true);
     t.insert_char('한');
     t.insert_char('글');
     assert_eq!(t.get_content(), "한글");
@@ -16,7 +16,7 @@ fn test_textarea_insert_cjk_and_get_content() {
 
 #[test]
 fn test_textarea_insert_emoji_cursor_position() {
-    let mut t = textarea();
+    let mut t = textarea().focused(true);
     t.insert_char('😀');
     t.insert_char('!');
     assert_eq!(t.get_content(), "😀!");
@@ -26,7 +26,7 @@ fn test_textarea_insert_emoji_cursor_position() {
 
 #[test]
 fn test_textarea_backspace_cjk() {
-    let mut t = textarea();
+    let mut t = textarea().focused(true);
     t.insert_char('가');
     t.insert_char('나');
     t.insert_char('다');
@@ -41,7 +41,7 @@ fn test_textarea_backspace_cjk() {
 
 #[test]
 fn test_textarea_backspace_emoji() {
-    let mut t = textarea();
+    let mut t = textarea().focused(true);
     t.insert_char('🎉');
     t.insert_char('🔥');
     assert_eq!(t.get_content(), "🎉🔥");
@@ -52,7 +52,7 @@ fn test_textarea_backspace_emoji() {
 
 #[test]
 fn test_textarea_delete_at_cjk() {
-    let mut t = textarea().content("한글테스트");
+    let mut t = textarea().focused(true).content("한글테스트");
     t.set_cursor(0, 0);
 
     t.delete_char_at();
@@ -64,7 +64,7 @@ fn test_textarea_delete_at_cjk() {
 
 #[test]
 fn test_textarea_insert_str_cjk_cursor() {
-    let mut t = textarea();
+    let mut t = textarea().focused(true);
     t.insert_str("안녕하세요");
     assert_eq!(t.get_content(), "안녕하세요");
     let (_, col) = t.cursor_position();
@@ -73,7 +73,7 @@ fn test_textarea_insert_str_cjk_cursor() {
 
 #[test]
 fn test_textarea_mixed_ascii_cjk() {
-    let mut t = textarea();
+    let mut t = textarea().focused(true);
     t.insert_str("Hello");
     t.insert_char('世');
     t.insert_char('界');
@@ -84,7 +84,7 @@ fn test_textarea_mixed_ascii_cjk() {
 
 #[test]
 fn test_textarea_cursor_navigation_cjk() {
-    let mut t = textarea().content("가나다라");
+    let mut t = textarea().focused(true).content("가나다라");
     t.set_cursor(0, 4);
 
     t.handle_key(&Key::Left);
@@ -102,7 +102,7 @@ fn test_textarea_cursor_navigation_cjk() {
 
 #[test]
 fn test_textarea_insert_in_middle_cjk() {
-    let mut t = textarea().content("가다");
+    let mut t = textarea().focused(true).content("가다");
     t.set_cursor(0, 1);
 
     t.insert_char('나');
@@ -111,7 +111,7 @@ fn test_textarea_insert_in_middle_cjk() {
 
 #[test]
 fn test_textarea_newline_with_cjk() {
-    let mut t = textarea().content("안녕하세요");
+    let mut t = textarea().focused(true).content("안녕하세요");
     t.set_cursor(0, 2);
 
     t.insert_char('\n');
@@ -121,7 +121,7 @@ fn test_textarea_newline_with_cjk() {
 
 #[test]
 fn test_textarea_multiline_insert_cjk() {
-    let mut t = textarea();
+    let mut t = textarea().focused(true);
     t.insert_str("첫째줄\n둘째줄");
     assert_eq!(t.get_content(), "첫째줄\n둘째줄");
     assert_eq!(t.line_count(), 2);


### PR DESCRIPTION
## Summary

Input, TextArea, Select now check `focused` state before processing keyboard events. This prevents the critical bug where multiple widgets in a form all respond to the same key event simultaneously.

### Before
```rust
let mut input1 = Input::new().focused(true);
let mut input2 = Input::new().focused(true);
// Both process Key::Char('a') — both get modified!
```

### After
```rust
let mut input1 = Input::new().focused(true);
let mut input2 = Input::new(); // focused=false by default
// Only input1 processes events. input2 returns false/Ignored.
```

## Changes
- `Input::handle_key_event()` — early return false if !focused
- `TextArea::handle_key()` — early return false if !focused
- `Select::handle_key()` — return EventResult::Ignored if !focused
- Tests updated to set `.focused(true)` before calling handle_key