### PR TITLE
fix(ux): auto-close dropdown on focus loss, improve Tab handling

### DIFF
--- a/src/widget/input/input_widgets/combobox/input.rs
+++ b/src/widget/input/input_widgets/combobox/input.rs
@@ -123,12 +123,13 @@ impl Combobox {
                 true
             }
             Key::Tab if self.open && !self.filtered.is_empty() => {
-                // Tab completion: fill with highlighted option
+                // Tab completion: fill with highlighted option and close dropdown
                 if let Some(&option_idx) = self.filtered.get(self.selected_idx) {
                     self.input = self.options[option_idx].label.clone();
                     self.cursor = self.input.chars().count();
                     self.update_filter();
                 }
+                self.close_dropdown();
                 true
             }
             _ => false,

--- a/src/widget/input/input_widgets/combobox/mod.rs
+++ b/src/widget/input/input_widgets/combobox/mod.rs
@@ -250,6 +250,28 @@ impl crate::widget::traits::View for Combobox {
     crate::impl_view_meta!("Combobox");
 }
 
+impl crate::widget::traits::Interactive for Combobox {
+    fn handle_key(&mut self, event: &crate::event::KeyEvent) -> crate::widget::traits::EventResult {
+        // When closed and Tab pressed, let the focus manager handle navigation
+        if event.key == crate::event::Key::Tab && !self.open {
+            return crate::widget::traits::EventResult::Ignored;
+        }
+
+        let changed = self.handle_key(&event.key);
+        if changed {
+            crate::widget::traits::EventResult::ConsumedAndRender
+        } else {
+            crate::widget::traits::EventResult::Ignored
+        }
+    }
+
+    fn on_blur(&mut self) {
+        if self.open {
+            self.close_dropdown();
+        }
+    }
+}
+
 impl_styled_view!(Combobox);
 impl_props_builders!(Combobox);
 

--- a/src/widget/input/input_widgets/select.rs
+++ b/src/widget/input/input_widgets/select.rs
@@ -135,6 +135,10 @@ impl Select {
     /// Set focused state
     pub fn focused(mut self, focused: bool) -> Self {
         self.focused = focused;
+        if !focused {
+            self.open = false;
+            self.clear_query();
+        }
         self
     }
 
@@ -669,6 +673,11 @@ impl Interactive for Select {
             }
             Key::End if self.open => {
                 self.select_last();
+                true
+            }
+            Key::Tab if self.open => {
+                self.close();
+                self.clear_query();
                 true
             }
             _ => false,

--- a/src/widget/multi_select/key_handling.rs
+++ b/src/widget/multi_select/key_handling.rs
@@ -1,8 +1,40 @@
 //! Key handling for the multi-select widget
 
 use crate::event::Key;
+use crate::widget::traits::{EventResult, Interactive};
 
 use super::types::MultiSelect;
+
+impl Interactive for MultiSelect {
+    fn handle_key(&mut self, event: &crate::event::KeyEvent) -> EventResult {
+        // When closed and Tab pressed, let the focus manager handle navigation
+        if event.key == Key::Tab && !self.open {
+            return EventResult::Ignored;
+        }
+
+        let changed = self.handle_key(&event.key);
+        if changed {
+            EventResult::ConsumedAndRender
+        } else {
+            EventResult::Ignored
+        }
+    }
+
+    fn focusable(&self) -> bool {
+        !self.state.disabled
+    }
+
+    fn on_focus(&mut self) {
+        self.state.focused = true;
+    }
+
+    fn on_blur(&mut self) {
+        self.state.focused = false;
+        if self.open {
+            self.close();
+        }
+    }
+}
 
 impl MultiSelect {
     /// Handle key input, returns true if needs redraw
@@ -102,6 +134,12 @@ impl MultiSelect {
             // Clear selection
             Key::Char('c') if !self.open => {
                 self.clear_selection();
+                true
+            }
+
+            // Close dropdown on Tab when open
+            Key::Tab if self.open => {
+                self.close();
                 true
             }
 


### PR DESCRIPTION
## Summary

Fix two multi-widget interaction issues:

### 1. Two dropdowns open simultaneously
Select, Combobox, MultiSelect now close their dropdown when losing focus (`on_blur`). When user tabs/clicks to another widget, the previous dropdown auto-closes.

### 2. Tab key navigation
- Dropdown **open**: Tab closes it (so focus can move)
- Dropdown **closed**: Tab returns `Ignored` so focus manager handles navigation
- TextArea: unchanged (Tab inserts tab character — expected for editors)

## Changes
| Widget | on_blur | Tab (open) | Tab (closed) |
|--------|---------|------------|--------------|
| Select | closes dropdown + clears query | closes dropdown | Ignored |
| Combobox | closes dropdown | closes dropdown | Ignored |
| MultiSelect | closes dropdown | closes dropdown | Ignored |