### PR TITLE
feat(render): implement overflow clipping in RenderContext

### DIFF
--- a/src/widget/traits/render_context/mod.rs
+++ b/src/widget/traits/render_context/mod.rs
@@ -35,6 +35,11 @@ pub struct RenderContext<'a> {
     transitions: Option<&'a std::collections::HashMap<String, f32>>,
     /// Overlay queue for floating content (dropdowns, tooltips, toasts)
     overlays: Option<&'a mut OverlayQueue>,
+    /// Clipping region for overflow: hidden (absolute coordinates)
+    ///
+    /// When set, all drawing operations are clipped to this rectangle.
+    /// Content outside this area is not rendered.
+    clip: Option<Rect>,
 }
 
 impl<'a> RenderContext<'a> {
@@ -47,6 +52,7 @@ impl<'a> RenderContext<'a> {
             state: None,
             transitions: None,
             overlays: None,
+            clip: None,
         }
     }
 
@@ -59,6 +65,7 @@ impl<'a> RenderContext<'a> {
             state: None,
             transitions: None,
             overlays: None,
+            clip: None,
         }
     }
 
@@ -76,6 +83,7 @@ impl<'a> RenderContext<'a> {
             state: Some(state),
             transitions: None,
             overlays: None,
+            clip: None,
         }
     }
 
@@ -143,6 +151,34 @@ impl<'a> RenderContext<'a> {
     /// Check if disabled
     pub fn is_disabled(&self) -> bool {
         self.state.map(|s| s.disabled).unwrap_or(false)
+    }
+
+    /// Set a clipping region (absolute coordinates)
+    ///
+    /// When a clipping region is set, all drawing operations (`set`, `put_str`, etc.)
+    /// will be restricted to this rectangle. Content outside is silently discarded.
+    /// Used by containers with `overflow: hidden`.
+    pub fn with_clip(mut self, clip: Rect) -> Self {
+        self.clip = Some(clip);
+        self
+    }
+
+    /// Get the current clipping region
+    pub fn clip(&self) -> Option<Rect> {
+        self.clip
+    }
+
+    /// Check if an absolute coordinate is within the clipping region
+    #[inline]
+    pub fn is_clipped(&self, abs_x: u16, abs_y: u16) -> bool {
+        if let Some(clip) = &self.clip {
+            abs_x < clip.x
+                || abs_y < clip.y
+                || abs_x >= clip.x.saturating_add(clip.width)
+                || abs_y >= clip.y.saturating_add(clip.height)
+        } else {
+            false
+        }
     }
 
     /// Create a child `Rect` from relative position and size.

--- a/src/widget/traits/render_context/relative.rs
+++ b/src/widget/traits/render_context/relative.rs
@@ -19,35 +19,37 @@ impl super::RenderContext<'_> {
     }
 
     /// Set a cell at relative position (0,0 = area top-left)
+    ///
+    /// Respects the clipping region set by `overflow: hidden`.
     pub fn set(&mut self, x: u16, y: u16, cell: Cell) {
         if x < self.area.width && y < self.area.height {
-            self.buffer.set(
-                self.area.x.saturating_add(x),
-                self.area.y.saturating_add(y),
-                cell,
-            );
+            let abs_x = self.area.x.saturating_add(x);
+            let abs_y = self.area.y.saturating_add(y);
+            if !self.is_clipped(abs_x, abs_y) {
+                self.buffer.set(abs_x, abs_y, cell);
+            }
         }
     }
 
     /// Set foreground color at relative position
     pub fn set_fg(&mut self, x: u16, y: u16, fg: Color) {
         if x < self.area.width && y < self.area.height {
-            self.buffer.set_fg(
-                self.area.x.saturating_add(x),
-                self.area.y.saturating_add(y),
-                fg,
-            );
+            let abs_x = self.area.x.saturating_add(x);
+            let abs_y = self.area.y.saturating_add(y);
+            if !self.is_clipped(abs_x, abs_y) {
+                self.buffer.set_fg(abs_x, abs_y, fg);
+            }
         }
     }
 
     /// Set background color at relative position
     pub fn set_bg(&mut self, x: u16, y: u16, bg: Color) {
         if x < self.area.width && y < self.area.height {
-            self.buffer.set_bg(
-                self.area.x.saturating_add(x),
-                self.area.y.saturating_add(y),
-                bg,
-            );
+            let abs_x = self.area.x.saturating_add(x);
+            let abs_y = self.area.y.saturating_add(y);
+            if !self.is_clipped(abs_x, abs_y) {
+                self.buffer.set_bg(abs_x, abs_y, bg);
+            }
         }
     }
 
@@ -73,6 +75,8 @@ impl super::RenderContext<'_> {
 
     /// Put a string at relative position, handling wide characters.
     /// Returns the number of columns written.
