### PR TITLE
fix: resolve runtime bugs, unicode rendering, and usability issues across 45 files

### DIFF
--- a/src/state/reactive/tracker.rs
+++ b/src/state/reactive/tracker.rs
@@ -259,9 +259,16 @@ pub fn notify_dependents(signal_id: SignalId) {
         new_depth
     });
 
+    // Guard ensures depth is decremented even if a callback panics
+    struct DepthGuard;
+    impl Drop for DepthGuard {
+        fn drop(&mut self) {
+            NOTIFY_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+        }
+    }
+    let _guard = DepthGuard;
+
     if depth > MAX_NOTIFY_DEPTH {
-        // Decrement before panicking to keep state consistent for any recovery
-        NOTIFY_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
         panic!(
             "Maximum reactive update depth ({}) exceeded. \
              This usually indicates a circular dependency in your reactive graph.",
@@ -286,9 +293,6 @@ pub fn notify_dependents(signal_id: SignalId) {
     for callback in callbacks {
         callback();
     }
-
-    // Decrement depth after all callbacks complete
-    NOTIFY_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
 }
 
 /// Dispose a subscriber (called when effect is dropped)

--- a/src/utils/textbuffer/mod.rs
+++ b/src/utils/textbuffer/mod.rs
@@ -130,6 +130,9 @@ impl TextBuffer {
 
     /// Get substring by character range
     pub fn substring(&self, start: usize, end: usize) -> &str {
+        if start >= end {
+            return "";
+        }
         let start_byte = self.char_to_byte(start);
         let end_byte = self.char_to_byte(end);
         &self.content[start_byte..end_byte]

--- a/src/widget/command_palette/view.rs
+++ b/src/widget/command_palette/view.rs
@@ -1,5 +1,6 @@
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::utils::{char_width, display_width};
 use crate::widget::theme::{DARK_GRAY, DISABLED_FG, SUBTLE_GRAY};
 use crate::widget::traits::RenderContext;
 use crate::widget::View;
@@ -65,15 +66,18 @@ impl View for CommandPalette {
             ctx.set(x, current_y, left);
 
             let title_x = x + 2;
-            for (i, ch) in title.chars().enumerate() {
-                if title_x + i as u16 >= x + width - 2 {
+            let mut dx: u16 = 0;
+            for ch in title.chars() {
+                let cw = char_width(ch) as u16;
+                if title_x + dx >= x + width - 2 {
                     break;
                 }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(Color::CYAN);
                 cell.bg = Some(self.bg_color);
                 cell.modifier |= Modifier::BOLD;
-                ctx.set(title_x + i as u16, current_y, cell);
+                ctx.set(title_x + dx, current_y, cell);
+                dx += cw;
             }
 
             let mut right = Cell::new(border_chars[5]);
@@ -105,19 +109,22 @@ impl View for CommandPalette {
             Color::WHITE
         };
 
-        for (i, ch) in display_text.chars().enumerate() {
-            if input_x + i as u16 >= x + width - 2 {
+        let mut dx: u16 = 0;
+        for ch in display_text.chars() {
+            let cw = char_width(ch) as u16;
+            if input_x + dx >= x + width - 2 {
                 break;
             }
             let mut cell = Cell::new(ch);
             cell.fg = Some(text_color);
             cell.bg = Some(self.bg_color);
-            ctx.set(input_x + i as u16, current_y, cell);
+            ctx.set(input_x + dx, current_y, cell);
+            dx += cw;
         }
 
         // Cursor
         if !self.query.is_empty() || display_text == &self.placeholder {
-            let cursor_x = input_x + self.query.len() as u16;
+            let cursor_x = input_x + display_width(&self.query) as u16;
             if cursor_x < x + width - 2 {
                 let mut cursor = Cell::new('▏');
                 cursor.fg = Some(Color::WHITE);
@@ -216,12 +223,15 @@ impl View for CommandPalette {
             // Shortcut (right-aligned)
             if self.show_shortcuts {
                 if let Some(ref shortcut) = cmd.shortcut {
-                    let shortcut_x = x + width - 2 - shortcut.len() as u16;
-                    for (i, ch) in shortcut.chars().enumerate() {
+                    let shortcut_x = x + width - 2 - display_width(shortcut) as u16;
+                    let mut dx: u16 = 0;
+                    for ch in shortcut.chars() {
+                        let cw = char_width(ch) as u16;
                         let mut cell = Cell::new(ch);
                         cell.fg = Some(SUBTLE_GRAY);
                         cell.bg = Some(row_bg);
-                        ctx.set(shortcut_x + i as u16, item_y, cell);
+                        ctx.set(shortcut_x + dx, item_y, cell);
+                        dx += cw;
                     }
                 }
             }
@@ -266,12 +276,15 @@ impl View for CommandPalette {
 
         // Results count
         let count_str = format!("{}/{}", self.filtered.len(), self.commands.len());
-        let count_x = x + width - 2 - count_str.len() as u16;
-        for (i, ch) in count_str.chars().enumerate() {
+        let count_x = x + width - 2 - display_width(&count_str) as u16;
+        let mut dx: u16 = 0;
+        for ch in count_str.chars() {
+            let cw = char_width(ch) as u16;
             let mut cell = Cell::new(ch);
             cell.fg = Some(DARK_GRAY);
             cell.bg = Some(self.bg_color);
-            ctx.set(count_x + i as u16, bottom_y, cell);
+            ctx.set(count_x + dx, bottom_y, cell);
+            dx += cw;
         }
     }
 }

--- a/src/widget/data/calendar/render.rs
+++ b/src/widget/data/calendar/render.rs
@@ -145,7 +145,8 @@ impl<'a> CalendarRender<'a> {
             "December",
         ];
         let header = format!("{} {}", month_names[(self.month - 1) as usize], self.year);
-        let header_x = start_x + week_num_offset + (20u16.saturating_sub(display_width(&header) as u16)) / 2;
+        let header_x =
+            start_x + week_num_offset + (20u16.saturating_sub(display_width(&header) as u16)) / 2;
 
         let mut dx: u16 = 0;
         for ch in header.chars() {

--- a/src/widget/data/calendar/render.rs
+++ b/src/widget/data/calendar/render.rs
@@ -3,6 +3,7 @@
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::utils::border::render_border;
+use crate::utils::{char_width, display_width};
 use crate::widget::traits::RenderContext;
 
 use super::types::{DateMarker, FirstDayOfWeek};
@@ -144,14 +145,17 @@ impl<'a> CalendarRender<'a> {
             "December",
         ];
         let header = format!("{} {}", month_names[(self.month - 1) as usize], self.year);
-        let header_x = start_x + week_num_offset + (20 - header.len() as u16) / 2;
+        let header_x = start_x + week_num_offset + (20u16.saturating_sub(display_width(&header) as u16)) / 2;
 
-        for (i, ch) in header.chars().enumerate() {
+        let mut dx: u16 = 0;
+        for ch in header.chars() {
+            let cw = char_width(ch) as u16;
             let mut cell = Cell::new(ch);
             cell.fg = Some(self.header_fg);
             cell.bg = self.header_bg;
             cell.modifier |= Modifier::BOLD;
-            ctx.set(header_x + i as u16, start_y, cell);
+            ctx.set(header_x + dx, start_y, cell);
+            dx += cw;
         }
 
         // Navigation arrows

--- a/src/widget/data/chart/barchart.rs
+++ b/src/widget/data/chart/barchart.rs
@@ -4,6 +4,7 @@
 
 use crate::render::Cell;
 use crate::style::Color;
+use crate::utils::{char_width, truncate_to_width};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -235,10 +236,12 @@ impl BarChart {
                         )
                     };
 
-                    for (i, ch) in label.chars().enumerate() {
-                        if (i as u16) < area.width {
-                            ctx.set(i as u16, y, Cell::new(ch));
+                    let mut dx: u16 = 0;
+                    for ch in label.chars() {
+                        if dx < area.width {
+                            ctx.set(dx, y, Cell::new(ch));
                         }
+                        dx += char_width(ch) as u16;
                     }
                 }
 
@@ -256,10 +259,12 @@ impl BarChart {
                 if row == 0 && self.show_values {
                     let value_str = format!(" {:.1}", bar.value);
                     let value_x = bar_start + bar_length;
-                    for (i, ch) in value_str.chars().enumerate() {
-                        if value_x + (i as u16) < area.width {
-                            ctx.set(value_x + (i as u16), y, Cell::new(ch));
+                    let mut dx: u16 = 0;
+                    for ch in value_str.chars() {
+                        if value_x + dx < area.width {
+                            ctx.set(value_x + dx, y, Cell::new(ch));
                         }
+                        dx += char_width(ch) as u16;
                     }
                 }
             }
@@ -315,21 +320,25 @@ impl BarChart {
             if self.show_values && bar_area_height > 0 {
                 let value_str = format!("{:.0}", bar.value);
                 let value_y = bar_area_height - bar_height.saturating_sub(1).min(bar_area_height);
-                for (i, ch) in value_str.chars().enumerate() {
-                    if x + (i as u16) < area.width && value_y > 0 {
-                        ctx.set(x + (i as u16), value_y - 1, Cell::new(ch));
+                let mut dx: u16 = 0;
+                for ch in value_str.chars() {
+                    if x + dx < area.width && value_y > 0 {
+                        ctx.set(x + dx, value_y - 1, Cell::new(ch));
                     }
+                    dx += char_width(ch) as u16;
                 }
             }
 
             // Draw label below
             if label_height > 0 {
                 let label_y = area.height - 1;
-                let label: String = bar.label.chars().take(self.bar_width as usize).collect();
-                for (i, ch) in label.chars().enumerate() {
-                    if x + (i as u16) < area.width {
-                        ctx.set(x + (i as u16), label_y, Cell::new(ch));
+                let label = truncate_to_width(&bar.label, self.bar_width as usize);
+                let mut dx: u16 = 0;
+                for ch in label.chars() {
+                    if x + dx < area.width {
+                        ctx.set(x + dx, label_y, Cell::new(ch));
                     }
+                    dx += char_width(ch) as u16;
                 }
             }
 

--- a/src/widget/data/chart/boxplot/render.rs
+++ b/src/widget/data/chart/boxplot/render.rs
@@ -5,6 +5,7 @@ use super::types::WhiskerStyle;
 use crate::layout::Rect;
 use crate::render::Cell;
 use crate::style::Color;
+use crate::utils::{char_width, display_width, truncate_to_width};
 use crate::widget::traits::RenderContext;
 
 /// Box plot rendering state
@@ -231,13 +232,16 @@ impl<'a> BoxPlotRender<'a> {
             let label = value_axis.format_value(value);
             let y = area.y + 1 + (i as u16 * (area.height - 3) / 4);
 
-            for (j, ch) in label.chars().take(y_label_width as usize - 1).enumerate() {
-                let x = area.x + j as u16;
+            let label_truncated = truncate_to_width(&label, y_label_width as usize - 1);
+            let mut dx: u16 = 0;
+            for ch in label_truncated.chars() {
+                let x = area.x + dx;
                 if x < area.x + y_label_width && y < area.y + area.height {
                     let mut cell = Cell::new(ch);
                     cell.fg = Some(value_axis.color);
                     ctx.set(x, y, cell);
                 }
+                dx += char_width(ch) as u16;
             }
         }
 
@@ -249,15 +253,17 @@ impl<'a> BoxPlotRender<'a> {
         for (i, group) in self.groups.iter().enumerate() {
             let x = area.x + y_label_width + (i as u16 * group_width) + group_width / 2;
             let y = area.y + area.height - 1;
-            let label_start = x.saturating_sub(group.label.len() as u16 / 2);
+            let label_start = x.saturating_sub(display_width(&group.label) as u16 / 2);
 
-            for (j, ch) in group.label.chars().enumerate() {
-                let label_x = label_start + j as u16;
+            let mut dx: u16 = 0;
+            for ch in group.label.chars() {
+                let label_x = label_start + dx;
                 if label_x >= area.x + y_label_width && label_x < area.x + area.width {
                     let mut cell = Cell::new(ch);
                     cell.fg = Some(category_axis.color);
                     ctx.set(label_x, y, cell);
                 }
+                dx += char_width(ch) as u16;
             }
         }
     }

--- a/src/widget/data/chart/boxplot/types.rs
+++ b/src/widget/data/chart/boxplot/types.rs
@@ -43,7 +43,7 @@ impl BoxStats {
             return None;
         }
 
-        valid.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        valid.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
         let n = valid.len();
         let min = valid[0];

--- a/src/widget/data/chart/chart_render.rs
+++ b/src/widget/data/chart/chart_render.rs
@@ -9,6 +9,7 @@ use super::chart_common::{Axis, ChartGrid, Legend, LegendPosition};
 use crate::layout::Rect;
 use crate::render::Cell;
 use crate::style::Color;
+use crate::utils::{char_width, display_width, truncate_to_width};
 use crate::widget::theme::DISABLED_FG;
 use crate::widget::traits::RenderContext;
 
@@ -25,14 +26,16 @@ pub fn render_title(ctx: &mut RenderContext, area: Rect, title: Option<&str>, co
         return 0;
     };
 
-    let title_x = area.x + (area.width.saturating_sub(title.len() as u16)) / 2;
-    for (i, ch) in title.chars().enumerate() {
-        let x = title_x + i as u16;
+    let title_x = area.x + (area.width.saturating_sub(display_width(title) as u16)) / 2;
+    let mut dx: u16 = 0;
+    for ch in title.chars() {
+        let x = title_x + dx;
         if x < area.x + area.width {
             let mut cell = Cell::new(ch);
             cell.fg = Some(color);
             ctx.set(x, area.y, cell);
         }
+        dx += char_width(ch) as u16;
     }
     1
 }
@@ -108,13 +111,16 @@ pub fn render_y_axis_labels(
         let label = axis.format_value(value);
         let y = area.y + 1 + (i as u16 * (area.height - 2) / axis.ticks as u16);
 
-        for (j, ch) in label.chars().take(label_width as usize).enumerate() {
-            let x = area.x + j as u16;
+        let label_truncated = truncate_to_width(&label, label_width as usize);
+        let mut dx: u16 = 0;
+        for ch in label_truncated.chars() {
+            let x = area.x + dx;
             if x < area.x + label_width && y < area.y + area.height {
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(axis.color);
                 ctx.set(x, y, cell);
             }
+            dx += char_width(ch) as u16;
         }
     }
 }
@@ -137,13 +143,16 @@ pub fn render_x_axis_labels(
         let label = axis.format_value(value);
         let x = area.x + x_offset + (i as u16 * (area.width - x_offset) / axis.ticks as u16);
 
-        for (j, ch) in label.chars().take(6).enumerate() {
-            let label_x = x + j as u16;
+        let label_truncated = truncate_to_width(&label, 6);
+        let mut dx: u16 = 0;
+        for ch in label_truncated.chars() {
+            let label_x = x + dx;
             if label_x < area.x + area.width && label_y >= y_offset {
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(axis.color);
                 ctx.set(label_x, label_y, cell);
             }
+            dx += char_width(ch) as u16;
         }
     }
 }
@@ -163,15 +172,17 @@ pub fn render_axis_title(
     };
 
     if is_x_axis {
-        let title_x = area.x + (area.width - title.len() as u16) / 2;
+        let title_x = area.x + (area.width.saturating_sub(display_width(title) as u16)) / 2;
         let title_y = area.y + area.height - 1;
-        for (i, ch) in title.chars().enumerate() {
-            let x = title_x + i as u16;
+        let mut dx: u16 = 0;
+        for ch in title.chars() {
+            let x = title_x + dx;
             if x < area.x + area.width {
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(color);
                 ctx.set(x, title_y, cell);
             }
+            dx += char_width(ch) as u16;
         }
     }
     // Y axis title rendering would go here (rotated text, not commonly needed)
@@ -294,13 +305,15 @@ pub fn render_legend(
         }
 
         // Label
-        for (j, ch) in item.label.chars().enumerate() {
-            let x = legend_x + 3 + j as u16;
+        let mut dx: u16 = 0;
+        for ch in item.label.chars() {
+            let x = legend_x + 3 + dx;
             if x < area.x + area.width - 1 && x < legend_x + legend_width - 1 {
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(Color::WHITE);
                 ctx.set(x, y, cell);
             }
+            dx += char_width(ch) as u16;
         }
     }
 }

--- a/src/widget/data/chart/helper.rs
+++ b/src/widget/data/chart/helper.rs
@@ -5,6 +5,7 @@ use super::types::{ChartType, LineStyle, Series};
 use crate::layout::Rect;
 use crate::render::Cell;
 use crate::style::Color;
+use crate::utils::{char_width, display_width};
 use crate::widget::theme::DARK_GRAY;
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
@@ -457,13 +458,15 @@ impl View for Chart {
 
         // Draw title
         if let Some(ref title) = self.title {
-            let title_x = (area.width.saturating_sub(title.len() as u16)) / 2;
+            let title_x = (area.width.saturating_sub(display_width(title) as u16)) / 2;
             let title_y = if has_border { 1u16 } else { 0 };
-            for (i, ch) in title.chars().enumerate() {
+            let mut dx: u16 = 0;
+            for ch in title.chars() {
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(Color::WHITE);
                 cell.modifier |= crate::render::Modifier::BOLD;
-                ctx.set(title_x + i as u16, title_y, cell);
+                ctx.set(title_x + dx, title_y, cell);
+                dx += char_width(ch) as u16;
             }
         }
 
@@ -480,11 +483,13 @@ impl View for Chart {
             let y = inner_y + inner_h - 1 - ((t * (inner_h as f64 - 1.0)) as u16);
 
             // Right-align label
-            let label_start = y_label_x + y_label_width.saturating_sub(label.len() as u16 + 1);
-            for (j, ch) in label.chars().enumerate() {
+            let label_start = y_label_x + y_label_width.saturating_sub(display_width(&label) as u16 + 1);
+            let mut dx: u16 = 0;
+            for ch in label.chars() {
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(self.y_axis.color);
-                ctx.set(label_start + j as u16, y, cell);
+                ctx.set(label_start + dx, y, cell);
+                dx += char_width(ch) as u16;
             }
 
             // Draw grid line
@@ -506,14 +511,16 @@ impl View for Chart {
             let x = inner_x + (t * (inner_w as f64 - 1.0)) as u16;
 
             // Center label
-            let label_start = x.saturating_sub(label.len() as u16 / 2);
-            for (j, ch) in label.chars().enumerate() {
-                let px = label_start + j as u16;
+            let label_start = x.saturating_sub(display_width(&label) as u16 / 2);
+            let mut dx: u16 = 0;
+            for ch in label.chars() {
+                let px = label_start + dx;
                 if px < area.width {
                     let mut cell = Cell::new(ch);
                     cell.fg = Some(self.x_axis.color);
                     ctx.set(px, x_label_y, cell);
                 }
+                dx += char_width(ch) as u16;
             }
 
             // Draw grid line
@@ -528,8 +535,9 @@ impl View for Chart {
 
         // Draw axis titles
         if let Some(ref title) = self.y_axis.title {
-            // Draw vertically on the left
-            let y_start = inner_y + (inner_h.saturating_sub(title.len() as u16)) / 2;
+            // Draw vertically on the left (one char per row, so char count governs height)
+            let char_count = title.chars().count() as u16;
+            let y_start = inner_y + (inner_h.saturating_sub(char_count)) / 2;
             for (i, ch) in title.chars().enumerate() {
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(self.y_axis.color);
@@ -538,13 +546,15 @@ impl View for Chart {
         }
 
         if let Some(ref title) = self.x_axis.title {
-            let x_start = inner_x + (inner_w.saturating_sub(title.len() as u16)) / 2;
+            let x_start = inner_x + (inner_w.saturating_sub(display_width(title) as u16)) / 2;
             let y = x_label_y + 1;
             if y < area.height {
-                for (i, ch) in title.chars().enumerate() {
+                let mut dx: u16 = 0;
+                for ch in title.chars() {
                     let mut cell = Cell::new(ch);
                     cell.fg = Some(self.x_axis.color);
-                    ctx.set(x_start + i as u16, y, cell);
+                    ctx.set(x_start + dx, y, cell);
+                    dx += char_width(ch) as u16;
                 }
             }
         }
@@ -740,14 +750,16 @@ impl View for Chart {
                 ctx.set(legend_x + 1, y, indicator);
 
                 // Series name
-                for (j, ch) in series.name.chars().enumerate() {
-                    let x = legend_x + 3 + j as u16;
+                let mut dx: u16 = 0;
+                for ch in series.name.chars() {
+                    let x = legend_x + 3 + dx;
                     if x < legend_x + legend_width - 1 {
                         let mut cell = Cell::new(ch);
                         cell.fg = Some(Color::WHITE);
                         cell.bg = self.bg_color.or(Some(Color::rgb(20, 20, 20)));
                         ctx.set(x, y, cell);
                     }
+                    dx += char_width(ch) as u16;
                 }
             }
         }

--- a/src/widget/data/chart/helper.rs
+++ b/src/widget/data/chart/helper.rs
@@ -483,7 +483,8 @@ impl View for Chart {
             let y = inner_y + inner_h - 1 - ((t * (inner_h as f64 - 1.0)) as u16);
 
             // Right-align label
-            let label_start = y_label_x + y_label_width.saturating_sub(display_width(&label) as u16 + 1);
+            let label_start =
+                y_label_x + y_label_width.saturating_sub(display_width(&label) as u16 + 1);
             let mut dx: u16 = 0;
             for ch in label.chars() {
                 let mut cell = Cell::new(ch);

--- a/src/widget/data/chart/histogram/mod.rs
+++ b/src/widget/data/chart/histogram/mod.rs
@@ -8,6 +8,7 @@ use super::chart_stats::{self, mean, median};
 use crate::layout::Rect;
 use crate::render::Cell;
 use crate::style::Color;
+use crate::utils::{char_width, truncate_to_width};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -362,13 +363,16 @@ impl Histogram {
             };
             let y = area.y + 1 + (i as u16 * (area.height - 3) / 4);
 
-            for (j, ch) in label.chars().take(y_label_width as usize - 1).enumerate() {
-                let x = area.x + j as u16;
+            let label_truncated = truncate_to_width(&label, y_label_width as usize - 1);
+            let mut dx: u16 = 0;
+            for ch in label_truncated.chars() {
+                let x = area.x + dx;
                 if x < area.x + y_label_width && y < area.y + area.height {
                     let mut cell = Cell::new(ch);
                     cell.fg = Some(self.y_axis.color);
                     ctx.set(x, y, cell);
                 }
+                dx += char_width(ch) as u16;
             }
         }
 
@@ -380,13 +384,16 @@ impl Histogram {
             let x = area.x + y_label_width + (i as u16 * chart_width / 4);
             let y = area.y + area.height - 1;
 
-            for (j, ch) in label.chars().take(6).enumerate() {
-                let label_x = x + j as u16;
+            let label_truncated = truncate_to_width(&label, 6);
+            let mut dx: u16 = 0;
+            for ch in label_truncated.chars() {
+                let label_x = x + dx;
                 if label_x < area.x + area.width {
                     let mut cell = Cell::new(ch);
                     cell.fg = Some(self.x_axis.color);
                     ctx.set(label_x, y, cell);
                 }
+                dx += char_width(ch) as u16;
             }
         }
     }

--- a/src/widget/data/chart/timeseries/view.rs
+++ b/src/widget/data/chart/timeseries/view.rs
@@ -3,6 +3,7 @@
 use super::types::{TimeLineStyle, TimeSeriesData};
 use super::TimeSeries;
 use crate::render::Cell;
+use crate::utils::{char_width, display_width};
 use crate::widget::traits::{RenderContext, View};
 
 impl View for TimeSeries {
@@ -29,15 +30,17 @@ impl View for TimeSeries {
 
         // Title
         if let Some(ref title) = self.title {
-            let title_x = (area.width.saturating_sub(title.len() as u16)) / 2;
-            for (i, ch) in title.chars().enumerate() {
-                let x = title_x + i as u16;
+            let title_x = (area.width.saturating_sub(display_width(title) as u16)) / 2;
+            let mut dx: u16 = 0;
+            for ch in title.chars() {
+                let x = title_x + dx;
                 if x < area.width {
                     let mut cell = Cell::new(ch);
                     cell.fg = Some(crate::style::Color::WHITE);
                     cell.bg = self.bg_color;
                     ctx.set(x, current_y, cell);
                 }
+                dx += char_width(ch) as u16;
             }
             current_y += 1;
         }
@@ -112,15 +115,17 @@ impl View for TimeSeries {
                 } else {
                     format!("{:.2}", val)
                 };
-                let label_x = y_label_width.saturating_sub(label.len() as u16 + 1);
-                for (j, ch) in label.chars().enumerate() {
-                    let x = label_x + j as u16;
+                let label_x = y_label_width.saturating_sub(display_width(&label) as u16 + 1);
+                let mut dx: u16 = 0;
+                for ch in label.chars() {
+                    let x = label_x + dx;
                     if x < area.width {
                         let mut cell = Cell::new(ch);
                         cell.fg = Some(crate::style::Color::WHITE);
                         cell.bg = self.bg_color;
                         ctx.set(x, y, cell);
                     }
+                    dx += char_width(ch) as u16;
                 }
             }
         }
@@ -148,15 +153,17 @@ impl View for TimeSeries {
                 }
 
                 if !marker.label.is_empty() {
-                    let label_x = x.saturating_sub(marker.label.len() as u16 / 2);
-                    for (j, ch) in marker.label.chars().enumerate() {
-                        let lx = label_x + j as u16;
+                    let label_x = x.saturating_sub(display_width(&marker.label) as u16 / 2);
+                    let mut dx: u16 = 0;
+                    for ch in marker.label.chars() {
+                        let lx = label_x + dx;
                         if lx < area.width {
                             let mut cell = Cell::new(ch);
                             cell.fg = Some(marker.color);
                             cell.bg = self.bg_color;
                             ctx.set(lx, plot_y + plot_height + 1, cell);
                         }
+                        dx += char_width(ch) as u16;
                     }
                 }
             }
@@ -185,15 +192,17 @@ impl View for TimeSeries {
                 let ts = time_min + (ratio * time_range as f64) as u64;
                 let label = self.format_time(ts, time_range);
                 let x = plot_x + (ratio * (plot_width - 1) as f64) as u16;
-                let label_x = x.saturating_sub(label.len() as u16 / 2);
-                for (j, ch) in label.chars().enumerate() {
-                    let lx = label_x + j as u16;
+                let label_x = x.saturating_sub(display_width(&label) as u16 / 2);
+                let mut dx: u16 = 0;
+                for ch in label.chars() {
+                    let lx = label_x + dx;
                     if lx < area.width {
                         let mut cell = Cell::new(ch);
                         cell.fg = Some(crate::style::Color::WHITE);
                         cell.bg = self.bg_color;
                         ctx.set(lx, x_label_y, cell);
                     }
+                    dx += char_width(ch) as u16;
                 }
             }
         }

--- a/src/widget/data/csv_viewer/core.rs
+++ b/src/widget/data/csv_viewer/core.rs
@@ -525,7 +525,7 @@ impl CsvViewer {
         for row in &self.data {
             for (col, cell) in row.iter().enumerate() {
                 if col < self.column_widths.len() {
-                    let width = cell.chars().count() as u16;
+                    let width = crate::utils::display_width(cell) as u16;
                     self.column_widths[col] = self.column_widths[col].max(width);
                 }
             }

--- a/src/widget/data/csv_viewer/parser.rs
+++ b/src/widget/data/csv_viewer/parser.rs
@@ -115,8 +115,8 @@ pub fn calculate_column_widths(data: &[Vec<String>]) -> Vec<u16> {
     for row in data {
         for (col, cell) in row.iter().enumerate() {
             if col < column_widths.len() {
-                // Clamp to u16::MAX to prevent truncation
-                let width = cell.chars().count().min(u16::MAX as usize) as u16;
+                // Use display width for proper CJK/emoji column sizing
+                let width = crate::utils::display_width(cell).min(u16::MAX as usize) as u16;
                 column_widths[col] = column_widths[col].max(width);
             }
         }

--- a/src/widget/data/csv_viewer/render.rs
+++ b/src/widget/data/csv_viewer/render.rs
@@ -2,6 +2,7 @@
 
 use crate::render::Cell;
 use crate::style::Color;
+use crate::utils::{char_width, truncate_to_width};
 use crate::widget::traits::RenderContext;
 
 /// Row number width calculation
@@ -92,30 +93,31 @@ pub fn render_csv_viewer(
                     ""
                 };
 
-                let display: String = format!("{}{}", cell_value, sort_indicator)
-                    .chars()
-                    .take(width)
-                    .collect();
+                let combined = format!("{}{}", cell_value, sort_indicator);
+                let display = truncate_to_width(&combined, width);
 
-                for (i, ch) in display.chars().enumerate() {
-                    if x + i as u16 >= area.width {
+                let mut dx: u16 = 0;
+                for ch in display.chars() {
+                    let cw = char_width(ch) as u16;
+                    if x + dx + cw > area.width {
                         break;
                     }
                     let mut cell = Cell::new(ch).bold();
                     cell.fg = header_fg;
                     cell.bg = header_bg;
-                    ctx.set(x + i as u16, y, cell);
+                    ctx.set(x + dx, y, cell);
+                    dx += cw;
                 }
 
                 // Fill remaining width
-                for i in display.chars().count()..width {
-                    if x + i as u16 >= area.width {
+                for i in dx..(width as u16) {
+                    if x + i >= area.width {
                         break;
                     }
                     let mut cell = Cell::new(' ');
                     cell.fg = header_fg;
                     cell.bg = header_bg;
-                    ctx.set(x + i as u16, y, cell);
+                    ctx.set(x + i, y, cell);
                 }
 
                 x += width as u16;
@@ -178,27 +180,30 @@ pub fn render_csv_viewer(
                     (fg, bg)
                 };
 
-                let display: String = cell_value.chars().take(width).collect();
+                let display = truncate_to_width(cell_value, width);
 
-                for (i, ch) in display.chars().enumerate() {
-                    if x + i as u16 >= area.width {
+                let mut dx: u16 = 0;
+                for ch in display.chars() {
+                    let cw = char_width(ch) as u16;
+                    if x + dx + cw > area.width {
                         break;
                     }
                     let mut cell = Cell::new(ch);
                     cell.fg = fg;
                     cell.bg = bg;
-                    ctx.set(x + i as u16, y, cell);
+                    ctx.set(x + dx, y, cell);
+                    dx += cw;
                 }
 
                 // Fill remaining width
-                for i in display.chars().count()..width {
-                    if x + i as u16 >= area.width {
+                for i in dx..(width as u16) {
+                    if x + i >= area.width {
                         break;
                     }
                     let mut cell = Cell::new(' ');
                     cell.fg = fg;
                     cell.bg = bg;
-                    ctx.set(x + i as u16, y, cell);
+                    ctx.set(x + i, y, cell);
                 }
 
                 x += width as u16;

--- a/src/widget/data/csv_viewer/view.rs
+++ b/src/widget/data/csv_viewer/view.rs
@@ -3,6 +3,7 @@
 use super::core::CsvViewer;
 use super::types::SortOrder;
 use crate::render::Cell;
+use crate::utils::{char_width, truncate_to_width};
 use crate::widget::traits::{RenderContext, View};
 
 impl View for CsvViewer {
@@ -59,30 +60,31 @@ impl View for CsvViewer {
                         ""
                     };
 
-                    let display: String = format!("{}{}", cell_value, sort_indicator)
-                        .chars()
-                        .take(width)
-                        .collect();
+                    let combined = format!("{}{}", cell_value, sort_indicator);
+                    let display = truncate_to_width(&combined, width);
 
-                    for (i, ch) in display.chars().enumerate() {
-                        if x + i as u16 >= area.width {
+                    let mut dx: u16 = 0;
+                    for ch in display.chars() {
+                        let cw = char_width(ch) as u16;
+                        if x + dx + cw > area.width {
                             break;
                         }
                         let mut cell = Cell::new(ch).bold();
                         cell.fg = self.header_fg;
                         cell.bg = self.header_bg;
-                        ctx.set(x + i as u16, y, cell);
+                        ctx.set(x + dx, y, cell);
+                        dx += cw;
                     }
 
                     // Fill remaining width
-                    for i in display.chars().count()..width {
-                        if x + i as u16 >= area.width {
+                    for i in dx..(width as u16) {
+                        if x + i >= area.width {
                             break;
                         }
                         let mut cell = Cell::new(' ');
                         cell.fg = self.header_fg;
                         cell.bg = self.header_bg;
-                        ctx.set(x + i as u16, y, cell);
+                        ctx.set(x + i, y, cell);
                     }
 
                     x += width as u16;
@@ -122,7 +124,9 @@ impl View for CsvViewer {
                     row_idx + 1,
                     width = (row_num_width - 1) as usize
                 );
-                for (i, ch) in num_str.chars().enumerate() {
+                let mut dx: u16 = 0;
+                for ch in num_str.chars() {
+                    let cw = char_width(ch) as u16;
                     let mut cell = Cell::new(ch);
                     cell.fg = self.row_number_fg;
                     cell.bg = if is_selected_row {
@@ -130,7 +134,8 @@ impl View for CsvViewer {
                     } else {
                         self.bg
                     };
-                    ctx.set(i as u16, y, cell);
+                    ctx.set(dx, y, cell);
+                    dx += cw;
                 }
             }
 
@@ -150,27 +155,30 @@ impl View for CsvViewer {
                         (self.fg, self.bg)
                     };
 
-                    let display: String = cell_value.chars().take(width).collect();
+                    let display = truncate_to_width(cell_value, width);
 
-                    for (i, ch) in display.chars().enumerate() {
-                        if x + i as u16 >= area.width {
+                    let mut dx: u16 = 0;
+                    for ch in display.chars() {
+                        let cw = char_width(ch) as u16;
+                        if x + dx + cw > area.width {
                             break;
                         }
                         let mut cell = Cell::new(ch);
                         cell.fg = fg;
                         cell.bg = bg;
-                        ctx.set(x + i as u16, y, cell);
+                        ctx.set(x + dx, y, cell);
+                        dx += cw;
                     }
 
                     // Fill remaining width
-                    for i in display.chars().count()..width {
-                        if x + i as u16 >= area.width {
+                    for i in dx..(width as u16) {
+                        if x + i >= area.width {
                             break;
                         }
                         let mut cell = Cell::new(' ');
                         cell.fg = fg;
                         cell.bg = bg;
-                        ctx.set(x + i as u16, y, cell);
+                        ctx.set(x + i, y, cell);
                     }
 
                     x += width as u16;

--- a/src/widget/data/datagrid/core.rs
+++ b/src/widget/data/datagrid/core.rs
@@ -154,6 +154,9 @@ pub struct DataGrid {
     /// Show aggregation footer
     pub show_footer: bool,
 
+    /// Last known viewport height (rows visible), updated during render
+    pub(crate) last_viewport_height: std::cell::Cell<usize>,
+
     /// Widget props for CSS integration
     pub props: crate::widget::traits::WidgetProps,
 }
@@ -227,6 +230,7 @@ impl DataGrid {
             // Footer state
             footer_rows: Vec::new(),
             show_footer: false,
+            last_viewport_height: std::cell::Cell::new(10),
             props: crate::widget::traits::WidgetProps::new(),
         }
     }

--- a/src/widget/data/datagrid/editing.rs
+++ b/src/widget/data/datagrid/editing.rs
@@ -226,11 +226,13 @@ impl DataGrid {
                 true
             }
             Key::PageDown => {
-                self.page_down(10);
+                let page = self.last_viewport_height.get().max(1);
+                self.page_down(page);
                 true
             }
             Key::PageUp => {
-                self.page_up(10);
+                let page = self.last_viewport_height.get().max(1);
+                self.page_up(page);
                 true
             }
             Key::Home | Key::Char('g') => {

--- a/src/widget/data/datagrid/navigation.rs
+++ b/src/widget/data/datagrid/navigation.rs
@@ -123,8 +123,12 @@ impl DataGrid {
 
     /// Toggle row selection
     pub fn toggle_selection(&mut self) {
-        if self.options.multi_select && self.selected_row < self.rows.len() {
-            self.rows[self.selected_row].selected = !self.rows[self.selected_row].selected;
+        if self.options.multi_select {
+            if let Some(&actual_idx) = self.filtered_cache.get(self.selected_row) {
+                if actual_idx < self.rows.len() {
+                    self.rows[actual_idx].selected = !self.rows[actual_idx].selected;
+                }
+            }
         }
     }
 

--- a/src/widget/data/datagrid/render.rs
+++ b/src/widget/data/datagrid/render.rs
@@ -373,12 +373,8 @@ impl DataGrid {
         let dw = display_width(truncated) as u16;
         let start_x = match col.align {
             super::types::Alignment::Left => pos.x,
-            super::types::Alignment::Center => {
-                pos.x + (pos.width.saturating_sub(dw)) / 2
-            }
-            super::types::Alignment::Right => {
-                pos.x + pos.width.saturating_sub(dw + 1)
-            }
+            super::types::Alignment::Center => pos.x + (pos.width.saturating_sub(dw)) / 2,
+            super::types::Alignment::Right => pos.x + pos.width.saturating_sub(dw + 1),
         };
 
         let mut dx: u16 = 0;

--- a/src/widget/data/datagrid/render.rs
+++ b/src/widget/data/datagrid/render.rs
@@ -4,6 +4,7 @@ use super::core::{CellPos, CellState, DataGrid, RowRenderParams};
 use crate::layout::Rect;
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::utils::{char_width, display_width, truncate_to_width};
 use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY};
 use crate::widget::traits::{RenderContext, View};
 
@@ -59,6 +60,7 @@ impl View for DataGrid {
         let total_rows = self.filtered_count();
         let visible_height =
             (area.height - header_height) as usize / self.options.row_height.max(1) as usize;
+        self.last_viewport_height.set(visible_height);
 
         // Virtual scroll: calculate render range with overscan
         let (render_start, render_end) = if self.options.virtual_scroll {
@@ -232,7 +234,13 @@ impl DataGrid {
                 self.colors.header_fg
             };
 
-            for (j, ch) in title.chars().take(w as usize - 1).enumerate() {
+            let truncated = truncate_to_width(&title, w as usize - 1);
+            let mut dx: u16 = 0;
+            for ch in truncated.chars() {
+                let cw = char_width(ch) as u16;
+                if dx + cw > w - 1 {
+                    break;
+                }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(fg);
                 cell.bg = Some(bg);
@@ -241,7 +249,8 @@ impl DataGrid {
                 } else {
                     cell.modifier |= Modifier::DIM;
                 }
-                ctx.set(x + j as u16, y, cell);
+                ctx.set(x + dx, y, cell);
+                dx += cw;
             }
 
             // Draw separator with resize indicator
@@ -322,14 +331,15 @@ impl DataGrid {
 
     /// Render cell in edit mode with cursor
     fn render_edit_cell(&self, ctx: &mut RenderContext, x: u16, y: u16, width: u16, bg: Color) {
-        let display: String = self
-            .edit_state
-            .buffer
-            .chars()
-            .take(width as usize - 1)
-            .collect();
-        for (j, ch) in display.chars().enumerate() {
-            let is_cursor = j == self.edit_state.cursor;
+        let truncated = truncate_to_width(&self.edit_state.buffer, width as usize - 1);
+        let mut dx: u16 = 0;
+        let mut char_idx = 0;
+        for ch in truncated.chars() {
+            let cw = char_width(ch) as u16;
+            if dx + cw > width - 1 {
+                break;
+            }
+            let is_cursor = char_idx == self.edit_state.cursor;
             let mut cell = Cell::new(ch);
             cell.fg = Some(if is_cursor {
                 Color::BLACK
@@ -337,15 +347,15 @@ impl DataGrid {
                 Color::WHITE
             });
             cell.bg = Some(if is_cursor { Color::WHITE } else { bg });
-            ctx.set(x + j as u16, y, cell);
+            ctx.set(x + dx, y, cell);
+            dx += cw;
+            char_idx += 1;
         }
         // Draw cursor at end if needed
-        if self.edit_state.cursor >= display.chars().count()
-            && self.edit_state.cursor < width as usize
-        {
+        if self.edit_state.cursor >= char_idx && (dx as usize) < width as usize {
             let mut cursor_cell = Cell::new(' ');
             cursor_cell.bg = Some(Color::WHITE);
-            ctx.set(x + self.edit_state.cursor as u16, y, cursor_cell);
+            ctx.set(x + dx, y, cursor_cell);
         }
     }
 
@@ -359,18 +369,24 @@ impl DataGrid {
         row_bg: Color,
         is_selected: bool,
     ) {
-        let display: String = value.chars().take(pos.width as usize - 1).collect();
+        let truncated = truncate_to_width(value, pos.width as usize - 1);
+        let dw = display_width(truncated) as u16;
         let start_x = match col.align {
             super::types::Alignment::Left => pos.x,
             super::types::Alignment::Center => {
-                pos.x + (pos.width.saturating_sub(display.len() as u16)) / 2
+                pos.x + (pos.width.saturating_sub(dw)) / 2
             }
             super::types::Alignment::Right => {
-                pos.x + pos.width.saturating_sub(display.len() as u16 + 1)
+                pos.x + pos.width.saturating_sub(dw + 1)
             }
         };
 
-        for (j, ch) in display.chars().enumerate() {
+        let mut dx: u16 = 0;
+        for ch in truncated.chars() {
+            let cw = char_width(ch) as u16;
+            if dx + cw > pos.width {
+                break;
+            }
             let mut cell = Cell::new(ch);
             cell.fg = Some(if is_selected {
                 self.colors.selected_fg
@@ -378,7 +394,8 @@ impl DataGrid {
                 Color::WHITE
             });
             cell.bg = Some(row_bg);
-            ctx.set(start_x + j as u16, pos.y, cell);
+            ctx.set(start_x + dx, pos.y, cell);
+            dx += cw;
         }
     }
 

--- a/src/widget/data/log_viewer/view.rs
+++ b/src/widget/data/log_viewer/view.rs
@@ -7,6 +7,7 @@ use super::types::LogLevel;
 use crate::event::Key;
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::utils::{char_width, display_width, truncate_to_width};
 use crate::widget::theme::{DARK_GRAY, DISABLED_FG, SUBTLE_GRAY};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
@@ -673,13 +674,16 @@ impl View for LogViewer {
         if filtered.is_empty() {
             // Show empty message
             let msg = "No log entries";
-            let x = (area.width.saturating_sub(msg.len() as u16)) / 2;
+            let x = (area.width.saturating_sub(display_width(msg) as u16)) / 2;
             let y = area.height / 2;
-            for (i, ch) in msg.chars().enumerate() {
+            let mut dx: u16 = 0;
+            for ch in msg.chars() {
+                let cw = char_width(ch) as u16;
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(DISABLED_FG);
                 cell.bg = self.bg;
-                ctx.set(x + i as u16, y, cell);
+                ctx.set(x + dx, y, cell);
+                dx += cw;
             }
             return;
         }
@@ -752,14 +756,14 @@ impl View for LogViewer {
             // Draw timestamp
             if self.show_timestamps {
                 if let Some(ref ts) = entry.timestamp {
-                    let ts_display: String =
-                        ts.chars().take(timestamp_width as usize - 1).collect();
+                    let ts_display = truncate_to_width(ts, timestamp_width as usize - 1);
                     for ch in ts_display.chars() {
+                        let cw = char_width(ch) as u16;
                         let mut cell = Cell::new(ch);
                         cell.fg = Some(self.timestamp_fg);
                         cell.bg = row_bg;
                         ctx.set(x, y, cell);
-                        x += 1;
+                        x += cw;
                     }
                 }
                 x = line_num_width + bookmark_width + timestamp_width;
@@ -789,13 +793,14 @@ impl View for LogViewer {
             // Draw source
             if self.show_source {
                 if let Some(ref src) = entry.source {
-                    let src_display: String = src.chars().take(source_width as usize - 1).collect();
+                    let src_display = truncate_to_width(src, source_width as usize - 1);
                     for ch in src_display.chars() {
+                        let cw = char_width(ch) as u16;
                         let mut cell = Cell::new(ch);
                         cell.fg = Some(self.source_fg);
                         cell.bg = row_bg;
                         ctx.set(x, y, cell);
-                        x += 1;
+                        x += cw;
                     }
                 }
                 x = prefix_width;
@@ -809,12 +814,21 @@ impl View for LogViewer {
                 .collect();
 
             // Draw message with search highlighting
-            let msg_chars: Vec<char> = entry.message.chars().collect();
-            for (i, ch) in msg_chars.iter().enumerate().take(message_width as usize) {
-                // Check if this character is in a search match
-                let in_match = matches_for_entry.iter().any(|m| i >= m.start && i < m.end);
+            // Search match indices are byte offsets from the find() call in update_search
+            let mut col_dx: u16 = 0;
+            let mut byte_pos: usize = 0;
+            for ch in entry.message.chars() {
+                let cw = char_width(ch) as u16;
+                if col_dx + cw > message_width {
+                    break;
+                }
+                // Check if this character's byte range overlaps a search match
+                let ch_byte_len = ch.len_utf8();
+                let in_match = matches_for_entry
+                    .iter()
+                    .any(|m| byte_pos >= m.start && byte_pos < m.end);
 
-                let mut cell = Cell::new(*ch);
+                let mut cell = Cell::new(ch);
                 cell.fg = Some(if is_selected {
                     Color::WHITE
                 } else {
@@ -832,9 +846,11 @@ impl View for LogViewer {
                 if is_selected {
                     cell.modifier |= Modifier::BOLD;
                 }
-                ctx.set(x, y, cell);
-                x += 1;
+                ctx.set(x + col_dx, y, cell);
+                col_dx += cw;
+                byte_pos += ch_byte_len;
             }
+            let _ = col_dx; // message column is always last
         }
 
         // Draw scroll indicator
@@ -851,13 +867,17 @@ impl View for LogViewer {
         // Draw tail mode indicator
         if self.tail_mode {
             let indicator = "◉ TAIL";
-            let x = area.width - indicator.len() as u16 - 2;
+            let indicator_w = display_width(indicator) as u16;
+            let x = area.width.saturating_sub(indicator_w + 2);
             let y = 0u16;
-            for (i, ch) in indicator.chars().enumerate() {
+            let mut dx: u16 = 0;
+            for ch in indicator.chars() {
+                let cw = char_width(ch) as u16;
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(Color::GREEN);
                 cell.bg = self.bg;
-                ctx.set(x + i as u16, y, cell);
+                ctx.set(x + dx, y, cell);
+                dx += cw;
             }
         }
     }

--- a/src/widget/data/table.rs
+++ b/src/widget/data/table.rs
@@ -4,7 +4,7 @@ use std::cell::Cell as StdCell;
 
 use crate::render::Cell;
 use crate::style::Color;
-use crate::utils::Selection;
+use crate::utils::{char_width, truncate_to_width, Selection};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -443,24 +443,30 @@ impl Table {
 
         for (i, width) in widths.iter().enumerate() {
             let content = cells.get(i).map(|s| s.as_str()).unwrap_or("");
-            let truncated: String = content.chars().take(*width as usize).collect();
+            let truncated = truncate_to_width(content, *width as usize);
 
-            for (j, ch) in truncated.chars().enumerate() {
+            let mut dx: u16 = 0;
+            for ch in truncated.chars() {
+                let cw = char_width(ch) as u16;
+                if dx + cw > *width {
+                    break;
+                }
                 let mut cell = Cell::new(ch);
                 cell.fg = style.fg;
                 cell.bg = style.bg;
                 if style.bold {
                     cell.modifier |= crate::render::Modifier::BOLD;
                 }
-                ctx.set(cx + j as u16, y, cell);
+                ctx.set(cx + dx, y, cell);
+                dx += cw;
             }
 
             // Fill remaining space
-            for j in truncated.len()..(*width as usize) {
+            for j in dx..*width {
                 let mut cell = Cell::new(' ');
                 cell.fg = style.fg;
                 cell.bg = style.bg;
-                ctx.set(cx + j as u16, y, cell);
+                ctx.set(cx + j, y, cell);
             }
 
             cx += width;

--- a/src/widget/data/timeline.rs
+++ b/src/widget/data/timeline.rs
@@ -357,7 +357,9 @@ impl Timeline {
                     let mut dx: u16 = 0;
                     for ch in truncated.chars() {
                         let cw = char_width(ch) as u16;
-                        if dx + cw > timestamp_width - 1 { break; }
+                        if dx + cw > timestamp_width - 1 {
+                            break;
+                        }
                         let mut cell = Cell::new(ch);
                         cell.fg = Some(self.timestamp_color);
                         ctx.set(dx, y, cell);
@@ -409,7 +411,9 @@ impl Timeline {
             let mut dx: u16 = 0;
             for ch in title_truncated.chars() {
                 let cw = char_width(ch) as u16;
-                if dx + cw > content_width { break; }
+                if dx + cw > content_width {
+                    break;
+                }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(title_fg);
                 if is_selected {
@@ -437,7 +441,9 @@ impl Timeline {
                         let mut dx: u16 = 0;
                         for ch in desc_truncated.chars() {
                             let cw = char_width(ch) as u16;
-                            if dx + cw > content_width { break; }
+                            if dx + cw > content_width {
+                                break;
+                            }
                             let mut cell = Cell::new(ch);
                             cell.fg = Some(self.desc_color);
                             ctx.set(content_x + dx, y, cell);
@@ -502,7 +508,9 @@ impl Timeline {
             let mut dx: u16 = 0;
             for ch in title.chars() {
                 let cw = char_width(ch) as u16;
-                if dx + cw > event_width - 1 { break; }
+                if dx + cw > event_width - 1 {
+                    break;
+                }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(if is_selected { color } else { self.title_color });
                 ctx.set(title_x + dx, 0, cell);
@@ -517,7 +525,9 @@ impl Timeline {
                     let mut dx: u16 = 0;
                     for ch in ts_str.chars() {
                         let cw = char_width(ch) as u16;
-                        if dx + cw > event_width - 1 { break; }
+                        if dx + cw > event_width - 1 {
+                            break;
+                        }
                         let mut cell = Cell::new(ch);
                         cell.fg = Some(self.timestamp_color);
                         ctx.set(ts_x + dx, line_y + 1, cell);

--- a/src/widget/data/timeline.rs
+++ b/src/widget/data/timeline.rs
@@ -4,6 +4,7 @@
 
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::utils::{char_width, display_width, truncate_to_width};
 use crate::widget::theme::{DARK_GRAY, LIGHT_GRAY};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
@@ -352,10 +353,15 @@ impl Timeline {
             // Draw timestamp
             if self.show_timestamps {
                 if let Some(ref ts) = event.timestamp {
-                    for (j, ch) in ts.chars().take(timestamp_width as usize - 1).enumerate() {
+                    let truncated = truncate_to_width(ts, timestamp_width as usize - 1);
+                    let mut dx: u16 = 0;
+                    for ch in truncated.chars() {
+                        let cw = char_width(ch) as u16;
+                        if dx + cw > timestamp_width - 1 { break; }
                         let mut cell = Cell::new(ch);
                         cell.fg = Some(self.timestamp_color);
-                        ctx.set(j as u16, y, cell);
+                        ctx.set(dx, y, cell);
+                        dx += cw;
                     }
                 }
             }
@@ -399,13 +405,18 @@ impl Timeline {
 
             // Draw title
             let title_fg = if is_selected { color } else { self.title_color };
-            for (j, ch) in event.title.chars().take(content_width as usize).enumerate() {
+            let title_truncated = truncate_to_width(&event.title, content_width as usize);
+            let mut dx: u16 = 0;
+            for ch in title_truncated.chars() {
+                let cw = char_width(ch) as u16;
+                if dx + cw > content_width { break; }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(title_fg);
                 if is_selected {
                     cell.modifier |= Modifier::BOLD;
                 }
-                ctx.set(content_x + j as u16, y, cell);
+                ctx.set(content_x + dx, y, cell);
+                dx += cw;
             }
 
             y += 1;
@@ -422,10 +433,15 @@ impl Timeline {
                         }
 
                         // Draw description text
-                        for (j, ch) in desc.chars().take(content_width as usize).enumerate() {
+                        let desc_truncated = truncate_to_width(desc, content_width as usize);
+                        let mut dx: u16 = 0;
+                        for ch in desc_truncated.chars() {
+                            let cw = char_width(ch) as u16;
+                            if dx + cw > content_width { break; }
                             let mut cell = Cell::new(ch);
                             cell.fg = Some(self.desc_color);
-                            ctx.set(content_x + j as u16, y, cell);
+                            ctx.set(content_x + dx, y, cell);
+                            dx += cw;
                         }
 
                         y += 1;
@@ -481,23 +497,31 @@ impl Timeline {
             ctx.set(x + event_width / 2, line_y, icon_cell);
 
             // Draw title above
-            let title: String = event.title.chars().take(event_width as usize - 1).collect();
-            let title_x = x + (event_width - title.len() as u16) / 2;
-            for (j, ch) in title.chars().enumerate() {
+            let title = truncate_to_width(&event.title, event_width as usize - 1);
+            let title_x = x + (event_width.saturating_sub(display_width(title) as u16)) / 2;
+            let mut dx: u16 = 0;
+            for ch in title.chars() {
+                let cw = char_width(ch) as u16;
+                if dx + cw > event_width - 1 { break; }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(if is_selected { color } else { self.title_color });
-                ctx.set(title_x + j as u16, 0, cell);
+                ctx.set(title_x + dx, 0, cell);
+                dx += cw;
             }
 
             // Draw timestamp below
             if self.show_timestamps {
                 if let Some(ref ts) = event.timestamp {
-                    let ts_str: String = ts.chars().take(event_width as usize - 1).collect();
-                    let ts_x = x + (event_width - ts_str.len() as u16) / 2;
-                    for (j, ch) in ts_str.chars().enumerate() {
+                    let ts_str = truncate_to_width(ts, event_width as usize - 1);
+                    let ts_x = x + (event_width.saturating_sub(display_width(ts_str) as u16)) / 2;
+                    let mut dx: u16 = 0;
+                    for ch in ts_str.chars() {
+                        let cw = char_width(ch) as u16;
+                        if dx + cw > event_width - 1 { break; }
                         let mut cell = Cell::new(ch);
                         cell.fg = Some(self.timestamp_color);
-                        ctx.set(ts_x + j as u16, line_y + 1, cell);
+                        ctx.set(ts_x + dx, line_y + 1, cell);
+                        dx += cw;
                     }
                 }
             }

--- a/src/widget/datetime_picker/render.rs
+++ b/src/widget/datetime_picker/render.rs
@@ -2,6 +2,7 @@
 
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::utils::display_width;
 use crate::widget::data::calendar::{days_in_month, FirstDayOfWeek};
 use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY};
 use crate::widget::traits::RenderContext;
@@ -94,7 +95,7 @@ pub trait Rendering {
             super::helpers::month_name(self.date().month),
             self.date().year
         );
-        let header_x = x + (width.saturating_sub(header.len() as u16)) / 2;
+        let header_x = x + (width.saturating_sub(display_width(&header) as u16)) / 2;
         self.draw_text(ctx, header_x, y, &header, self.header_fg(), true);
 
         // Day headers

--- a/src/widget/developer/diff.rs
+++ b/src/widget/developer/diff.rs
@@ -5,6 +5,7 @@
 
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::utils::{char_width, truncate_to_width};
 use crate::widget::theme::DISABLED_FG;
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
@@ -405,18 +406,25 @@ impl DiffViewer {
             _ => None,
         };
 
-        for (i, ch) in content.chars().take(content_width).enumerate() {
+        let truncated = truncate_to_width(content, content_width);
+        let mut dx: u16 = 0;
+        for ch in truncated.chars() {
+            let cw = char_width(ch) as u16;
+            if dx + cw > content_width as u16 {
+                break;
+            }
             let mut cell = Cell::new(ch);
             cell.fg = fg;
             cell.bg = bg;
-            ctx.set(x + line_num_width + i as u16, y, cell);
+            ctx.set(x + line_num_width + dx, y, cell);
+            dx += cw;
         }
 
         // Fill remaining with background
-        for i in content.chars().count()..content_width {
+        for i in dx..(content_width as u16) {
             let mut cell = Cell::new(' ');
             cell.bg = bg;
-            ctx.set(x + line_num_width + i as u16, y, cell);
+            ctx.set(x + line_num_width + i, y, cell);
         }
     }
 
@@ -517,11 +525,18 @@ impl DiffViewer {
             } else {
                 &line.left
             };
-            for (j, ch) in content.chars().take(content_width).enumerate() {
+            let truncated = truncate_to_width(content, content_width);
+            let mut dx: u16 = 0;
+            for ch in truncated.chars() {
+                let cw = char_width(ch) as u16;
+                if dx + cw > content_width as u16 {
+                    break;
+                }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(fg);
                 cell.bg = Some(bg);
-                ctx.set(line_num_width + 1 + j as u16, y, cell);
+                ctx.set(line_num_width + 1 + dx, y, cell);
+                dx += cw;
             }
         }
     }

--- a/src/widget/display/empty_state.rs
+++ b/src/widget/display/empty_state.rs
@@ -25,6 +25,7 @@
 
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::utils::{char_width, display_width};
 use crate::widget::theme::{LIGHT_GRAY, PLACEHOLDER_FG};
 use crate::widget::traits::{RenderContext, View, WidgetProps, WidgetState};
 use crate::{impl_styled_view, impl_widget_builders};
@@ -267,16 +268,19 @@ impl EmptyState {
 
         // Title (centered, bold)
         if y < area.height {
-            let title_len = self.title.chars().count() as u16;
+            let title_len = display_width(&self.title) as u16;
             let title_x = area.width.saturating_sub(title_len) / 2;
-            for (i, ch) in self.title.chars().enumerate() {
-                if title_x + i as u16 >= area.width {
+            let mut dx: u16 = 0;
+            for ch in self.title.chars() {
+                let cw = char_width(ch) as u16;
+                if title_x + dx + cw > area.width {
                     break;
                 }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(Color::WHITE);
                 cell.modifier |= Modifier::BOLD;
-                ctx.set(title_x + i as u16, y, cell);
+                ctx.set(title_x + dx, y, cell);
+                dx += cw;
             }
             y += 1;
         }
@@ -284,15 +288,18 @@ impl EmptyState {
         // Description (centered, dimmed)
         if let Some(ref desc) = self.description {
             if y < area.height {
-                let desc_len = desc.chars().count() as u16;
+                let desc_len = display_width(desc) as u16;
                 let desc_x = area.width.saturating_sub(desc_len) / 2;
-                for (i, ch) in desc.chars().enumerate() {
-                    if desc_x + i as u16 >= area.width {
+                let mut dx: u16 = 0;
+                for ch in desc.chars() {
+                    let cw = char_width(ch) as u16;
+                    if desc_x + dx + cw > area.width {
                         break;
                     }
                     let mut cell = Cell::new(ch);
                     cell.fg = Some(LIGHT_GRAY);
-                    ctx.set(desc_x + i as u16, y, cell);
+                    ctx.set(desc_x + dx, y, cell);
+                    dx += cw;
                 }
                 y += 2;
             }
@@ -302,15 +309,18 @@ impl EmptyState {
         if let Some(ref action_text) = self.action {
             if y < area.height {
                 let btn_text = format!("[ {} ]", action_text);
-                let btn_len = btn_text.chars().count() as u16;
+                let btn_len = display_width(&btn_text) as u16;
                 let btn_x = area.width.saturating_sub(btn_len) / 2;
-                for (i, ch) in btn_text.chars().enumerate() {
-                    if btn_x + i as u16 >= area.width {
+                let mut dx: u16 = 0;
+                for ch in btn_text.chars() {
+                    let cw = char_width(ch) as u16;
+                    if btn_x + dx + cw > area.width {
                         break;
                     }
                     let mut cell = Cell::new(ch);
                     cell.fg = Some(accent);
-                    ctx.set(btn_x + i as u16, y, cell);
+                    ctx.set(btn_x + dx, y, cell);
+                    dx += cw;
                 }
             }
         }
@@ -331,14 +341,17 @@ impl EmptyState {
             x += 2;
         }
 
-        for (i, ch) in self.title.chars().enumerate() {
-            if x + i as u16 >= area.width {
+        let mut dx: u16 = 0;
+        for ch in self.title.chars() {
+            let cw = char_width(ch) as u16;
+            if x + dx + cw > area.width {
                 break;
             }
             let mut cell = Cell::new(ch);
             cell.fg = Some(Color::WHITE);
             cell.modifier |= Modifier::BOLD;
-            ctx.set(x + i as u16, y, cell);
+            ctx.set(x + dx, y, cell);
+            dx += cw;
         }
         y += 1;
 
@@ -346,13 +359,16 @@ impl EmptyState {
         if let Some(ref desc) = self.description {
             if y < area.height {
                 let desc_x: u16 = if self.show_icon { 2 } else { 0 };
-                for (i, ch) in desc.chars().enumerate() {
-                    if desc_x + i as u16 >= area.width {
+                let mut dx: u16 = 0;
+                for ch in desc.chars() {
+                    let cw = char_width(ch) as u16;
+                    if desc_x + dx + cw > area.width {
                         break;
                     }
                     let mut cell = Cell::new(ch);
                     cell.fg = Some(LIGHT_GRAY);
-                    ctx.set(desc_x + i as u16, y, cell);
+                    ctx.set(desc_x + dx, y, cell);
+                    dx += cw;
                 }
                 y += 1;
             }
@@ -363,13 +379,16 @@ impl EmptyState {
             if y < area.height {
                 let action_x: u16 = if self.show_icon { 2 } else { 0 };
                 let btn_text = format!("[{}]", action_text);
-                for (i, ch) in btn_text.chars().enumerate() {
-                    if action_x + i as u16 >= area.width {
+                let mut dx: u16 = 0;
+                for ch in btn_text.chars() {
+                    let cw = char_width(ch) as u16;
+                    if action_x + dx + cw > area.width {
                         break;
                     }
                     let mut cell = Cell::new(ch);
                     cell.fg = Some(accent);
-                    ctx.set(action_x + i as u16, y, cell);
+                    ctx.set(action_x + dx, y, cell);
+                    dx += cw;
                 }
             }
         }
@@ -390,13 +409,16 @@ impl EmptyState {
         }
 
         // Title
-        for (i, ch) in self.title.chars().enumerate() {
-            if x + i as u16 >= area.width {
+        let mut dx: u16 = 0;
+        for ch in self.title.chars() {
+            let cw = char_width(ch) as u16;
+            if x + dx + cw > area.width {
                 break;
             }
             let mut cell = Cell::new(ch);
             cell.fg = Some(LIGHT_GRAY);
-            ctx.set(x + i as u16, 0, cell);
+            ctx.set(x + dx, 0, cell);
+            dx += cw;
         }
     }
 }

--- a/src/widget/display/gauge.rs
+++ b/src/widget/display/gauge.rs
@@ -6,6 +6,7 @@
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::utils::color::contrast_color;
+use crate::utils::{char_width, display_width};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -328,10 +329,13 @@ impl Gauge {
         // Draw label inside
         if matches!(self.label_position, LabelPosition::Inside) {
             let label = self.get_label();
-            let label_x = (width.saturating_sub(label.len() as u16)) / 2;
-            for (i, ch) in label.chars().enumerate() {
-                let x = label_x + i as u16;
-                if x < width {
+            let lw = display_width(&label) as u16;
+            let label_x = (width.saturating_sub(lw)) / 2;
+            let mut dx: u16 = 0;
+            for ch in label.chars() {
+                let cw = char_width(ch) as u16;
+                let x = label_x + dx;
+                if x + cw <= width {
                     let is_filled = x < filled;
                     let bg = if is_filled {
                         self.fill_bg.unwrap_or(color)
@@ -344,6 +348,7 @@ impl Gauge {
                     cell.modifier |= Modifier::BOLD;
                     ctx.set(x, 0, cell);
                 }
+                dx += cw;
             }
         }
     }
@@ -441,17 +446,21 @@ impl Gauge {
         // Middle with label
         if area.height > 1 {
             let label = self.get_label();
-            let label_x = (width.saturating_sub(label.len() as u16)) / 2;
+            let lw = display_width(&label) as u16;
+            let label_x = (width.saturating_sub(lw)) / 2;
 
             let mut left = Cell::new('│');
             left.fg = Some(color);
             ctx.set(0, 1, left);
 
-            for (i, ch) in label.chars().enumerate() {
+            let mut dx: u16 = 0;
+            for ch in label.chars() {
+                let cw = char_width(ch) as u16;
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(contrast_color(self.empty_bg.unwrap_or(Color::rgb(0, 0, 0))));
                 cell.modifier |= Modifier::BOLD;
-                ctx.set(label_x + i as u16, 1, cell);
+                ctx.set(label_x + dx, 1, cell);
+                dx += cw;
             }
 
             let mut right = Cell::new('│');
@@ -510,10 +519,13 @@ impl Gauge {
 
         // Label
         let label_x = 3 + segments;
-        for (i, ch) in label.chars().enumerate() {
+        let mut dx: u16 = 0;
+        for ch in label.chars() {
+            let cw = char_width(ch) as u16;
             let mut cell = Cell::new(ch);
             cell.fg = Some(contrast_color(self.empty_bg.unwrap_or(Color::rgb(0, 0, 0))));
-            ctx.set(label_x + i as u16, 0, cell);
+            ctx.set(label_x + dx, 0, cell);
+            dx += cw;
         }
     }
 

--- a/src/widget/display/richlog.rs
+++ b/src/widget/display/richlog.rs
@@ -5,6 +5,7 @@
 use crate::event::Key;
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::utils::{char_width, truncate_to_width};
 use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
@@ -508,12 +509,14 @@ impl View for RichLog {
             // Draw timestamp
             if self.show_timestamps {
                 if let Some(ref ts) = entry.timestamp {
-                    for ch in ts.chars().take(timestamp_width as usize - 1) {
+                    let ts_display = truncate_to_width(ts, timestamp_width as usize - 1);
+                    for ch in ts_display.chars() {
+                        let cw = char_width(ch) as u16;
                         let mut cell = Cell::new(ch);
                         cell.fg = Some(self.timestamp_fg);
                         cell.bg = self.bg;
                         ctx.set(x, y, cell);
-                        x += 1;
+                        x += cw;
                     }
                 }
                 x = timestamp_width;
@@ -546,13 +549,14 @@ impl View for RichLog {
             // Draw source
             if self.show_sources {
                 if let Some(ref src) = entry.source {
-                    let src_display: String = src.chars().take(source_width as usize - 1).collect();
+                    let src_display = truncate_to_width(src, source_width as usize - 1);
                     for ch in src_display.chars() {
+                        let cw = char_width(ch) as u16;
                         let mut cell = Cell::new(ch);
                         cell.fg = Some(self.source_fg);
                         cell.bg = self.bg;
                         ctx.set(x, y, cell);
-                        x += 1;
+                        x += cw;
                     }
                 }
                 x = prefix_width;
@@ -564,7 +568,12 @@ impl View for RichLog {
             } else {
                 level_color
             };
-            for ch in entry.message.chars().take(message_width as usize) {
+            let msg_truncated = truncate_to_width(&entry.message, message_width as usize);
+            for ch in msg_truncated.chars() {
+                let cw = char_width(ch) as u16;
+                if x + cw > prefix_width + message_width {
+                    break;
+                }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(msg_fg);
                 cell.bg = self.bg;
@@ -575,7 +584,7 @@ impl View for RichLog {
                     cell.modifier |= Modifier::BOLD;
                 }
                 ctx.set(x, y, cell);
-                x += 1;
+                x += cw;
             }
         }
 

--- a/src/widget/feedback/alert.rs
+++ b/src/widget/feedback/alert.rs
@@ -402,7 +402,9 @@ impl Alert {
             let mut dx: u16 = 0;
             for ch in title.chars() {
                 let cw = char_width(ch) as u16;
-                if dx + cw > max_w { break; }
+                if dx + cw > max_w {
+                    break;
+                }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(text_fg);
                 cell.modifier |= Modifier::BOLD;
@@ -416,7 +418,9 @@ impl Alert {
             let mut dx: u16 = 0;
             for ch in self.message.chars() {
                 let cw = char_width(ch) as u16;
-                if dx + cw > max_w { break; }
+                if dx + cw > max_w {
+                    break;
+                }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(Color::rgb(180, 180, 180));
                 ctx.set(msg_x + dx, y, cell);
@@ -428,7 +432,9 @@ impl Alert {
             let mut dx: u16 = 0;
             for ch in self.message.chars() {
                 let cw = char_width(ch) as u16;
-                if dx + cw > max_w { break; }
+                if dx + cw > max_w {
+                    break;
+                }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(text_fg);
                 ctx.set(msg_x + dx, y, cell);
@@ -466,7 +472,9 @@ impl Alert {
             let mut dx: u16 = 0;
             for ch in title.chars() {
                 let cw = char_width(ch) as u16;
-                if x + dx + cw > area.width { break; }
+                if x + dx + cw > area.width {
+                    break;
+                }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(accent_color);
                 cell.modifier |= Modifier::BOLD;
@@ -480,7 +488,9 @@ impl Alert {
                 let mut dx: u16 = 0;
                 for ch in self.message.chars() {
                     let cw = char_width(ch) as u16;
-                    if msg_x + dx + cw > area.width { break; }
+                    if msg_x + dx + cw > area.width {
+                        break;
+                    }
                     let mut cell = Cell::new(ch);
                     cell.fg = Some(Color::rgb(180, 180, 180));
                     ctx.set(msg_x + dx, y + 1, cell);
@@ -492,7 +502,9 @@ impl Alert {
             let mut dx: u16 = 0;
             for ch in self.message.chars() {
                 let cw = char_width(ch) as u16;
-                if x + dx + cw > area.width { break; }
+                if x + dx + cw > area.width {
+                    break;
+                }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(text_fg);
                 ctx.set(x + dx, y, cell);

--- a/src/widget/feedback/alert.rs
+++ b/src/widget/feedback/alert.rs
@@ -25,6 +25,7 @@
 use crate::event::Key;
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::utils::char_width;
 use crate::widget::layout::border::{draw_border, BorderType};
 use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY};
 use crate::widget::traits::{RenderContext, View, WidgetProps, WidgetState};
@@ -397,36 +398,41 @@ impl Alert {
         // Title
         if let Some(ref title) = self.title {
             let title_x = content_x + icon_offset;
-            for (i, ch) in title.chars().enumerate() {
-                if i as u16 >= content_width - icon_offset {
-                    break;
-                }
+            let max_w = content_width - icon_offset;
+            let mut dx: u16 = 0;
+            for ch in title.chars() {
+                let cw = char_width(ch) as u16;
+                if dx + cw > max_w { break; }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(text_fg);
                 cell.modifier |= Modifier::BOLD;
-                ctx.set(title_x + i as u16, y, cell);
+                ctx.set(title_x + dx, y, cell);
+                dx += cw;
             }
             y += 1;
 
             // Message
             let msg_x = content_x + icon_offset;
-            for (i, ch) in self.message.chars().enumerate() {
-                if i as u16 >= content_width - icon_offset {
-                    break;
-                }
+            let mut dx: u16 = 0;
+            for ch in self.message.chars() {
+                let cw = char_width(ch) as u16;
+                if dx + cw > max_w { break; }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(Color::rgb(180, 180, 180));
-                ctx.set(msg_x + i as u16, y, cell);
+                ctx.set(msg_x + dx, y, cell);
+                dx += cw;
             }
         } else {
             let msg_x = content_x + icon_offset;
-            for (i, ch) in self.message.chars().enumerate() {
-                if i as u16 >= content_width - icon_offset {
-                    break;
-                }
+            let max_w = content_width - icon_offset;
+            let mut dx: u16 = 0;
+            for ch in self.message.chars() {
+                let cw = char_width(ch) as u16;
+                if dx + cw > max_w { break; }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(text_fg);
-                ctx.set(msg_x + i as u16, y, cell);
+                ctx.set(msg_x + dx, y, cell);
+                dx += cw;
             }
         }
 
@@ -457,37 +463,40 @@ impl Alert {
         // Title or message
         if let Some(ref title) = self.title {
             // Title on first line
-            for (i, ch) in title.chars().enumerate() {
-                if x + i as u16 >= area.width {
-                    break;
-                }
+            let mut dx: u16 = 0;
+            for ch in title.chars() {
+                let cw = char_width(ch) as u16;
+                if x + dx + cw > area.width { break; }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(accent_color);
                 cell.modifier |= Modifier::BOLD;
-                ctx.set(x + i as u16, y, cell);
+                ctx.set(x + dx, y, cell);
+                dx += cw;
             }
 
             // Message on second line
             if area.height > 1 {
                 let msg_x: u16 = if self.show_icon { 2 } else { 0 };
-                for (i, ch) in self.message.chars().enumerate() {
-                    if msg_x + i as u16 >= area.width {
-                        break;
-                    }
+                let mut dx: u16 = 0;
+                for ch in self.message.chars() {
+                    let cw = char_width(ch) as u16;
+                    if msg_x + dx + cw > area.width { break; }
                     let mut cell = Cell::new(ch);
                     cell.fg = Some(Color::rgb(180, 180, 180));
-                    ctx.set(msg_x + i as u16, y + 1, cell);
+                    ctx.set(msg_x + dx, y + 1, cell);
+                    dx += cw;
                 }
             }
         } else {
             // Just message
-            for (i, ch) in self.message.chars().enumerate() {
-                if x + i as u16 >= area.width {
-                    break;
-                }
+            let mut dx: u16 = 0;
+            for ch in self.message.chars() {
+                let cw = char_width(ch) as u16;
+                if x + dx + cw > area.width { break; }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(text_fg);
-                ctx.set(x + i as u16, y, cell);
+                ctx.set(x + dx, y, cell);
+                dx += cw;
             }
         }
 

--- a/src/widget/feedback/error_boundary.rs
+++ b/src/widget/feedback/error_boundary.rs
@@ -122,24 +122,30 @@ impl ErrorBoundary {
         // Title
         let title = " Error ";
         let title_x: u16 = 2;
-        for (i, ch) in title.chars().enumerate() {
-            let x = title_x + i as u16;
+        let mut dx: u16 = 0;
+        for ch in title.chars() {
+            let cw = crate::utils::char_width(ch) as u16;
+            let x = title_x + dx;
             if x < area.width - 1 {
                 ctx.set(x, 0, Cell::new(ch).fg(text_color));
             }
+            dx += cw;
         }
 
         // Error message
         let msg = self.error_message.borrow();
         let display_msg = msg.as_deref().unwrap_or("A rendering error occurred");
         let inner_width = (area.width.saturating_sub(4)) as usize;
-        let truncated: String = display_msg.chars().take(inner_width).collect();
+        let truncated = crate::utils::truncate_to_width(display_msg, inner_width);
         let msg_y: u16 = 1;
-        for (i, ch) in truncated.chars().enumerate() {
-            let x = 2 + i as u16;
+        let mut dx: u16 = 0;
+        for ch in truncated.chars() {
+            let cw = crate::utils::char_width(ch) as u16;
+            let x = 2 + dx;
             if x < area.width - 1 {
                 ctx.set(x, msg_y, Cell::new(ch).fg(dim_color).dim());
             }
+            dx += cw;
         }
     }
 }

--- a/src/widget/feedback/menu/context_menu.rs
+++ b/src/widget/feedback/menu/context_menu.rs
@@ -180,14 +180,17 @@ impl View for ContextMenu {
             }
 
             // Draw label
-            for (j, ch) in item.label.chars().enumerate() {
-                if j as u16 + 2 >= width - 1 {
+            let mut dx: u16 = 0;
+            for ch in item.label.chars() {
+                let cw = crate::utils::char_width(ch) as u16;
+                if dx + cw + 2 >= width - 1 {
                     break;
                 }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(fg);
                 cell.bg = Some(bg);
-                ctx.set(x + 2 + j as u16, item_y, cell);
+                ctx.set(x + 2 + dx, item_y, cell);
+                dx += cw;
             }
         }
     }

--- a/src/widget/feedback/notification/core.rs
+++ b/src/widget/feedback/notification/core.rs
@@ -3,6 +3,7 @@
 use super::types::{Notification, NotificationPosition};
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::utils::char_width;
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -366,15 +367,18 @@ impl NotificationCenter {
             }
 
             // Title text
-            for (i, ch) in title.chars().enumerate() {
-                if content_x + i as u16 >= x + width - 2 {
+            let mut dx: u16 = 0;
+            for ch in title.chars() {
+                let cw = char_width(ch) as u16;
+                if content_x + dx >= x + width - 2 {
                     break;
                 }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(Color::WHITE);
                 cell.bg = Some(bg);
                 cell.modifier |= Modifier::BOLD;
-                ctx.set(content_x + i as u16, current_y, cell);
+                ctx.set(content_x + dx, current_y, cell);
+                dx += cw;
             }
 
             let mut right = Cell::new('│');
@@ -408,14 +412,17 @@ impl NotificationCenter {
             }
 
             // Message text
-            for (i, ch) in notification.message.chars().enumerate() {
-                if content_x + i as u16 >= x + width - 2 {
+            let mut dx: u16 = 0;
+            for ch in notification.message.chars() {
+                let cw = char_width(ch) as u16;
+                if content_x + dx >= x + width - 2 {
                     break;
                 }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(Color::WHITE);
                 cell.bg = Some(bg);
-                ctx.set(content_x + i as u16, current_y, cell);
+                ctx.set(content_x + dx, current_y, cell);
+                dx += cw;
             }
 
             let mut right = Cell::new('│');

--- a/src/widget/feedback/toast_queue.rs
+++ b/src/widget/feedback/toast_queue.rs
@@ -24,6 +24,7 @@
 use super::toast::{ToastLevel, ToastPosition};
 use crate::render::Cell;
 use crate::style::Color;
+use crate::utils::{char_width, truncate_to_width};
 use crate::widget::theme::DISABLED_FG;
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
@@ -491,12 +492,19 @@ impl ToastQueue {
 
         // Message
         let msg_x = content_x + 2;
-        let max_msg_len = (toast_w.saturating_sub(5)) as usize;
-        for (i, ch) in entry.message.chars().take(max_msg_len).enumerate() {
+        let max_msg_width = toast_w.saturating_sub(5) as usize;
+        let truncated_msg = truncate_to_width(&entry.message, max_msg_width);
+        let mut dx: u16 = 0;
+        for ch in truncated_msg.chars() {
+            let cw = char_width(ch) as u16;
+            if dx + cw > max_msg_width as u16 {
+                break;
+            }
             let mut cell = Cell::new(ch);
             cell.fg = Some(Color::WHITE);
             cell.bg = Some(bg);
-            ctx.set(msg_x + i as u16, content_y, cell);
+            ctx.set(msg_x + dx, content_y, cell);
+            dx += cw;
         }
 
         // Dismiss hint for dismissible toasts

--- a/src/widget/feedback/tooltip.rs
+++ b/src/widget/feedback/tooltip.rs
@@ -361,8 +361,16 @@ impl Tooltip {
         let has_border = self.style.border_chars().is_some();
         let has_title = self.title.is_some();
 
-        let content_width = lines.iter().map(|l| l.len()).max().unwrap_or(0) as u16;
-        let title_width = self.title.as_ref().map(|t| t.len() as u16 + 2).unwrap_or(0);
+        let content_width = lines
+            .iter()
+            .map(|l| crate::utils::display_width(l))
+            .max()
+            .unwrap_or(0) as u16;
+        let title_width = self
+            .title
+            .as_ref()
+            .map(|t| crate::utils::display_width(t) as u16 + 2)
+            .unwrap_or(0);
         let text_width = content_width.max(title_width);
 
         let width = text_width + if has_border { 4 } else { 2 }; // padding + border

--- a/src/widget/filepicker/render.rs
+++ b/src/widget/filepicker/render.rs
@@ -21,13 +21,25 @@ impl View for FilePicker {
             content = content.child(Text::new(title).bold());
         }
 
-        // Current path
+        // Current path - truncate from the left to show the end of the path
         let path_str = self.current_dir.display().to_string();
-        let truncated_path = if path_str.len() > self.width as usize - 4 {
-            format!(
-                "...{}",
-                &path_str[path_str.len() - self.width as usize + 7..]
-            )
+        let max_path_width = self.width as usize - 4;
+        let truncated_path = if crate::utils::display_width(&path_str) > max_path_width {
+            let suffix_width = max_path_width.saturating_sub(3); // "..." prefix
+            // Find suffix that fits by iterating from the end
+            let chars: Vec<char> = path_str.chars().collect();
+            let mut w = 0;
+            let mut start = chars.len();
+            for i in (0..chars.len()).rev() {
+                let cw = crate::utils::char_width(chars[i]);
+                if w + cw > suffix_width {
+                    break;
+                }
+                w += cw;
+                start = i;
+            }
+            let suffix: String = chars[start..].iter().collect();
+            format!("...{}", suffix)
         } else {
             path_str
         };

--- a/src/widget/filepicker/render.rs
+++ b/src/widget/filepicker/render.rs
@@ -26,7 +26,7 @@ impl View for FilePicker {
         let max_path_width = self.width as usize - 4;
         let truncated_path = if crate::utils::display_width(&path_str) > max_path_width {
             let suffix_width = max_path_width.saturating_sub(3); // "..." prefix
-            // Find suffix that fits by iterating from the end
+                                                                 // Find suffix that fits by iterating from the end
             let chars: Vec<char> = path_str.chars().collect();
             let mut w = 0;
             let mut start = chars.len();

--- a/src/widget/form/form.rs
+++ b/src/widget/form/form.rs
@@ -28,6 +28,7 @@ use crate::impl_props_builders;
 use crate::patterns::form::FormState;
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::utils::char_width;
 use crate::widget::theme::{DISABLED_FG, SUBTLE_GRAY};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use std::collections::HashMap;
@@ -181,13 +182,16 @@ impl Form {
         let title = "Form";
         let title_x: u16 = 2;
 
-        for (i, ch) in title.chars().enumerate() {
-            if title_x + (i as u16) < area.width - 1 {
+        let mut dx: u16 = 0;
+        for ch in title.chars() {
+            let cw = char_width(ch) as u16;
+            if title_x + dx < area.width - 1 {
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(Color::WHITE);
                 cell.bg = Some(Color::BLACK);
-                ctx.set(title_x + i as u16, 0, cell);
+                ctx.set(title_x + dx, 0, cell);
             }
+            dx += cw;
         }
     }
 }

--- a/src/widget/form/masked_input.rs
+++ b/src/widget/form/masked_input.rs
@@ -29,6 +29,7 @@
 //! ```
 
 use crate::style::Color;
+use crate::utils::display_width;
 use crate::widget::theme::{DARK_GRAY, DISABLED_FG, PLACEHOLDER_FG};
 use crate::widget::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
@@ -605,13 +606,14 @@ impl View for MaskedInput {
 
         // Build input display with pre-allocated padding
         let width = self.width.unwrap_or(20) as usize;
-        let padded = if display.len() < width {
+        let display_w = display_width(&display);
+        let padded = if display_w < width {
             let mut result = String::with_capacity(width);
             result.push_str(&display);
-            result.extend(std::iter::repeat_n(' ', width - display.len()));
+            result.extend(std::iter::repeat_n(' ', width - display_w));
             result
         } else {
-            display.chars().take(width).collect()
+            crate::utils::truncate_to_width(&display, width).to_owned()
         };
 
         // Insert cursor if focused

--- a/src/widget/form/rich_text_editor/dialog.rs
+++ b/src/widget/form/rich_text_editor/dialog.rs
@@ -3,6 +3,7 @@
 use super::{DialogType, RichTextEditor};
 use crate::render::Cell;
 use crate::style::Color;
+use crate::utils::{char_width, display_width};
 use crate::widget::traits::RenderContext;
 
 impl RichTextEditor {
@@ -69,13 +70,16 @@ impl RichTextEditor {
             DialogType::InsertLink { text, url, field } => {
                 // Title
                 let title = "Insert Link";
-                let title_x = dialog_x + (dialog_width - title.len() as u16) / 2;
-                for (i, ch) in title.chars().enumerate() {
+                let title_x = dialog_x + (dialog_width.saturating_sub(display_width(title) as u16)) / 2;
+                let mut dx: u16 = 0;
+                for ch in title.chars() {
+                    let cw = char_width(ch) as u16;
                     ctx.set(
-                        title_x + i as u16,
+                        title_x + dx,
                         dialog_y + 1,
                         Cell::new(ch).fg(fg).bg(bg),
                     );
+                    dx += cw;
                 }
 
                 // Text field
@@ -121,13 +125,16 @@ impl RichTextEditor {
             DialogType::InsertImage { alt, src, field } => {
                 // Title
                 let title = "Insert Image";
-                let title_x = dialog_x + (dialog_width - title.len() as u16) / 2;
-                for (i, ch) in title.chars().enumerate() {
+                let title_x = dialog_x + (dialog_width.saturating_sub(display_width(title) as u16)) / 2;
+                let mut dx: u16 = 0;
+                for ch in title.chars() {
+                    let cw = char_width(ch) as u16;
                     ctx.set(
-                        title_x + i as u16,
+                        title_x + dx,
                         dialog_y + 1,
                         Cell::new(ch).fg(fg).bg(bg),
                     );
+                    dx += cw;
                 }
 
                 // Alt field

--- a/src/widget/form/rich_text_editor/dialog.rs
+++ b/src/widget/form/rich_text_editor/dialog.rs
@@ -70,15 +70,12 @@ impl RichTextEditor {
             DialogType::InsertLink { text, url, field } => {
                 // Title
                 let title = "Insert Link";
-                let title_x = dialog_x + (dialog_width.saturating_sub(display_width(title) as u16)) / 2;
+                let title_x =
+                    dialog_x + (dialog_width.saturating_sub(display_width(title) as u16)) / 2;
                 let mut dx: u16 = 0;
                 for ch in title.chars() {
                     let cw = char_width(ch) as u16;
-                    ctx.set(
-                        title_x + dx,
-                        dialog_y + 1,
-                        Cell::new(ch).fg(fg).bg(bg),
-                    );
+                    ctx.set(title_x + dx, dialog_y + 1, Cell::new(ch).fg(fg).bg(bg));
                     dx += cw;
                 }
 
@@ -125,15 +122,12 @@ impl RichTextEditor {
             DialogType::InsertImage { alt, src, field } => {
                 // Title
                 let title = "Insert Image";
-                let title_x = dialog_x + (dialog_width.saturating_sub(display_width(title) as u16)) / 2;
+                let title_x =
+                    dialog_x + (dialog_width.saturating_sub(display_width(title) as u16)) / 2;
                 let mut dx: u16 = 0;
                 for ch in title.chars() {
                     let cw = char_width(ch) as u16;
-                    ctx.set(
-                        title_x + dx,
-                        dialog_y + 1,
-                        Cell::new(ch).fg(fg).bg(bg),
-                    );
+                    ctx.set(title_x + dx, dialog_y + 1, Cell::new(ch).fg(fg).bg(bg));
                     dx += cw;
                 }
 

--- a/src/widget/input/input_widgets/color_picker/core.rs
+++ b/src/widget/input/input_widgets/color_picker/core.rs
@@ -198,6 +198,9 @@ impl ColorPicker {
 
     fn handle_palette_key(&mut self, key: &Key) -> bool {
         let colors = self.palette.colors();
+        if colors.is_empty() {
+            return false;
+        }
         let (cols, _rows) = self.palette.grid_size();
 
         match key {
@@ -209,7 +212,7 @@ impl ColorPicker {
                 true
             }
             Key::Right | Key::Char('l') => {
-                if self.palette_index < colors.len() - 1 {
+                if self.palette_index + 1 < colors.len() {
                     self.palette_index += 1;
                     self.set_color(colors[self.palette_index]);
                 }

--- a/src/widget/input/input_widgets/input/render.rs
+++ b/src/widget/input/input_widgets/input/render.rs
@@ -73,7 +73,7 @@ impl View for Input {
         }
 
         // Draw cursor at end if cursor is at the end of text
-        if self.focused && self.cursor >= display_text.len() && x < area.width {
+        if self.focused && self.cursor >= display_text.chars().count() && x < area.width {
             let mut cursor_cell = Cell::new(' ');
             cursor_cell.fg = self.cursor_fg;
             cursor_cell.bg = self.cursor_bg;

--- a/src/widget/input/input_widgets/search_bar.rs
+++ b/src/widget/input/input_widgets/search_bar.rs
@@ -8,6 +8,7 @@
 use crate::query::{ParseError, Query};
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::utils::{char_width, truncate_to_width};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -331,25 +332,48 @@ impl View for SearchBar {
 
         if self.input.is_empty() {
             // Draw placeholder
-            for (i, ch) in self.placeholder.chars().enumerate() {
-                if i as u16 >= input_width {
+            let ph = truncate_to_width(&self.placeholder, input_width as usize);
+            let mut dx: u16 = 0;
+            for ch in ph.chars() {
+                let cw = char_width(ch) as u16;
+                if dx + cw > input_width {
                     break;
                 }
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(self.placeholder_color);
                 cell.bg = Some(self.bg_color);
-                ctx.set(input_x + i as u16, 0, cell);
+                ctx.set(input_x + dx, 0, cell);
+                dx += cw;
             }
         } else {
-            // Draw input text
-            let display_start = if self.cursor as u16 >= input_width {
-                self.cursor - input_width as usize + 1
+            // Calculate display_start based on display width up to cursor
+            let chars: Vec<char> = self.input.chars().collect();
+            let mut cursor_display_width: u16 = 0;
+            for &ch in &chars[..self.cursor.min(chars.len())] {
+                cursor_display_width += char_width(ch) as u16;
+            }
+            let display_start = if cursor_display_width >= input_width {
+                // Find the character offset where display should start
+                let target_width = cursor_display_width - input_width + 1;
+                let mut w: u16 = 0;
+                let mut start = 0;
+                for (i, &ch) in chars.iter().enumerate() {
+                    if w >= target_width {
+                        start = i;
+                        break;
+                    }
+                    w += char_width(ch) as u16;
+                    start = i + 1;
+                }
+                start
             } else {
                 0
             };
 
-            for (i, ch) in self.input.chars().skip(display_start).enumerate() {
-                if i as u16 >= input_width {
+            let mut dx: u16 = 0;
+            for &ch in &chars[display_start..] {
+                let cw = char_width(ch) as u16;
+                if dx + cw > input_width {
                     break;
                 }
                 let mut cell = Cell::new(ch);
@@ -359,13 +383,25 @@ impl View for SearchBar {
                     self.text_color
                 });
                 cell.bg = Some(self.bg_color);
-                ctx.set(input_x + i as u16, 0, cell);
+                ctx.set(input_x + dx, 0, cell);
+                dx += cw;
             }
         }
 
         // Draw cursor
         if self.focused {
-            let cursor_x = input_x + (self.cursor.saturating_sub(0)) as u16;
+            let cursor_display_x: u16 = self
+                .input
+                .chars()
+                .take(self.cursor)
+                .map(|ch| char_width(ch) as u16)
+                .sum();
+            let visible_start: u16 = if cursor_display_x >= input_width {
+                cursor_display_x - input_width + 1
+            } else {
+                0
+            };
+            let cursor_x = input_x + cursor_display_x.saturating_sub(visible_start);
             if cursor_x < width - 1 {
                 // Use skip().next() for O(n) instead of O(n²) with .chars().nth()
                 let cursor_char = self.input.chars().skip(self.cursor).next().unwrap_or(' ');

--- a/src/widget/input/input_widgets/textarea/mod.rs
+++ b/src/widget/input/input_widgets/textarea/mod.rs
@@ -116,6 +116,8 @@ pub struct TextArea {
     pub(super) current_match_bg: Option<Color>,
     /// CSS styling properties (id, classes)
     pub(super) props: WidgetProps,
+    /// Last known viewport height (lines visible), updated during render
+    pub(super) last_viewport_height: std::cell::Cell<usize>,
 }
 
 impl TextArea {
@@ -145,6 +147,7 @@ impl TextArea {
             match_highlight_bg: None,
             current_match_bg: None,
             props: WidgetProps::new(),
+            last_viewport_height: std::cell::Cell::new(10),
         }
     }
 
@@ -325,11 +328,13 @@ impl TextArea {
                 true
             }
             Key::PageUp => {
-                self.page_up(10);
+                let page = self.last_viewport_height.get().max(1);
+                self.page_up(page);
                 true
             }
             Key::PageDown => {
-                self.page_down(10);
+                let page = self.last_viewport_height.get().max(1);
+                self.page_down(page);
                 true
             }
             _ => false,

--- a/src/widget/input/input_widgets/textarea/view.rs
+++ b/src/widget/input/input_widgets/textarea/view.rs
@@ -39,6 +39,7 @@ impl View for TextArea {
         let text_start_x = line_num_width;
         let text_width = area.width.saturating_sub(line_num_width);
         let visible_lines = area.height as usize;
+        self.last_viewport_height.set(visible_lines);
 
         // Draw background
         if let Some(bg) = self.bg {

--- a/src/widget/layout/collapsible.rs
+++ b/src/widget/layout/collapsible.rs
@@ -337,7 +337,10 @@ impl View for Collapsible {
 
         // Title
         let max_title_width = (area.width.saturating_sub(3)) as usize;
-        for ch in self.title.chars().take(max_title_width) {
+        let title_display = crate::utils::truncate_to_width(&self.title, max_title_width);
+        for ch in title_display.chars() {
+            let cw = crate::utils::char_width(ch) as u16;
+            if x + cw > area.width { break; }
             let mut cell = Cell::new(ch);
             cell.fg = Some(header_fg);
             if let Some(bg) = self.header_bg {
@@ -347,7 +350,7 @@ impl View for Collapsible {
                 cell.modifier |= Modifier::BOLD;
             }
             ctx.set(x, 0, cell);
-            x += 1;
+            x += cw;
         }
 
         // Render content if expanded

--- a/src/widget/layout/collapsible.rs
+++ b/src/widget/layout/collapsible.rs
@@ -340,7 +340,9 @@ impl View for Collapsible {
         let title_display = crate::utils::truncate_to_width(&self.title, max_title_width);
         for ch in title_display.chars() {
             let cw = crate::utils::char_width(ch) as u16;
-            if x + cw > area.width { break; }
+            if x + cw > area.width {
+                break;
+            }
             let mut cell = Cell::new(ch);
             cell.fg = Some(header_fg);
             if let Some(bg) = self.header_bg {

--- a/src/widget/layout/sidebar/render.rs
+++ b/src/widget/layout/sidebar/render.rs
@@ -3,6 +3,7 @@
 use super::types::{CollapseMode, FlattenedItem};
 use super::Sidebar;
 use crate::render::Cell;
+use crate::utils::{char_width, display_width, truncate_to_width};
 use crate::widget::traits::RenderContext;
 
 impl Sidebar {
@@ -40,13 +41,19 @@ impl Sidebar {
         // Render header if present
         if let Some(header) = &self.header {
             if !is_collapsed {
-                let display: String = header.chars().take(content_width as usize - 2).collect();
-                let x_offset = (content_width as usize - display.chars().count()) / 2;
-                for (i, ch) in display.chars().enumerate() {
+                let display = truncate_to_width(header, content_width as usize - 2);
+                let x_offset = (content_width as usize).saturating_sub(display_width(display)) / 2;
+                let mut dx: u16 = 0;
+                for ch in display.chars() {
+                    let cw = char_width(ch) as u16;
+                    if x_offset as u16 + dx + cw > content_width {
+                        break;
+                    }
                     let mut cell = Cell::new(ch).bold();
                     cell.fg = self.fg;
                     cell.bg = self.bg;
-                    ctx.set(x_offset as u16 + i as u16, y, cell);
+                    ctx.set(x_offset as u16 + dx, y, cell);
+                    dx += cw;
                 }
             }
             y += 1;
@@ -79,15 +86,18 @@ impl Sidebar {
                     if !is_collapsed {
                         if let Some(title_text) = title {
                             // Section title
-                            let display: String = title_text
-                                .chars()
-                                .take(content_width as usize - 2)
-                                .collect();
-                            for (i, ch) in display.chars().enumerate() {
+                            let display = truncate_to_width(title_text, content_width as usize - 2);
+                            let mut dx: u16 = 0;
+                            for ch in display.chars() {
+                                let cw = char_width(ch) as u16;
+                                if 1 + dx + cw > content_width {
+                                    break;
+                                }
                                 let mut cell = Cell::new(ch);
                                 cell.fg = self.section_fg;
                                 cell.bg = self.bg;
-                                ctx.set(1 + i as u16, y, cell);
+                                ctx.set(1 + dx, y, cell);
+                                dx += cw;
                             }
                         } else {
                             // Separator line
@@ -151,28 +161,41 @@ impl Sidebar {
                     // Label (only if not collapsed)
                     if !is_collapsed {
                         let max_label_width = content_width.saturating_sub(x + 1);
-                        let badge_space = item.badge.as_ref().map(|b| b.len() + 2).unwrap_or(0);
+                        let badge_space = item
+                            .badge
+                            .as_ref()
+                            .map(|b| display_width(b) + 2)
+                            .unwrap_or(0);
                         let label_width = (max_label_width as usize).saturating_sub(badge_space);
-                        let display: String = item.label.chars().take(label_width).collect();
+                        let display = truncate_to_width(&item.label, label_width);
 
                         for ch in display.chars() {
-                            if x < content_width - badge_space as u16 {
-                                let mut cell = Cell::new(ch);
-                                cell.fg = fg;
-                                cell.bg = bg;
-                                ctx.set(x, y, cell);
-                                x += 1;
+                            let cw = char_width(ch) as u16;
+                            if x + cw > content_width.saturating_sub(badge_space as u16) {
+                                break;
                             }
+                            let mut cell = Cell::new(ch);
+                            cell.fg = fg;
+                            cell.bg = bg;
+                            ctx.set(x, y, cell);
+                            x += cw;
                         }
 
                         // Badge
                         if let Some(badge) = &item.badge {
-                            let badge_x = content_width - badge.len() as u16 - 2;
-                            for (i, ch) in badge.chars().enumerate() {
+                            let badge_x =
+                                content_width.saturating_sub(display_width(badge) as u16 + 2);
+                            let mut dx: u16 = 0;
+                            for ch in badge.chars() {
+                                let cw = char_width(ch) as u16;
+                                if badge_x + dx + cw > content_width {
+                                    break;
+                                }
                                 let mut cell = Cell::new(ch);
                                 cell.fg = self.badge_fg;
                                 cell.bg = self.badge_bg;
-                                ctx.set(badge_x + i as u16, y, cell);
+                                ctx.set(badge_x + dx, y, cell);
+                                dx += cw;
                             }
                         }
                     }
@@ -194,13 +217,19 @@ impl Sidebar {
             }
 
             if !is_collapsed {
-                let display: String = footer.chars().take(content_width as usize - 2).collect();
-                let x_offset = (content_width as usize - display.chars().count()) / 2;
-                for (i, ch) in display.chars().enumerate() {
+                let display = truncate_to_width(footer, content_width as usize - 2);
+                let x_offset = (content_width as usize).saturating_sub(display_width(display)) / 2;
+                let mut dx: u16 = 0;
+                for ch in display.chars() {
+                    let cw = char_width(ch) as u16;
+                    if x_offset as u16 + dx + cw > content_width {
+                        break;
+                    }
                     let mut cell = Cell::new(ch);
                     cell.fg = self.section_fg;
                     cell.bg = self.bg;
-                    ctx.set(x_offset as u16 + i as u16, footer_y + 1, cell);
+                    ctx.set(x_offset as u16 + dx, footer_y + 1, cell);
+                    dx += cw;
                 }
             }
         }

--- a/src/widget/streamline/view.rs
+++ b/src/widget/streamline/view.rs
@@ -2,6 +2,7 @@
 
 use super::core::Streamline;
 use crate::render::Cell;
+use crate::utils::{char_width, display_width};
 use crate::widget::traits::{RenderContext, View};
 
 impl View for Streamline {
@@ -29,7 +30,7 @@ impl View for Streamline {
 
         // Title
         if let Some(ref title) = self.title {
-            let title_x = (area.width.saturating_sub(title.len() as u16)) / 2;
+            let title_x = (area.width.saturating_sub(display_width(title) as u16)) / 2;
             ctx.draw_text(title_x, chart_y, title, crate::style::Color::WHITE);
             chart_y += 1;
             chart_height = chart_height.saturating_sub(1);
@@ -44,16 +45,19 @@ impl View for Streamline {
                 cell.fg = Some(color);
                 ctx.set(x, chart_y, cell);
                 x += 2;
-                for (j, ch) in layer.name.chars().enumerate() {
-                    if x + j as u16 >= area.width {
+                let mut dx: u16 = 0;
+                for ch in layer.name.chars() {
+                    let cw = char_width(ch) as u16;
+                    if x + dx >= area.width {
                         break;
                     }
                     let mut c = Cell::new(ch);
                     c.fg = Some(crate::style::Color::WHITE);
                     c.bg = self.bg_color;
-                    ctx.set(x + j as u16, chart_y, c);
+                    ctx.set(x + dx, chart_y, c);
+                    dx += cw;
                 }
-                x += layer.name.len() as u16 + 2;
+                x += display_width(&layer.name) as u16 + 2;
 
                 if x > area.width - 10 {
                     break;
@@ -162,17 +166,20 @@ impl View for Streamline {
                     - ((mid_y - min_y) / y_range * (plot_height - 1) as f64) as u16;
 
                 let label = &self.layers[layer_idx].name;
-                let label_x = screen_x.saturating_sub(label.len() as u16 / 2);
+                let label_x = screen_x.saturating_sub(display_width(label) as u16 / 2);
 
                 if screen_y >= chart_y && screen_y < chart_y + plot_height {
-                    for (j, ch) in label.chars().enumerate() {
-                        if label_x + j as u16 >= area.width {
+                    let mut dx: u16 = 0;
+                    for ch in label.chars() {
+                        let cw = char_width(ch) as u16;
+                        if label_x + dx >= area.width {
                             break;
                         }
                         let mut c = Cell::new(ch);
                         c.fg = Some(crate::style::Color::WHITE);
                         c.bg = Some(display_color);
-                        ctx.set(label_x + j as u16, screen_y, c);
+                        ctx.set(label_x + dx, screen_y, c);
+                        dx += cw;
                     }
                 }
             }
@@ -186,15 +193,18 @@ impl View for Streamline {
             for (i, label) in self.x_labels.iter().take(num_labels).enumerate() {
                 let x =
                     (i as f64 / (num_labels - 1).max(1) as f64 * (area.width - 1) as f64) as u16;
-                let label_x = x.saturating_sub(label.len() as u16 / 2);
-                for (j, ch) in label.chars().enumerate() {
-                    if label_x + j as u16 >= area.width {
+                let label_x = x.saturating_sub(display_width(label) as u16 / 2);
+                let mut dx: u16 = 0;
+                for ch in label.chars() {
+                    let cw = char_width(ch) as u16;
+                    if label_x + dx >= area.width {
                         break;
                     }
                     let mut c = Cell::new(ch);
                     c.fg = Some(crate::style::Color::WHITE);
                     c.bg = self.bg_color;
-                    ctx.set(label_x + j as u16, label_y, c);
+                    ctx.set(label_x + dx, label_y, c);
+                    dx += cw;
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **Runtime bug fixes**: DataGrid filtered selection, reactive depth counter leak, TextBuffer range panic, ColorPicker empty palette crash
- **Unicode rendering**: Replace `.len()`/`.chars().count()`/`i as u16` with `display_width()`/`char_width()`/`truncate_to_width()` across all widgets for correct CJK/emoji rendering
- **Usability**: Viewport-aware PageUp/Down for DataGrid and TextArea, BoxPlot NaN-safe sorting

## Detail

### Runtime Bugs (4)
| Bug | File | Fix |
|-----|------|-----|
| `toggle_selection()` toggles wrong row when filter active | `datagrid/navigation.rs` | Use `filtered_cache` lookup |
| `NOTIFY_DEPTH` leaks on callback panic | `reactive/tracker.rs` | Drop guard pattern |
| `substring(start, end)` panics when start > end | `textbuffer/mod.rs` | Early return `""` |
| `colors.len() - 1` underflows on empty palette | `color_picker/core.rs` | Empty check + `+ 1 < len` |

### Unicode Rendering (36 files)
All user-facing widgets now use the existing `display_width()`, `char_width()`, and `truncate_to_width()` utilities instead of byte length or character count for:
- Cell content truncation and alignment (DataGrid, Table, CSV Viewer)
- Label centering (Gauge, Charts, EmptyState, Sidebar, Timeline)
- Text positioning (Alert, Toast, Notification, Diff, SearchBar)
- Width calculation (Tooltip, Column sizing, MaskedInput)
- Path truncation (FilePicker - fixes potential panic on multi-byte UTF-8 slice)

### Usability (3)
- **PageUp/Down**: DataGrid and TextArea now move by actual viewport height (stored via `Cell<usize>`) instead of hardcoded 10 rows
- **BoxPlot**: `sort_by` uses `unwrap_or(Ordering::Equal)` instead of `unwrap()` to handle edge cases

## Test plan

- [x] `cargo test --lib` — 5208 passed, 0 failed
- [x] `cargo clippy --lib -- -D warnings` — 0 warnings
- [x] `cargo build --lib` — 0 warnings
- [ ] Manual test with CJK/emoji content in DataGrid, Table, CSV Viewer
- [ ] Manual test PageUp/Down in DataGrid and TextArea with varying terminal sizes