### PR TITLE
feat(css): add overflow property

### DIFF
--- a/src/runtime/style/parser/apply.rs
+++ b/src/runtime/style/parser/apply.rs
@@ -626,6 +626,15 @@ fn apply_visual(style: &mut Style, property: &str, value: &str) {
             }
             style.visual.text_decoration = decoration;
         }
+        "overflow" | "overflow-x" | "overflow-y" => {
+            style.visual.overflow = match value {
+                "visible" => crate::style::Overflow::Visible,
+                "hidden" => crate::style::Overflow::Hidden,
+                "scroll" => crate::style::Overflow::Scroll,
+                "auto" => crate::style::Overflow::Auto,
+                _ => return,
+            };
+        }
         _ => {} // Unknown property, ignore
     }
 }

--- a/src/runtime/style/parser/mod.rs
+++ b/src/runtime/style/parser/mod.rs
@@ -18,8 +18,8 @@ pub use value_parsers::{
 mod tests {
     use super::*;
     use crate::style::{
-        AlignSelf, Color, Display, FlexDirection, FlexWrap, FontWeight, Position, Size, Spacing,
-        Style, TextAlign, VisualStyle,
+        AlignSelf, Color, Display, FlexDirection, FlexWrap, FontWeight, Overflow, Position, Size,
+        Spacing, Style, TextAlign, VisualStyle,
     };
 
     #[test]
@@ -462,5 +462,43 @@ mod tests {
         let sheet = parse(css).unwrap();
         let style = sheet.apply(".text", &Style::default());
         assert_eq!(style.visual.color, Color::CYAN);
+    }
+
+    #[test]
+    fn test_overflow_hidden() {
+        let css = ".box { overflow: hidden; }";
+        let sheet = parse(css).unwrap();
+        let style = sheet.apply(".box", &Style::default());
+        assert_eq!(style.visual.overflow, Overflow::Hidden);
+    }
+
+    #[test]
+    fn test_overflow_scroll() {
+        let css = ".box { overflow: scroll; }";
+        let sheet = parse(css).unwrap();
+        let style = sheet.apply(".box", &Style::default());
+        assert_eq!(style.visual.overflow, Overflow::Scroll);
+    }
+
+    #[test]
+    fn test_overflow_auto() {
+        let css = ".box { overflow: auto; }";
+        let sheet = parse(css).unwrap();
+        let style = sheet.apply(".box", &Style::default());
+        assert_eq!(style.visual.overflow, Overflow::Auto);
+    }
+
+    #[test]
+    fn test_overflow_visible() {
+        let css = ".box { overflow: visible; }";
+        let sheet = parse(css).unwrap();
+        let style = sheet.apply(".box", &Style::default());
+        assert_eq!(style.visual.overflow, Overflow::Visible);
+    }
+
+    #[test]
+    fn test_overflow_default() {
+        let style = Style::default();
+        assert_eq!(style.visual.overflow, Overflow::Visible);
     }
 }

--- a/src/runtime/style/properties/style.rs
+++ b/src/runtime/style/properties/style.rs
@@ -184,6 +184,10 @@ impl Style {
     pub fn text_decoration(&self) -> TextDecoration {
         self.visual.text_decoration
     }
+    /// Overflow behavior - non-inherited
+    pub fn overflow(&self) -> Overflow {
+        self.visual.overflow
+    }
 }
 
 impl Style {

--- a/src/runtime/style/properties/types.rs
+++ b/src/runtime/style/properties/types.rs
@@ -146,6 +146,20 @@ pub enum JustifyContent {
     SpaceAround,
 }
 
+/// Overflow behavior
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Overflow {
+    /// Content is visible outside the box (default)
+    #[default]
+    Visible,
+    /// Content is clipped to the box
+    Hidden,
+    /// Content is scrollable if it overflows
+    Scroll,
+    /// Browser decides (scroll if needed)
+    Auto,
+}
+
 /// Cross axis alignment for flexbox
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum AlignItems {

--- a/src/runtime/style/properties/visual.rs
+++ b/src/runtime/style/properties/visual.rs
@@ -1,6 +1,6 @@
 //! Visual-related style property structures
 
-use super::types::{BorderStyle, Color, FontWeight, TextAlign, TextDecoration};
+use super::types::{BorderStyle, Color, FontWeight, Overflow, TextAlign, TextDecoration};
 
 /// Visual style properties
 ///
@@ -27,6 +27,8 @@ pub struct VisualStyle {
     pub font_weight: FontWeight,
     /// Text decoration (not inherited)
     pub text_decoration: TextDecoration,
+    /// Overflow behavior
+    pub overflow: Overflow,
 }
 
 impl VisualStyle {
@@ -42,10 +44,6 @@ impl VisualStyle {
 }
 
 /// Apply opacity to a cell modifier. Returns true if the cell should be visible.
-/// - opacity <= 0.0: invisible
-/// - opacity < 0.5: invisible
-/// - opacity < 1.0: add DIM modifier
-/// - opacity >= 1.0: no change
 pub fn apply_opacity(opacity: f32, modifier: &mut crate::render::Modifier) -> bool {
     if opacity <= 0.0 || opacity < 0.5 {
         return false;
@@ -69,6 +67,7 @@ impl Default for VisualStyle {
             text_align: TextAlign::default(),
             font_weight: FontWeight::default(),
             text_decoration: TextDecoration::default(),
+            overflow: Overflow::default(),
         }
     }
 }
@@ -132,10 +131,8 @@ mod tests {
     #[test]
     fn test_visual_style_default_values() {
         let style = VisualStyle::default();
-        // Check inherited property defaults
         assert_eq!(style.opacity, 1.0);
         assert_eq!(style.visible, true);
-        // Check non-inherited property defaults
         assert_eq!(style.z_index, 0);
     }
 }


### PR DESCRIPTION
## Summary (Phase 1C of 9.5 roadmap)

Add CSS overflow property for content clipping control.

```css
.container { overflow: hidden; }   /* clip content */
.scroll-area { overflow: scroll; } /* always show scrollbar */
.smart { overflow: auto; }         /* scroll when needed */
```

## Changed Files
- `types.rs` - Add Overflow enum
- `visual.rs` - Add overflow field to VisualStyle
- `style.rs` - Add accessor
- `apply.rs` - Parse overflow, overflow-x, overflow-y
- `mod.rs` - 5 new tests

## Test plan
- [x] All 5233 tests pass
- [x] `cargo clippy --all-features` clean