### PR TITLE
fix: replace production unwrap() calls with safe alternatives

### DIFF
--- a/src/widget/developer/code_editor/editing.rs
+++ b/src/widget/developer/code_editor/editing.rs
@@ -107,12 +107,10 @@ impl super::CodeEditor {
 
             // Check if we should add extra indent (after opening bracket)
             let trimmed = current_line.trim_end();
-            let extra_indent = if !trimmed.is_empty() {
-                let last_char = trimmed.chars().last().unwrap();
-                matches!(last_char, '{' | '[' | '(' | ':')
-            } else {
-                false
-            };
+            let extra_indent = trimmed
+                .chars()
+                .last()
+                .is_some_and(|c| matches!(c, '{' | '[' | '(' | ':'));
 
             let base = leading_ws;
             if extra_indent {

--- a/src/widget/developer/terminal/ansi.rs
+++ b/src/widget/developer/terminal/ansi.rs
@@ -112,7 +112,7 @@ impl AnsiParser {
             },
             ParserState::Csi => {
                 if ch.is_ascii_digit() {
-                    let digit = ch.to_digit(10).unwrap() as u16;
+                    let digit = ch.to_digit(10).unwrap_or(0) as u16;
                     self.current_param = Some(
                         self.current_param
                             .unwrap_or(0)

--- a/src/widget/layout/sidebar/state.rs
+++ b/src/widget/layout/sidebar/state.rs
@@ -141,8 +141,8 @@ impl SidebarState for super::Sidebar {
             if current_pos > 0 {
                 self.hovered = item_indices[current_pos - 1];
             }
-        } else if !item_indices.is_empty() {
-            self.hovered = *item_indices.last().unwrap();
+        } else if let Some(&last) = item_indices.last() {
+            self.hovered = last;
         }
     }
 


### PR DESCRIPTION
## Summary (Phase 3A of 9.5 roadmap)

Replace the remaining production-code `unwrap()` calls that could panic on unexpected input:

- `ansi.rs`: `to_digit(10).unwrap()` → `unwrap_or(0)` (malformed ANSI escape)
- `editing.rs`: `chars().last().unwrap()` → `is_some_and()` (empty string edge case)
- `sidebar/state.rs`: `.last().unwrap()` → `if let Some(&last)` (empty indices)

Test-code unwraps (inside `#[cfg(test)]` blocks) are intentionally kept — they provide clear failure messages in tests.

## Test plan
- [x] All 5228 tests pass
- [x] `cargo clippy --all-features` clean