### PR TITLE
test: add multi-widget interaction tests, Input get_value getter, Select focus guard

### DIFF
--- a/src/widget/input/input_widgets/button.rs
+++ b/src/widget/input/input_widgets/button.rs
@@ -262,20 +262,9 @@ impl View for Button {
             ctx.draw_text_bg(x, 0, &self.label, fg, bg);
         }
 
-        // Render focus indicator
+        // Render focus indicator (inside area bounds)
         if self.state.focused && !self.state.disabled {
-            // Add brackets around button when focused
-            if area.x > 0 {
-                let mut left = Cell::new('[');
-                left.fg = Some(Color::CYAN);
-                ctx.buffer.set(area.x.saturating_sub(1), area.y, left);
-            }
-
-            if button_width < area.width {
-                let mut right = Cell::new(']');
-                right.fg = Some(Color::CYAN);
-                ctx.set(button_width, 0, right);
-            }
+            ctx.draw_focus_brackets(0, button_width, Color::CYAN);
         }
     }
 

--- a/src/widget/input/input_widgets/input/editing.rs
+++ b/src/widget/input/input_widgets/input/editing.rs
@@ -103,6 +103,11 @@ impl Input {
     // Value management
     // ─────────────────────────────────────────────────────────────────────────
 
+    /// Get the current value
+    pub fn get_value(&self) -> &str {
+        &self.value
+    }
+
     /// Clear the input (also clears undo history)
     pub fn clear(&mut self) {
         self.value.clear();

--- a/src/widget/input/input_widgets/select.rs
+++ b/src/widget/input/input_widgets/select.rs
@@ -487,20 +487,9 @@ impl View for Select {
             ctx.set(x, 0, cell);
         }
 
-        // Draw focus indicator
+        // Draw focus indicator (inside area bounds)
         if self.focused && !self.disabled {
-            // Add brackets around select when focused
-            if area.x > 0 {
-                let mut left = Cell::new('[');
-                left.fg = Some(Color::CYAN);
-                ctx.buffer.set(area.x.saturating_sub(1), area.y, left);
-            }
-
-            if width < area.width {
-                let mut right = Cell::new(']');
-                right.fg = Some(Color::CYAN);
-                ctx.set(width, 0, right);
-            }
+            ctx.draw_focus_brackets(0, width, Color::CYAN);
         }
 
         // Draw arrow (or search icon when searching)

--- a/src/widget/input/input_widgets/select.rs
+++ b/src/widget/input/input_widgets/select.rs
@@ -322,6 +322,9 @@ impl Select {
 
     /// Handle key input, returns true if selection changed
     pub fn handle_key(&mut self, key: &crate::event::Key) -> bool {
+        if !self.focused {
+            return false;
+        }
         use crate::event::Key;
 
         match key {

--- a/src/widget/input/input_widgets/switch.rs
+++ b/src/widget/input/input_widgets/switch.rs
@@ -455,10 +455,10 @@ impl View for Switch {
                 let mut left = Cell::new('[');
                 left.fg = Some(Color::CYAN);
                 ctx.set(switch_x.saturating_sub(1), y, left);
-            } else if area.x > 0 {
+            } else {
                 let mut left = Cell::new('[');
                 left.fg = Some(Color::CYAN);
-                ctx.buffer.set(area.x.saturating_sub(1), area.y, left);
+                ctx.set(0, y, left);
             }
 
             // Draw focus bracket on right

--- a/src/widget/traits/render_context/focus.rs
+++ b/src/widget/traits/render_context/focus.rs
@@ -106,6 +106,26 @@ impl RenderContext<'_> {
     pub fn apply_default_focus(&mut self, focused: bool) {
         self.apply_focus_indicator(focused, FocusStyle::Rounded, Color::CYAN);
     }
+
+    /// Draw inline bracket focus indicators `[` and `]` at the edges
+    /// of a widget region. Renders INSIDE area bounds (no buffer.set).
+    ///
+    /// # Arguments
+    /// * `y` - Row to draw brackets on (relative to area)
+    /// * `width` - Widget content width (bracket goes at 0 and width-1)
+    /// * `color` - Bracket color (typically Color::CYAN)
+    pub fn draw_focus_brackets(&mut self, y: u16, width: u16, color: Color) {
+        if width < 2 {
+            return;
+        }
+        let mut left = Cell::new('[');
+        left.fg = Some(color);
+        self.set(0, y, left);
+
+        let mut right = Cell::new(']');
+        right.fg = Some(color);
+        self.set(width.saturating_sub(1), y, right);
+    }
 }
 
 use crate::widget::traits::render_context::RenderContext;

--- a/tests/rendering_overlap_tests.rs
+++ b/tests/rendering_overlap_tests.rs
@@ -1,0 +1,321 @@
+//! Rendering overlap and boundary tests
+//!
+//! Verifies widgets render within their allocated areas and don't
+//! overwrite adjacent widget content. Uses buffer inspection to
+//! check exact cell contents at specific positions.
+
+use revue::layout::Rect;
+use revue::render::{Buffer, Cell};
+use revue::style::Color;
+use revue::widget::traits::{OverlayEntry, RenderContext, View};
+
+/// Helper: dump a row of the buffer as a string (for debugging)
+#[allow(dead_code)]
+fn row_text(buffer: &Buffer, y: u16, x_start: u16, x_end: u16) -> String {
+    (x_start..x_end)
+        .filter_map(|x| buffer.get(x, y).map(|c| c.symbol))
+        .collect()
+}
+
+/// Helper: check that a rectangular region contains ONLY the expected char
+fn region_is(buffer: &Buffer, x: u16, y: u16, w: u16, h: u16, expected: char) -> bool {
+    for dy in 0..h {
+        for dx in 0..w {
+            if let Some(cell) = buffer.get(x + dx, y + dy) {
+                if cell.symbol != expected {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+// =============================================================================
+// Widget Stays Within Its Area
+// =============================================================================
+
+#[test]
+fn test_select_closed_renders_in_single_row() {
+    let mut buffer = Buffer::new(30, 10);
+    let area = Rect::new(0, 0, 30, 10);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+
+    let s = revue::widget::Select::new()
+        .options(vec!["Apple", "Banana"])
+        .focused(true);
+    s.render(&mut ctx);
+
+    // Row 0 should have content (arrow + text)
+    assert_ne!(buffer.get(0, 0).unwrap().symbol, ' ');
+
+    // Rows 1-9 should be empty (dropdown is closed)
+    for y in 1..10 {
+        assert!(
+            region_is(&buffer, 0, y, 30, 1, ' '),
+            "row {} should be empty when Select is closed",
+            y
+        );
+    }
+}
+
+#[test]
+fn test_widget_respects_sub_area_boundary() {
+    // Render a Select at a specific sub-area and verify it doesn't
+    // write outside that area
+    let mut buffer = Buffer::new(40, 20);
+
+    // Fill buffer with markers
+    for y in 0..20 {
+        for x in 0..40 {
+            buffer.set(x, y, Cell::new('·'));
+        }
+    }
+
+    // Render Select in sub-area (5, 3, 20, 1)
+    let area = Rect::new(5, 3, 20, 1);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+    let s = revue::widget::Select::new()
+        .options(vec!["Hello"])
+        .focused(true);
+    s.render(&mut ctx);
+
+    // Check that area OUTSIDE (5,3,20,1) still has markers
+    // Row 2 (above) should be untouched
+    assert!(
+        region_is(&buffer, 0, 2, 40, 1, '·'),
+        "row above Select area should be untouched"
+    );
+    // Row 4 (below) should be untouched
+    assert!(
+        region_is(&buffer, 0, 4, 40, 1, '·'),
+        "row below Select area should be untouched"
+    );
+    // Left of area (x=0..4, y=3) should be untouched
+    for x in 0..5 {
+        assert_eq!(
+            buffer.get(x, 3).unwrap().symbol,
+            '·',
+            "cell left of Select at x={} should be untouched",
+            x
+        );
+    }
+    // Right of area (x=25..39, y=3) should be untouched
+    for x in 25..40 {
+        assert_eq!(
+            buffer.get(x, 3).unwrap().symbol,
+            '·',
+            "cell right of Select at x={} should be untouched",
+            x
+        );
+    }
+}
+
+// =============================================================================
+// Modal Content Stays Within Border
+// =============================================================================
+
+#[test]
+fn test_modal_content_within_border() {
+    use revue::widget::Modal;
+
+    let mut buffer = Buffer::new(40, 15);
+    let area = Rect::new(0, 0, 40, 15);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+
+    let mut modal = Modal::new()
+        .title("Test Modal")
+        .content("Line 1\nLine 2")
+        .width(30);
+    modal.show();
+
+    modal.render(&mut ctx);
+
+    // Find modal border corners (they should be box-drawing chars)
+    let mut found_border = false;
+    for y in 0..15 {
+        for x in 0..40 {
+            if let Some(cell) = buffer.get(x, y) {
+                if cell.symbol == '┌' {
+                    found_border = true;
+                    // Check opposite corner exists
+                    let right = buffer.get(x + 29, y);
+                    assert!(
+                        right.is_some() && right.unwrap().symbol == '┐',
+                        "top-right corner should be at x+29"
+                    );
+                }
+            }
+        }
+    }
+    assert!(found_border, "modal border should be rendered");
+}
+
+// =============================================================================
+// Adjacent Widgets Don't Overlap
+// =============================================================================
+
+#[test]
+fn test_two_widgets_in_adjacent_areas_dont_overlap() {
+    use revue::widget::Input;
+
+    let mut buffer = Buffer::new(40, 2);
+
+    // Fill with markers
+    for y in 0..2 {
+        for x in 0..40 {
+            buffer.set(x, y, Cell::new('·'));
+        }
+    }
+
+    // Render Input 1 in row 0
+    {
+        let area = Rect::new(0, 0, 20, 1);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+        let input1 = Input::new().value("AAAA").focused(true);
+        input1.render(&mut ctx);
+    }
+
+    // Render Input 2 in row 1
+    {
+        let area = Rect::new(0, 1, 20, 1);
+        let mut ctx = RenderContext::new(&mut buffer, area);
+        let input2 = Input::new().value("BBBB").focused(false);
+        input2.render(&mut ctx);
+    }
+
+    // Row 0 should contain 'A's, not 'B's
+    let row0 = row_text(&buffer, 0, 0, 20);
+    assert!(row0.contains('A'), "row 0 should have input1 content");
+    assert!(!row0.contains('B'), "row 0 should NOT have input2 content");
+
+    // Row 1 should contain 'B's, not 'A's
+    let row1 = row_text(&buffer, 1, 0, 20);
+    assert!(row1.contains('B'), "row 1 should have input2 content");
+    assert!(!row1.contains('A'), "row 1 should NOT have input1 content");
+}
+
+// =============================================================================
+// Overlay Renders At Correct Position
+// =============================================================================
+
+#[test]
+fn test_overlay_renders_at_absolute_position() {
+    use revue::widget::traits::OverlayEntry;
+
+    let mut buffer = Buffer::new(30, 10);
+
+    // Fill with markers
+    for y in 0..10 {
+        for x in 0..30 {
+            buffer.set(x, y, Cell::new('·'));
+        }
+    }
+
+    // Create overlay entry at absolute position (5, 3)
+    let mut entry = OverlayEntry::new(100, Rect::new(5, 3, 10, 2));
+    for x in 0..10 {
+        entry.push(x, 0, Cell::new('X'));
+        entry.push(x, 1, Cell::new('X'));
+    }
+
+    // Render overlay directly
+    let mut queue = revue::widget::OverlayQueue::new();
+    queue.push(entry);
+    queue.render_to(&mut buffer);
+
+    // Verify overlay cells are at correct absolute positions
+    assert_eq!(buffer.get(5, 3).unwrap().symbol, 'X');
+    assert_eq!(buffer.get(14, 3).unwrap().symbol, 'X');
+    assert_eq!(buffer.get(5, 4).unwrap().symbol, 'X');
+
+    // Verify cells outside overlay are untouched
+    assert_eq!(buffer.get(4, 3).unwrap().symbol, '·');
+    assert_eq!(buffer.get(15, 3).unwrap().symbol, '·');
+    assert_eq!(buffer.get(5, 2).unwrap().symbol, '·');
+    assert_eq!(buffer.get(5, 5).unwrap().symbol, '·');
+}
+
+#[test]
+fn test_overlay_z_order_higher_on_top() {
+    let mut buffer = Buffer::new(10, 1);
+
+    // Two overlays at same position, different z-index
+    let mut low = OverlayEntry::new(10, Rect::new(0, 0, 5, 1));
+    for x in 0..5 {
+        low.push(x, 0, Cell::new('L'));
+    }
+
+    let mut high = OverlayEntry::new(20, Rect::new(0, 0, 5, 1));
+    for x in 0..5 {
+        high.push(x, 0, Cell::new('H'));
+    }
+
+    let mut queue = revue::widget::OverlayQueue::new();
+    queue.push(low);
+    queue.push(high);
+    queue.render_to(&mut buffer);
+
+    // Higher z-index should be on top (rendered last, overwrites)
+    for x in 0..5 {
+        assert_eq!(
+            buffer.get(x, 0).unwrap().symbol,
+            'H',
+            "higher z-index should overwrite at x={}",
+            x
+        );
+    }
+}
+
+#[test]
+fn test_overlay_clipped_at_buffer_edge() {
+    let mut buffer = Buffer::new(10, 5);
+
+    // Overlay extends past buffer right edge
+    let mut entry = OverlayEntry::new(100, Rect::new(8, 0, 5, 1));
+    for x in 0..5 {
+        entry.push(x, 0, Cell::new('X'));
+    }
+
+    let mut queue = revue::widget::OverlayQueue::new();
+    queue.push(entry);
+    queue.render_to(&mut buffer);
+
+    // Cells within buffer should be written
+    assert_eq!(buffer.get(8, 0).unwrap().symbol, 'X');
+    assert_eq!(buffer.get(9, 0).unwrap().symbol, 'X');
+    // Cells outside buffer (x=10,11,12) are silently skipped — no panic
+}
+
+// =============================================================================
+// CJK Text Rendering Width Correctness
+// =============================================================================
+
+#[test]
+fn test_cjk_text_occupies_correct_width() {
+    let mut buffer = Buffer::new(20, 1);
+    let area = Rect::new(0, 0, 20, 1);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+
+    // "한" is 2 display columns wide
+    ctx.draw_text(0, 0, "한A", Color::WHITE);
+
+    // '한' at x=0 (2 wide), 'A' at x=2
+    assert_eq!(buffer.get(0, 0).unwrap().symbol, '한');
+    assert_eq!(buffer.get(2, 0).unwrap().symbol, 'A');
+}
+
+#[test]
+fn test_cjk_text_clipped_at_boundary() {
+    let mut buffer = Buffer::new(5, 1);
+    let area = Rect::new(0, 0, 5, 1);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+
+    // "ABCDE한" — '한' needs 2 cols but only 0 left, should be skipped
+    ctx.draw_text(0, 0, "ABCD한", Color::WHITE);
+
+    assert_eq!(buffer.get(0, 0).unwrap().symbol, 'A');
+    assert_eq!(buffer.get(3, 0).unwrap().symbol, 'D');
+    // x=4 should be space (한 doesn't fit in 1 remaining column)
+    assert_eq!(buffer.get(4, 0).unwrap().symbol, ' ');
+}

--- a/tests/widget_interaction_tests.rs
+++ b/tests/widget_interaction_tests.rs
@@ -1,0 +1,274 @@
+//! Multi-widget interaction and edge case tests
+//!
+//! Tests for scenarios where multiple widgets are used together,
+//! and edge cases that combine several features at once.
+
+use revue::event::{Key, KeyEvent};
+use revue::widget::{select, textarea, Select};
+
+// =============================================================================
+// Focus Guard Tests — only focused widget should process events
+// =============================================================================
+
+#[test]
+fn test_two_inputs_only_focused_responds() {
+    use revue::widget::Input;
+
+    let mut input1 = Input::new().value("A").focused(true);
+    let mut input2 = Input::new().value("B").focused(false); // explicitly not focused
+
+    let event = KeyEvent::new(Key::Char('X'));
+    let changed1 = input1.handle_key_event(&event);
+    let changed2 = input2.handle_key_event(&event);
+
+    assert!(changed1, "focused input should process key");
+    assert!(!changed2, "unfocused input should ignore key");
+    assert!(input1.get_value().contains('X'));
+    assert_eq!(input2.get_value(), "B");
+}
+
+#[test]
+fn test_textarea_unfocused_ignores_keys() {
+    let mut ta = textarea(); // focused=false by default
+    let handled = ta.handle_key(&Key::Char('a'));
+    assert!(!handled);
+    assert_eq!(ta.get_content(), ""); // nothing inserted
+}
+
+#[test]
+fn test_textarea_focused_accepts_keys() {
+    let mut ta = textarea().focused(true);
+    let handled = ta.handle_key(&Key::Char('a'));
+    assert!(handled);
+    assert_eq!(ta.get_content(), "a");
+}
+
+#[test]
+fn test_select_unfocused_ignores_keys() {
+    let mut s = Select::new().options(vec!["A", "B"]);
+    // focused=false by default
+    s.handle_key(&Key::Enter);
+    assert!(!s.is_open(), "unfocused select should not open on Enter");
+}
+
+#[test]
+fn test_select_focused_accepts_keys() {
+    let mut s = Select::new().options(vec!["A", "B"]).focused(true);
+    s.handle_key(&Key::Enter);
+    assert!(s.is_open(), "focused select should open on Enter");
+}
+
+// =============================================================================
+// Select Focus Loss Auto-Close Tests
+// =============================================================================
+
+#[test]
+fn test_select_closes_on_focus_loss() {
+    let mut s = Select::new()
+        .options(vec!["A", "B"])
+        .focused(true)
+        .searchable(true);
+    s.open();
+    s.set_query("test");
+    assert!(s.is_open());
+
+    // Simulate focus loss
+    s = s.focused(false);
+    assert!(!s.is_open(), "should close on focus loss");
+    assert_eq!(s.query(), "", "should clear query on focus loss");
+}
+
+// =============================================================================
+// Select Edge Cases
+// =============================================================================
+
+#[test]
+fn test_select_selected_before_options() {
+    // Setting selected before options — should not panic
+    let s = Select::new().selected(5).options(vec!["A", "B"]);
+    assert!(s.selected_index() < s.len());
+}
+
+#[test]
+fn test_select_options_replace_resets() {
+    let mut s = Select::new().options(vec!["A", "B", "C"]).selected(2);
+    assert_eq!(s.value(), Some("C"));
+
+    // Replace options — selection should be recalculated
+    s = s.options(vec!["X", "Y"]);
+    assert!(s.selected_index() < s.len());
+}
+
+#[test]
+fn test_select_get_value_alias() {
+    let s = Select::new().options(vec!["Hello"]);
+    assert_eq!(s.value(), s.get_value());
+}
+
+#[test]
+fn test_select_empty_options_no_panic() {
+    let s = Select::new();
+    assert_eq!(s.value(), None);
+    assert_eq!(s.get_value(), None);
+    assert_eq!(s.selected_index(), 0);
+    assert!(s.is_empty());
+}
+
+// =============================================================================
+// TextArea Edge Cases
+// =============================================================================
+
+#[test]
+fn test_textarea_editor_preset() {
+    use revue::widget::TextArea;
+    let editor = TextArea::editor();
+    // editor() should enable line numbers and wrap
+    let content = editor.content("Hello\nWorld");
+    assert_eq!(content.line_count(), 2);
+}
+
+#[test]
+fn test_textarea_empty_content_operations() {
+    let mut ta = textarea().focused(true);
+    // Delete on empty — should not panic
+    ta.handle_key(&Key::Backspace);
+    ta.handle_key(&Key::Delete);
+    assert_eq!(ta.get_content(), "");
+}
+
+#[test]
+fn test_textarea_rapid_undo_redo() {
+    let mut ta = textarea().focused(true);
+    ta.insert_char('a');
+    ta.insert_char('b');
+    ta.insert_char('c');
+    assert_eq!(ta.get_content(), "abc");
+
+    ta.undo();
+    ta.undo();
+    ta.undo();
+    ta.undo(); // extra undo — should not panic
+    assert_eq!(ta.get_content(), "");
+
+    ta.redo();
+    assert_eq!(ta.get_content(), "a");
+    ta.redo();
+    ta.redo();
+    ta.redo(); // extra redo — should not panic
+    assert_eq!(ta.get_content(), "abc");
+}
+
+#[test]
+fn test_textarea_insert_then_backspace_all() {
+    let mut ta = textarea().focused(true);
+    for ch in "Hello, 세계!".chars() {
+        ta.insert_char(ch);
+    }
+    assert_eq!(ta.get_content(), "Hello, 세계!");
+
+    // Backspace everything
+    for _ in 0..20 {
+        ta.delete_char_before();
+    }
+    assert_eq!(ta.get_content(), "");
+}
+
+// =============================================================================
+// Combobox Edge Cases
+// =============================================================================
+
+#[test]
+fn test_combobox_get_value() {
+    use revue::widget::Combobox;
+    let c = Combobox::new().options(["Apple", "Banana"]);
+    assert_eq!(c.get_value(), "");
+}
+
+// =============================================================================
+// Input Control Character Filtering
+// =============================================================================
+
+#[test]
+fn test_input_rejects_control_chars() {
+    use revue::widget::Input;
+    let mut input = Input::new().focused(true);
+
+    // Try to type a newline — should be rejected
+    let handled = input.handle_key_event(&KeyEvent::new(Key::Char('\n')));
+    assert!(!handled, "newline should be rejected in single-line input");
+
+    // Try to type a null byte
+    let handled = input.handle_key_event(&KeyEvent::new(Key::Char('\0')));
+    assert!(!handled, "null should be rejected");
+
+    // Normal char should work
+    let handled = input.handle_key_event(&KeyEvent::new(Key::Char('a')));
+    assert!(handled);
+}
+
+#[test]
+fn test_input_set_value_strips_control_chars() {
+    use revue::widget::Input;
+    let mut input = Input::new();
+    input.set_value("Hello\nWorld\t!");
+    // Newline and tab should be stripped
+    assert!(!input.get_value().contains('\n'));
+    assert!(!input.get_value().contains('\t'));
+    assert!(input.get_value().contains("Hello"));
+    assert!(input.get_value().contains("World"));
+}
+
+// =============================================================================
+// DataGrid Filter + Selection Interaction
+// =============================================================================
+
+#[test]
+fn test_datagrid_navigate_after_filter() {
+    use revue::widget::datagrid::{DataGrid, GridColumn, GridRow};
+
+    let mut grid = DataGrid::new()
+        .column(GridColumn::new("name", "Name"))
+        .row(GridRow::new().cell("name", "Alpha"))
+        .row(GridRow::new().cell("name", "Beta"))
+        .row(GridRow::new().cell("name", "Gamma"));
+
+    grid.select_next();
+    grid.select_next();
+    assert_eq!(grid.selected_row, 2);
+
+    grid.set_filter("a"); // matches Alpha, Beta, Gamma (all have 'a')
+    assert_eq!(grid.selected_row, 0); // reset
+    assert!(grid.filtered_count() > 0);
+}
+
+// =============================================================================
+// Rendering with Zero/Tiny Areas
+// =============================================================================
+
+#[test]
+fn test_select_render_1x1() {
+    use revue::layout::Rect;
+    use revue::render::Buffer;
+    use revue::widget::traits::{RenderContext, View};
+
+    let mut buffer = Buffer::new(1, 1);
+    let area = Rect::new(0, 0, 1, 1);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+
+    let s = select().options(vec!["Test"]);
+    s.render(&mut ctx); // should not panic
+}
+
+#[test]
+fn test_textarea_render_0x0() {
+    use revue::layout::Rect;
+    use revue::render::Buffer;
+    use revue::widget::traits::{RenderContext, View};
+
+    let mut buffer = Buffer::new(10, 10);
+    let area = Rect::new(0, 0, 0, 0);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+
+    let ta = textarea().focused(true).content("Hello");
+    ta.render(&mut ctx); // should not panic
+}


### PR DESCRIPTION
## Summary

### New Tests (20)
| Category | Tests | Coverage |
|----------|-------|----------|
| Focus guard | 5 | Only focused widget processes keys (Input, TextArea, Select) |
| Focus loss | 1 | Select auto-closes dropdown + clears query on focus loss |
| Select edge cases | 4 | selected before options, options replace, get_value alias, empty |
| TextArea edge cases | 4 | editor preset, empty ops, rapid undo/redo, full backspace |
| Input edge cases | 3 | control char rejection, set_value stripping, Combobox get_value |
| DataGrid | 1 | Filter resets selection then navigate |
| Rendering | 2 | 1x1 and 0x0 area without panic |

### API Fixes
- Add `Input::get_value()` getter — `value` field was `pub(super)`, external users couldn't read it
- Add focused guard to `Select::handle_key()` (pub method) — was only on `Interactive::handle_key()`