### PR TITLE
feat(css): add text-align, font-weight, text-decoration properties

### DIFF
--- a/examples/qrcode_generator.rs
+++ b/examples/qrcode_generator.rs
@@ -1,0 +1,209 @@
+//! QR Code Generator - Interactive URL to QR
+//!
+//! Type a URL and instantly see its QR code rendered in the terminal.
+//! Switch between rendering styles with Tab.
+//!
+//! Run with: cargo run --example qrcode_generator --features qrcode
+
+use revue::prelude::*;
+use revue::widget::{qrcode, ErrorCorrection, QrStyle};
+
+struct QrGenerator {
+    url: Signal<String>,
+    style_idx: Signal<usize>,
+    cursor: Signal<usize>,
+}
+
+impl QrGenerator {
+    fn new() -> Self {
+        let default_url = String::from("https://example.com");
+        let len = default_url.len();
+        Self {
+            url: signal(default_url),
+            style_idx: signal(0),
+            cursor: signal(len),
+        }
+    }
+
+    fn styles() -> &'static [(QrStyle, &'static str)] {
+        &[
+            (QrStyle::HalfBlock, "Half Block"),
+            (QrStyle::Braille, "Braille"),
+            (QrStyle::FullBlock, "Full Block"),
+            (QrStyle::Ascii, "ASCII"),
+        ]
+    }
+
+    fn handle_key(&self, key_event: &KeyEvent) -> bool {
+        match (&key_event.key, key_event.ctrl) {
+            (Key::Char('u'), true) => {
+                self.url.set(String::new());
+                self.cursor.set(0);
+                true
+            }
+            (Key::Char(c), false) if !c.is_control() => {
+                let ch = *c;
+                let cur = self.cursor.get();
+                self.url.update(|s| s.insert(cur, ch));
+                self.cursor.update(|c| *c += 1);
+                true
+            }
+            (Key::Backspace, _) => {
+                let cur = self.cursor.get();
+                if cur > 0 {
+                    self.url.update(|s| {
+                        s.remove(cur - 1);
+                    });
+                    self.cursor.update(|c| *c -= 1);
+                }
+                true
+            }
+            (Key::Delete, _) => {
+                let cur = self.cursor.get();
+                let len = self.url.get().len();
+                if cur < len {
+                    self.url.update(|s| {
+                        s.remove(cur);
+                    });
+                }
+                true
+            }
+            (Key::Left, _) => {
+                self.cursor.update(|c| {
+                    if *c > 0 {
+                        *c -= 1;
+                    }
+                });
+                true
+            }
+            (Key::Right, _) => {
+                let len = self.url.get().len();
+                self.cursor.update(|c| {
+                    if *c < len {
+                        *c += 1;
+                    }
+                });
+                true
+            }
+            (Key::Home, _) => {
+                self.cursor.set(0);
+                true
+            }
+            (Key::End, _) => {
+                let len = self.url.get().len();
+                self.cursor.set(len);
+                true
+            }
+            (Key::Tab, _) => {
+                let len = Self::styles().len();
+                self.style_idx.update(|v| *v = (*v + 1) % len);
+                true
+            }
+            (Key::BackTab, _) => {
+                let len = Self::styles().len();
+                self.style_idx.update(|v| *v = (*v + len - 1) % len);
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+impl View for QrGenerator {
+    fn render(&self, ctx: &mut RenderContext) {
+        let url = self.url.get();
+        let cursor = self.cursor.get();
+        let idx = self.style_idx.get();
+        let (style, style_name) = Self::styles()[idx];
+
+        // Build input display with cursor indicator
+        let input_display = if url.is_empty() {
+            "Enter a URL...".to_string()
+        } else {
+            // Show cursor position with a block character
+            let pos = cursor.min(url.len());
+            let (before, after) = url.split_at(pos);
+            format!("{}\u{2502}{}", before, after)
+        };
+
+        let input_color = if url.is_empty() {
+            Color::hex(0x666666)
+        } else {
+            Color::WHITE
+        };
+
+        // Title (1 line, no border)
+        let title = Text::new(format!("QR Code Generator [{}]", style_name))
+            .bold()
+            .fg(Color::CYAN)
+            .align(Alignment::Center);
+
+        // URL Input (border = 3 lines)
+        let input = Border::rounded()
+            .title("URL")
+            .fg(Color::GREEN)
+            .child(Text::new(input_display).fg(input_color));
+
+        // QR Code (auto = fills remaining space)
+        let qr_box = if !url.is_empty() {
+            let qr = qrcode(&url)
+                .style(style)
+                .fg(Color::WHITE)
+                .bg(Color::BLACK)
+                .error_correction(ErrorCorrection::Medium)
+                .quiet_zone(1);
+
+            Border::rounded().title("QR").child(qr)
+        } else {
+            Border::rounded().title("QR").child(
+                Text::new("Type a URL to generate QR code")
+                    .fg(Color::hex(0x666666))
+                    .align(Alignment::Center),
+            )
+        };
+
+        // Controls (border = 3 lines)
+        let controls = Border::single().title("Controls").child(
+            hstack()
+                .gap(3)
+                .child(Text::muted("[Tab] Style"))
+                .child(Text::muted("[Ctrl+U] Clear"))
+                .child(Text::muted("[Esc] Quit")),
+        );
+
+        let main = vstack()
+            .gap(1)
+            .child_sized(title, 1)
+            .child_sized(input, 3)
+            .child(qr_box) // auto: takes remaining space
+            .child_sized(controls, 3);
+
+        main.render(ctx);
+    }
+
+    fn meta(&self) -> WidgetMeta {
+        WidgetMeta::new("QrGenerator")
+    }
+}
+
+fn main() -> Result<()> {
+    let mut app = App::builder().build();
+    let generator = QrGenerator::new();
+
+    app.run(generator, |event, gen, app| match event {
+        Event::Key(key_event) => match key_event.key {
+            Key::Escape => {
+                app.quit();
+                false
+            }
+            _ => gen.handle_key(key_event),
+        },
+        Event::Paste(text) => {
+            let cur = gen.cursor.get();
+            gen.url.update(|s| s.insert_str(cur, text));
+            gen.cursor.update(|c| *c += text.len());
+            true
+        }
+        _ => false,
+    })
+}

--- a/examples/qrcode_showcase.rs
+++ b/examples/qrcode_showcase.rs
@@ -1,0 +1,115 @@
+//! QR Code Showcase - Google Drive Link
+//!
+//! Demonstrates the QrCodeWidget with different rendering styles.
+//!
+//! Run with: cargo run --example qrcode_showcase --features qrcode
+
+use revue::prelude::*;
+use revue::widget::{qrcode, ErrorCorrection, QrStyle};
+
+const DRIVE_URL: &str =
+    "https://drive.google.com/drive/folders/1iUx5K9AjN-LVa8X0A8RxV1RiscXHjgnC?usp=drive_link";
+
+struct QrShowcase {
+    current_style: Signal<usize>,
+}
+
+impl QrShowcase {
+    fn new() -> Self {
+        Self {
+            current_style: signal(0),
+        }
+    }
+
+    fn styles() -> &'static [(QrStyle, &'static str)] {
+        &[
+            (QrStyle::HalfBlock, "Half Block"),
+            (QrStyle::FullBlock, "Full Block"),
+            (QrStyle::Braille, "Braille"),
+            (QrStyle::Ascii, "ASCII"),
+        ]
+    }
+
+    fn next_style(&self) {
+        let len = Self::styles().len();
+        self.current_style.update(|v| *v = (*v + 1) % len);
+    }
+
+    fn prev_style(&self) {
+        let len = Self::styles().len();
+        self.current_style.update(|v| *v = (*v + len - 1) % len);
+    }
+
+    fn handle_key(&self, key: &Key) -> bool {
+        match key {
+            Key::Right | Key::Char('l') | Key::Tab => {
+                self.next_style();
+                true
+            }
+            Key::Left | Key::Char('h') => {
+                self.prev_style();
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+impl View for QrShowcase {
+    fn render(&self, ctx: &mut RenderContext) {
+        let idx = self.current_style.get();
+        let (style, style_name) = Self::styles()[idx];
+
+        let qr = qrcode(DRIVE_URL)
+            .style(style)
+            .fg(Color::WHITE)
+            .bg(Color::BLACK)
+            .error_correction(ErrorCorrection::Medium)
+            .quiet_zone(2);
+
+        // Header (1 line)
+        let title = Text::new(format!("QR Code Showcase [{}]", style_name))
+            .bold()
+            .fg(Color::CYAN)
+            .align(Alignment::Center);
+
+        // URL display (1 line)
+        let url_text = Text::new(DRIVE_URL)
+            .fg(Color::hex(0x888888))
+            .align(Alignment::Center);
+
+        // QR Code (auto = fills remaining space)
+        let qr_box = Border::rounded().title("QR").child(qr);
+
+        // Controls (border = 3 lines)
+        let controls = Border::single().title("Controls").child(
+            hstack()
+                .gap(3)
+                .child(Text::muted("[<-/->] Style"))
+                .child(Text::muted("[q/Esc] Quit")),
+        );
+
+        let view = vstack()
+            .gap(1)
+            .child_sized(title, 1)
+            .child_sized(url_text, 1)
+            .child(qr_box) // auto: takes remaining space
+            .child_sized(controls, 3);
+
+        view.render(ctx);
+    }
+
+    fn meta(&self) -> WidgetMeta {
+        WidgetMeta::new("QrShowcase")
+    }
+}
+
+fn main() -> Result<()> {
+    let mut app = App::builder().build();
+    let showcase = QrShowcase::new();
+
+    app.run(showcase, |event, showcase, _app| match event {
+        Event::Key(key_event) => showcase.handle_key(&key_event.key),
+        _ => false,
+    })
+}

--- a/src/runtime/style/parser/apply.rs
+++ b/src/runtime/style/parser/apply.rs
@@ -7,7 +7,8 @@ use crate::style::parser::value_parsers::{
 };
 use crate::style::Style;
 use crate::style::{
-    AlignItems, AlignSelf, BorderStyle, Display, FlexDirection, FlexWrap, JustifyContent, Position,
+    AlignItems, AlignSelf, BorderStyle, Display, FlexDirection, FlexWrap, FontWeight,
+    JustifyContent, Position, TextAlign, TextDecoration,
 };
 use std::collections::HashMap;
 
@@ -576,6 +577,36 @@ fn apply_visual(style: &mut Style, property: &str, value: &str) {
         }
         "visible" | "visibility" => {
             style.visual.visible = value != "hidden" && value != "false";
+        }
+        "text-align" => {
+            style.visual.text_align = match value {
+                "left" | "start" => TextAlign::Left,
+                "center" => TextAlign::Center,
+                "right" | "end" => TextAlign::Right,
+                _ => return,
+            };
+        }
+        "font-weight" => {
+            style.visual.font_weight = match value {
+                "bold" | "700" | "800" | "900" => FontWeight::Bold,
+                "normal" | "400" => FontWeight::Normal,
+                _ => return,
+            };
+        }
+        "text-decoration" | "text-decoration-line" => {
+            let mut decoration = TextDecoration::default();
+            for part in value.split_whitespace() {
+                match part {
+                    "underline" => decoration.underline = true,
+                    "line-through" => decoration.line_through = true,
+                    "none" => {
+                        decoration = TextDecoration::default();
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            style.visual.text_decoration = decoration;
         }
         _ => {} // Unknown property, ignore
     }

--- a/src/runtime/style/parser/mod.rs
+++ b/src/runtime/style/parser/mod.rs
@@ -18,7 +18,8 @@ pub use value_parsers::{
 mod tests {
     use super::*;
     use crate::style::{
-        AlignSelf, Color, Display, FlexDirection, FlexWrap, Position, Size, Spacing, Style,
+        AlignSelf, Color, Display, FlexDirection, FlexWrap, FontWeight, Position, Size, Spacing,
+        Style, TextAlign, VisualStyle,
     };
 
     #[test]
@@ -265,5 +266,99 @@ mod tests {
         let sheet = parse(css).unwrap();
         let style = sheet.apply(".container", &Style::default());
         assert_eq!(style.layout.gap, 8);
+    }
+
+    #[test]
+    fn test_apply_text_align() {
+        let css = ".centered { text-align: center; }";
+        let sheet = parse(css).unwrap();
+        let style = sheet.apply(".centered", &Style::default());
+        assert_eq!(style.visual.text_align, TextAlign::Center);
+    }
+
+    #[test]
+    fn test_apply_text_align_right() {
+        let css = ".right { text-align: right; }";
+        let sheet = parse(css).unwrap();
+        let style = sheet.apply(".right", &Style::default());
+        assert_eq!(style.visual.text_align, TextAlign::Right);
+    }
+
+    #[test]
+    fn test_apply_font_weight_bold() {
+        let css = ".bold { font-weight: bold; }";
+        let sheet = parse(css).unwrap();
+        let style = sheet.apply(".bold", &Style::default());
+        assert_eq!(style.visual.font_weight, FontWeight::Bold);
+    }
+
+    #[test]
+    fn test_apply_font_weight_700() {
+        let css = ".bold { font-weight: 700; }";
+        let sheet = parse(css).unwrap();
+        let style = sheet.apply(".bold", &Style::default());
+        assert_eq!(style.visual.font_weight, FontWeight::Bold);
+    }
+
+    #[test]
+    fn test_apply_text_decoration_underline() {
+        let css = ".underlined { text-decoration: underline; }";
+        let sheet = parse(css).unwrap();
+        let style = sheet.apply(".underlined", &Style::default());
+        assert!(style.visual.text_decoration.underline);
+        assert!(!style.visual.text_decoration.line_through);
+    }
+
+    #[test]
+    fn test_apply_text_decoration_line_through() {
+        let css = ".struck { text-decoration: line-through; }";
+        let sheet = parse(css).unwrap();
+        let style = sheet.apply(".struck", &Style::default());
+        assert!(!style.visual.text_decoration.underline);
+        assert!(style.visual.text_decoration.line_through);
+    }
+
+    #[test]
+    fn test_apply_text_decoration_combined() {
+        let css = ".both { text-decoration: underline line-through; }";
+        let sheet = parse(css).unwrap();
+        let style = sheet.apply(".both", &Style::default());
+        assert!(style.visual.text_decoration.underline);
+        assert!(style.visual.text_decoration.line_through);
+    }
+
+    #[test]
+    fn test_apply_text_decoration_none() {
+        let css = ".plain { text-decoration: none; }";
+        let sheet = parse(css).unwrap();
+        let style = sheet.apply(".plain", &Style::default());
+        assert!(!style.visual.text_decoration.underline);
+        assert!(!style.visual.text_decoration.line_through);
+    }
+
+    #[test]
+    fn test_text_align_inherited() {
+        let parent = Style {
+            visual: VisualStyle {
+                text_align: TextAlign::Center,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let child = Style::inherit(&parent);
+        assert_eq!(child.visual.text_align, TextAlign::Center);
+    }
+
+    #[test]
+    fn test_font_weight_inherited() {
+        let parent = Style {
+            visual: VisualStyle {
+                font_weight: FontWeight::Bold,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let child = Style::inherit(&parent);
+        assert_eq!(child.visual.font_weight, FontWeight::Bold);
     }
 }

--- a/src/runtime/style/properties/style.rs
+++ b/src/runtime/style/properties/style.rs
@@ -172,6 +172,18 @@ impl Style {
     pub fn z_index(&self) -> i16 {
         self.visual.z_index
     }
+    /// Text alignment - INHERITED
+    pub fn text_align(&self) -> TextAlign {
+        self.visual.text_align
+    }
+    /// Font weight - INHERITED
+    pub fn font_weight(&self) -> FontWeight {
+        self.visual.font_weight
+    }
+    /// Text decoration - non-inherited
+    pub fn text_decoration(&self) -> TextDecoration {
+        self.visual.text_decoration
+    }
 }
 
 impl Style {
@@ -181,6 +193,8 @@ impl Style {
     /// - `color` - text color
     /// - `opacity` - visual opacity
     /// - `visible` - visibility
+    /// - `text-align` - text alignment
+    /// - `font-weight` - font weight
     ///
     /// Non-inherited properties are reset to their defaults.
     pub fn inherit(parent: &Style) -> Self {
@@ -193,6 +207,8 @@ impl Style {
                 color: parent.visual.color,
                 opacity: parent.visual.opacity,
                 visible: parent.visual.visible,
+                text_align: parent.visual.text_align,
+                font_weight: parent.visual.font_weight,
                 // Non-inherited - use defaults
                 ..VisualStyle::default()
             },

--- a/src/runtime/style/properties/types.rs
+++ b/src/runtime/style/properties/types.rs
@@ -188,6 +188,36 @@ pub enum AlignSelf {
     Stretch,
 }
 
+/// Text alignment
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TextAlign {
+    /// Left-aligned (default)
+    #[default]
+    Left,
+    /// Centered
+    Center,
+    /// Right-aligned
+    Right,
+}
+
+/// Text decoration flags
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TextDecoration {
+    /// Underline text
+    pub underline: bool,
+    /// Strikethrough text
+    pub line_through: bool,
+}
+
+/// Font weight
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FontWeight {
+    /// Normal weight (default)
+    #[default]
+    Normal,
+    /// Bold weight
+    Bold,
+}
 /// Spacing values for padding and margin
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct Spacing {

--- a/src/runtime/style/properties/visual.rs
+++ b/src/runtime/style/properties/visual.rs
@@ -1,6 +1,6 @@
 //! Visual-related style property structures
 
-use super::types::{BorderStyle, Color};
+use super::types::{BorderStyle, Color, FontWeight, TextAlign, TextDecoration};
 
 /// Visual style properties
 ///
@@ -21,6 +21,12 @@ pub struct VisualStyle {
     pub visible: bool,
     /// Z-index for stacking order
     pub z_index: i16,
+    /// Text alignment (INHERITED)
+    pub text_align: TextAlign,
+    /// Font weight (INHERITED)
+    pub font_weight: FontWeight,
+    /// Text decoration (not inherited)
+    pub text_decoration: TextDecoration,
 }
 
 impl VisualStyle {
@@ -60,6 +66,9 @@ impl Default for VisualStyle {
             opacity: 1.0,
             visible: true,
             z_index: 0,
+            text_align: TextAlign::default(),
+            font_weight: FontWeight::default(),
+            text_decoration: TextDecoration::default(),
         }
     }
 }


### PR DESCRIPTION
## Summary
Add CSS text properties that map to terminal capabilities (Phase 1A of 9.5 roadmap).

Previously text/font CSS properties were 0% supported. This adds the 3 most impactful ones:

- `text-align: left | center | right` (inherited)
- `font-weight: normal | bold | 700-900` (inherited)
- `text-decoration: underline | line-through | none` (combinable)

## CSS Usage
```css
.header { text-align: center; font-weight: bold; }
.link { text-decoration: underline; }
.deleted { text-decoration: line-through; }
.fancy { text-decoration: underline line-through; }
```

## Changed Files
- `src/runtime/style/properties/types.rs` - Add TextAlign, FontWeight, TextDecoration types
- `src/runtime/style/properties/visual.rs` - Add fields to VisualStyle
- `src/runtime/style/properties/style.rs` - Add accessors + inheritance
- `src/runtime/style/parser/apply.rs` - Parse CSS declarations
- `src/runtime/style/parser/mod.rs` - 11 new tests

## Test plan
- [x] All 5238 lib tests pass (11 new)
- [x] `cargo clippy --all-features` clean
- [x] `cargo fmt` clean
- [x] Inheritance verified (text-align, font-weight)