### PR TITLE
docs: update CSS documentation with new properties and features

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -210,13 +210,15 @@ cssparser           selectors      specificity  inheritance
 
 | Category | Properties |
 |----------|------------|
-| Layout | `display`, `flex-direction`, `flex-wrap`, `justify-content`, `align-items`, `gap` |
-| Spacing | `padding`, `margin`, `width`, `height`, `min-*`, `max-*` |
-| Border | `border`, `border-style`, `border-color` |
-| Colors | `color`, `background`, `background-color` |
-| Text | `text-align`, `text-wrap`, `font-weight` |
-| Visual | `opacity`, `visibility` |
-| Animation | `transition`, `transition-duration`, `transition-property` |
+| Layout | `display`, `position`, `flex-direction`, `flex-wrap`, `flex-grow`, `flex`, `justify-content`, `align-items`, `align-self`, `order`, `gap`, `column-gap`, `row-gap` |
+| Spacing | `padding`, `margin`, `width`, `height`, `min-*`, `max-*`, `top`, `right`, `bottom`, `left` |
+| Border | `border` (shorthand), `border-style`, `border-color` |
+| Colors | `color`, `background` — formats: hex, rgb, hsl/hsla, 50+ named colors, `transparent` |
+| Text | `text-align`, `font-weight`, `text-decoration` |
+| Visual | `opacity`, `visibility`, `overflow`, `z-index` |
+| Variables | `:root { --name: value; }`, `var(--name)`, `var(--name, fallback)` |
+| Selectors | `:nth-child(odd/even/An+B)`, `:focus`, `:hover`, `:disabled`, `:not()` |
+| Animation | `transition`, `@keyframes`, animation shorthand |
 
 ### 3. Reactive Layer (`src/reactive/`)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -101,13 +101,65 @@ text {
 | `height` | same as width | `height: 10;` |
 | `min-width` | same as width | `min-width: 20;` |
 | `max-width` | same as width | `max-width: 100;` |
-| `border` | `<style> <color>` | `border: solid cyan;` |
+| `flex-grow` | `<number>` | `flex-grow: 1;` |
+| `flex` | `<grow>` | `flex: 2;` |
+| `flex-wrap` | `nowrap`, `wrap`, `wrap-reverse` | `flex-wrap: wrap;` |
+| `align-self` | `auto`, `start`, `center`, `end`, `stretch` | `align-self: center;` |
+| `order` | `<integer>` | `order: -1;` |
+| `column-gap` | `<number>` | `column-gap: 2;` |
+| `row-gap` | `<number>` | `row-gap: 1;` |
+| `border` | `<style> [color]` | `border: solid cyan;` |
 | `border-style` | `none`, `solid`, `dashed`, `double`, `rounded` | `border-style: rounded;` |
+| `border-color` | `<color>` | `border-color: red;` |
 | `color` | `<color>` | `color: #ff0000;` |
 | `background` | `<color>` | `background: blue;` |
 | `opacity` | `0.0` - `1.0` | `opacity: 0.5;` |
 | `visibility` | `visible`, `hidden` | `visibility: hidden;` |
+| `overflow` | `visible`, `hidden`, `scroll`, `auto` | `overflow: hidden;` |
 | `text-align` | `left`, `center`, `right` | `text-align: center;` |
+| `font-weight` | `normal`, `bold`, `700`-`900` | `font-weight: bold;` |
+| `text-decoration` | `none`, `underline`, `line-through` | `text-decoration: underline;` |
+| `z-index` | `<integer>` | `z-index: 10;` |
+| `position` | `static`, `relative`, `absolute`, `fixed` | `position: absolute;` |
+| `top`, `right`, `bottom`, `left` | `<number>` | `top: 5;` |
+
+### Color Formats
+
+| Format | Example |
+|--------|---------|
+| Hex (6-digit) | `color: #ff0000;` |
+| Hex (3-digit) | `color: #f00;` |
+| RGB | `color: rgb(255, 0, 0);` |
+| HSL | `color: hsl(0, 100%, 50%);` |
+| HSLA | `color: hsla(120, 100%, 50%, 0.5);` |
+| Named (basic) | `color: red;` `blue;` `cyan;` `magenta;` |
+| Named (extended) | `color: orange;` `rebeccapurple;` `teal;` `coral;` |
+| Transparent | `color: transparent;` |
+
+50+ CSS named colors supported including: orange, coral, salmon, pink, hotpink, deeppink, purple, rebeccapurple, indigo, violet, gold, lime, olive, teal, navy, royalblue, dodgerblue, skyblue, brown, maroon, crimson, gray/grey, silver, and more.
+
+### CSS Variables with Fallback
+
+```css
+:root {
+    --primary: #3b82f6;
+}
+.button {
+    color: var(--primary);
+    background: var(--accent, orange);  /* fallback if undefined */
+}
+```
+
+### Selectors
+
+Supports `:nth-child()` with full An+B formula syntax:
+
+```css
+tr:nth-child(odd) { background: #333; }
+tr:nth-child(even) { background: #222; }
+li:nth-child(3n+1) { color: cyan; }
+li:nth-child(-n+3) { font-weight: bold; }  /* first 3 items */
+```
 
 ### Transitions
 

--- a/docs/FRAMEWORK_COMPARISON.md
+++ b/docs/FRAMEWORK_COMPARISON.md
@@ -134,8 +134,9 @@
 | Feature | Revue | Textual | Ratatui | Cursive |
 |---------|-------|---------|---------|---------|
 | CSS Files | ✅ | ✅ TCSS | ❌ | ❌ |
