### PR TITLE
perf(style): eliminate Vec clone in selector cache hot path

### DIFF
--- a/src/runtime/dom/renderer/style.rs
+++ b/src/runtime/dom/renderer/style.rs
@@ -5,10 +5,9 @@ use crate::dom::{DomId, DomNode, StyleResolver};
 use crate::style::Style;
 
 impl DomRenderer {
-    /// Get or create cached parsed selectors
-    pub(crate) fn get_cached_selectors(&mut self) -> &Vec<(crate::dom::Selector, usize)> {
+    /// Ensure selector cache is populated (parse once, reuse everywhere)
+    fn ensure_selectors_cached(&mut self) {
         if self.cached_selectors.is_none() {
-            // Parse all selectors and cache them
             let mut selectors = Vec::new();
             for (idx, rule) in self.stylesheet.rules.iter().enumerate() {
                 if let Ok(selector) = crate::dom::parse_selector(&rule.selector) {
@@ -17,7 +16,6 @@ impl DomRenderer {
             }
             self.cached_selectors = Some(selectors);
         }
-        self.cached_selectors.as_ref().unwrap()
     }
 
     /// Get computed style for a node (without inheritance)
@@ -27,16 +25,12 @@ impl DomRenderer {
             return Some(style.clone());
         }
 
-        // Get cached selectors (parsed once, reused across all nodes)
-        // Clone the cached selectors to end the mutable borrow before creating resolver
-        let cached_selectors: Vec<_> = self.get_cached_selectors().clone();
+        // Ensure selectors are cached before borrowing fields separately
+        self.ensure_selectors_cached();
+        let cached = self.cached_selectors.as_ref().unwrap();
 
-        // Create resolver with cached selectors (avoids reparsing)
-        let mut resolver =
-            StyleResolver::with_cached_selectors(&self.stylesheet, &cached_selectors);
+        let mut resolver = StyleResolver::with_cached_selectors(&self.stylesheet, cached);
         let node = self.tree.get(node_id)?;
-
-        // Create closure for node lookup
         let get_node = |id: DomId| -> Option<&DomNode> { self.tree.get(id) };
 
         let style = resolver.compute_style(node, get_node);
@@ -64,16 +58,12 @@ impl DomRenderer {
         // Now get parent style from cache
         let parent_style = parent_id.and_then(|pid| self.styles.get(&pid).cloned());
 
-        // Get cached selectors (parsed once, reused across all nodes)
-        // Clone the cached selectors to end the mutable borrow before creating resolver
-        let cached_selectors: Vec<_> = self.get_cached_selectors().clone();
+        // Ensure selectors are cached before borrowing fields separately
+        self.ensure_selectors_cached();
+        let cached = self.cached_selectors.as_ref().unwrap();
 
-        // Create resolver with cached selectors (avoids reparsing)
-        let mut resolver =
-            StyleResolver::with_cached_selectors(&self.stylesheet, &cached_selectors);
+        let mut resolver = StyleResolver::with_cached_selectors(&self.stylesheet, cached);
         let node = self.tree.get(node_id)?;
-
-        // Create closure for node lookup
         let get_node = |id: DomId| -> Option<&DomNode> { self.tree.get(id) };
 
         let style = resolver.compute_style_with_parent(node, parent_style.as_ref(), get_node);


### PR DESCRIPTION
## Summary (Phase 2B of 9.5 roadmap)

Eliminate unnecessary `Vec::clone()` in the style computation hot path.

**Before**: Every `style_for()` / `style_for_with_inheritance()` call did `get_cached_selectors().clone()` which allocated a full copy of the parsed selector cache (Vec of Selector + rule index pairs). With 100+ CSS rules and 100+ DOM nodes, this was thousands of unnecessary allocations per frame.

**After**: `ensure_selectors_cached()` populates the cache once, then `self.cached_selectors.as_ref().unwrap()` borrows it directly — zero allocation.

## Changed Files
- `src/runtime/dom/renderer/style.rs` - Replace clone pattern with direct borrow, remove unused `get_cached_selectors()`

## Test plan
- [x] All 5228 tests pass
- [x] `cargo clippy --all-features` clean