+    ///
+    /// Respects the clipping region set by `overflow: hidden`.
     pub fn put_str(&mut self, x: u16, y: u16, s: &str) -> u16 {
         if y >= self.area.height {
             return 0;
@@ -91,9 +95,13 @@ impl super::RenderContext<'_> {
             if cx.saturating_add(w) > max_x {
                 break;
             }
-            self.buffer.set(cx, abs_y, Cell::new(ch));
-            for i in 1..w {
-                self.buffer.set(cx + i, abs_y, Cell::continuation());
+            if !self.is_clipped(cx, abs_y) {
+                self.buffer.set(cx, abs_y, Cell::new(ch));
+                for i in 1..w {
+                    if !self.is_clipped(cx + i, abs_y) {
+                        self.buffer.set(cx + i, abs_y, Cell::continuation());
+                    }
+                }
             }
             offset = offset.saturating_add(w);
         }

--- a/src/widget/traits/render_context/tests.rs
+++ b/src/widget/traits/render_context/tests.rs
@@ -1248,3 +1248,92 @@ fn test_fill_bg_with_offset() {
     // Outside the fill area should be untouched
     assert_eq!(buffer.get(8, 3).unwrap().bg, None);
 }
+
+// =========================================================================
+// Clipping (overflow: hidden) tests
+// =========================================================================
+
+#[test]
+fn test_clip_none_allows_all() {
+    let mut buffer = test_buffer();
+    let area = Rect::new(2, 2, 10, 5);
+    {
+        let mut ctx = RenderContext::new(&mut buffer, area);
+        assert!(ctx.clip().is_none());
+        ctx.set(0, 0, crate::render::Cell::new('A'));
+    }
+    assert_eq!(buffer.get(2, 2).unwrap().symbol, 'A');
+}
+
+#[test]
+fn test_clip_blocks_outside() {
+    let mut buffer = test_buffer();
+    let area = Rect::new(0, 0, 20, 10);
+    {
+        let mut ctx = RenderContext::new(&mut buffer, area).with_clip(Rect::new(2, 2, 5, 3));
+        ctx.set(3, 3, crate::render::Cell::new('Y'));
+        ctx.set(0, 0, crate::render::Cell::new('N'));
+    }
+    assert_eq!(buffer.get(3, 3).unwrap().symbol, 'Y');
+    assert_eq!(buffer.get(0, 0).unwrap().symbol, ' ');
+}
+
+#[test]
+fn test_clip_boundary() {
+    let mut buffer = test_buffer();
+    let area = Rect::new(0, 0, 20, 10);
+    {
+        let mut ctx = RenderContext::new(&mut buffer, area).with_clip(Rect::new(5, 5, 3, 2));
+        ctx.set(5, 5, crate::render::Cell::new('S'));
+        ctx.set(8, 5, crate::render::Cell::new('E'));
+        ctx.set(7, 6, crate::render::Cell::new('I'));
+    }
+    assert_eq!(buffer.get(5, 5).unwrap().symbol, 'S');
+    assert_eq!(buffer.get(8, 5).unwrap().symbol, ' ');
+    assert_eq!(buffer.get(7, 6).unwrap().symbol, 'I');
+}
+
+#[test]
+fn test_clip_put_str() {
+    let mut buffer = test_buffer();
+    let area = Rect::new(0, 0, 20, 10);
+    {
+        let mut ctx = RenderContext::new(&mut buffer, area).with_clip(Rect::new(2, 0, 5, 10));
+        ctx.put_str(0, 0, "ABCDEFGH");
+    }
+    assert_eq!(buffer.get(0, 0).unwrap().symbol, ' ');
+    assert_eq!(buffer.get(1, 0).unwrap().symbol, ' ');
+    assert_eq!(buffer.get(2, 0).unwrap().symbol, 'C');
+    assert_eq!(buffer.get(6, 0).unwrap().symbol, 'G');
+    assert_eq!(buffer.get(7, 0).unwrap().symbol, ' ');
+}
+
+#[test]
+fn test_clip_set_fg_bg() {
+    let mut buffer = test_buffer();
+    let area = Rect::new(0, 0, 20, 10);
+    {
+        let mut ctx = RenderContext::new(&mut buffer, area).with_clip(Rect::new(5, 5, 3, 3));
+        ctx.set_fg(5, 5, Color::RED);
+        ctx.set_fg(0, 0, Color::BLUE);
+        ctx.set_bg(6, 6, Color::GREEN);
+        ctx.set_bg(0, 0, Color::YELLOW);
+    }
+    assert_eq!(buffer.get(5, 5).unwrap().fg, Some(Color::RED));
+    assert_eq!(buffer.get(0, 0).unwrap().fg, None);
+    assert_eq!(buffer.get(6, 6).unwrap().bg, Some(Color::GREEN));
+    assert_eq!(buffer.get(0, 0).unwrap().bg, None);
+}
+
+#[test]
+fn test_is_clipped() {
+    let mut buffer = test_buffer();
+    let area = Rect::new(0, 0, 20, 10);
+    let ctx = RenderContext::new(&mut buffer, area).with_clip(Rect::new(5, 5, 3, 3));
+    assert!(ctx.is_clipped(0, 0));
+    assert!(ctx.is_clipped(4, 5));
+    assert!(!ctx.is_clipped(5, 5));
+    assert!(!ctx.is_clipped(7, 7));
+    assert!(ctx.is_clipped(8, 5));
+    assert!(ctx.is_clipped(5, 8));
+}


### PR DESCRIPTION
## Summary

Make `overflow: hidden` actually work by adding clipping support to RenderContext.

**Before**: overflow CSS property was parsed and stored but completely ignored during rendering
**After**: Containers can set `ctx.with_clip(area)` to prevent child content from rendering outside bounds

### API
```rust
// Container with overflow: hidden
let mut child_ctx = RenderContext::new(ctx.buffer, child_area)
    .with_clip(container_area);  // clip to container bounds
child.render(&mut child_ctx);

// All set/put_str/set_fg/set_bg calls respect the clip region
```

### Implementation
- `clip: Option<Rect>` field on RenderContext
- `with_clip()`, `clip()`, `is_clipped()` methods
- Clipping enforced in `set()`, `set_fg()`, `set_bg()`, `put_str()`
- Zero overhead when no clip is set (Option::is_none fast path)
- 6 new tests

## Test plan
- [x] All 5432 tests pass (6 new)
- [x] `cargo clippy --all-features` clean
- [x] Backward compatible (clip defaults to None)