-| CSS Variables | ✅ | ✅ | ❌ | ❌ |
-| CSS Selectors | ✅ (partial) | ✅ (full) | ❌ | ❌ |
+| CSS Variables | ✅ (with fallback) | ✅ | ❌ | ❌ |
+| CSS Selectors | ✅ (pseudo-classes, An+B, combinators) | ✅ (full) | ❌ | ❌ |
+| Color Formats | ✅ hex, rgb, hsl, 50+ named | ✅ | ❌ | ❌ |
 | Theme System | ✅ | ✅ | ❌ | ✅ TOML |
 | Inline Styles | ✅ | ✅ | ✅ | ✅ |
 | Hot Reload | ✅ | ✅ | ❌ | ❌ |

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -49,7 +49,7 @@
 
 | Crate | Version | Purpose | Used By |
 |-------|---------|---------|---------|
-| **crossterm** | 0.28 | Terminal I/O, events | Render, Event |
+| **crossterm** | 0.29 | Terminal I/O, events | Render, Event |
 | **tokio** | 1.x | Async runtime | Runtime |
 
 ### CSS & Layout

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -158,7 +158,15 @@ renderer.build_incremental(&widget);
 
 ### Dirty Rect Optimization
 
-Only re-render changed regions:
+Revue automatically tracks dirty regions and only re-renders what changed. When a widget's state changes, only the affected screen area is updated — unchanged pixels are preserved from the previous frame.
+
+This happens transparently without requiring user code changes:
+
+- **No dirty regions**: Previous buffer is reused (zero rendering work)
+- **Partial dirty**: Old buffer copied, only dirty regions cleared and re-rendered
+- **Full screen dirty**: Falls back to full clear (e.g., on resize)
+
+The selector cache is also optimized — parsed selectors are cached once and referenced without copying, eliminating per-node Vec allocations during style computation.
 
 ```rust
 // Transitions track affected nodes

--- a/docs/guides/styling.md
+++ b/docs/guides/styling.md
@@ -57,14 +57,18 @@ Button::new("Submit")
 
 ```css
 .widget {
-    color: cyan;              /* Named color */
-    color: #7aa2f7;           /* Hex color */
-    color: rgb(122, 162, 247); /* RGB */
+    color: cyan;                    /* Named color */
+    color: #7aa2f7;                 /* Hex color */
+    color: #f00;                    /* Short hex */
+    color: rgb(122, 162, 247);      /* RGB */
+    color: hsl(220, 90%, 72%);      /* HSL */
+    color: hsla(120, 100%, 50%, 1); /* HSLA */
+    color: transparent;             /* Transparent */
     background: #1a1b26;
 }
 ```
 
-Built-in colors: `red`, `green`, `blue`, `cyan`, `magenta`, `yellow`, `white`, `black`
+50+ CSS named colors: `red`, `green`, `blue`, `cyan`, `magenta`, `yellow`, `white`, `black`, `orange`, `coral`, `salmon`, `pink`, `hotpink`, `deeppink`, `purple`, `rebeccapurple`, `indigo`, `violet`, `gold`, `lime`, `olive`, `teal`, `navy`, `royalblue`, `dodgerblue`, `skyblue`, `brown`, `maroon`, `crimson`, `gray`/`grey`, `silver`, and more.
 
 ### Text Styling
 
@@ -109,6 +113,17 @@ Built-in colors: `red`, `green`, `blue`, `cyan`, `magenta`, `yellow`, `white`, `
     flex-direction: column;  /* column, row */
     align-items: center;     /* start, center, end, stretch */
     justify-content: center; /* start, center, end, space-between */
+    flex-wrap: wrap;         /* nowrap, wrap, wrap-reverse */
+    gap: 1;                  /* space between children */
+    column-gap: 2;           /* grid column gap */
+    row-gap: 1;              /* grid row gap */
+}
+
+.item {
+    flex: 1;                 /* shorthand for flex-grow */
+    align-self: center;      /* override parent align-items */
+    order: -1;               /* render order (lower = first) */
+    overflow: hidden;        /* visible, hidden, scroll, auto */
 }
 ```
 
@@ -131,8 +146,10 @@ Define reusable values:
     color: var(--fg-primary);
 }
 
-Button.primary {
-    background: var(--accent);
+/* Fallback values for undefined variables */
+.button {
+    background: var(--accent, orange);  /* uses orange if --accent undefined */
+    color: var(--text, white);
 }
 ```
 
@@ -157,6 +174,12 @@ List-item:selected {
     background: var(--accent);
     color: var(--bg-primary);
 }
+
+/* Structural pseudo-classes with An+B formula */
+tr:nth-child(odd) { background: #2a2a3a; }
+tr:nth-child(even) { background: #1e1e2e; }
+li:nth-child(3n+1) { color: cyan; }
+li:nth-child(-n+3) { font-weight: bold; }  /* first 3 items */
 ```
 
 ## Transitions


### PR DESCRIPTION
## Summary
Sync documentation with recently added CSS features.

### Updated Files
- **FEATURES.md**: +11 CSS properties, color formats table, var() fallback, nth-child selectors
- **guides/styling.md**: HSL colors, 50+ named colors, flex-wrap/align-self/order/overflow, var() fallback, nth-child examples
- **ARCHITECTURE.md**: Complete CSS properties table with variables, selectors, animation

### What was outdated
- Only 8 basic named colors documented (now 50+)
- No HSL/HSLA color documentation
- No var() fallback syntax
- Missing flex-wrap, align-self, order, overflow, z-index, position offsets
- No nth-child formula examples (odd/even/An+B)
- Architecture table was incomplete

## Test plan
- [x] No code changes, docs only