### PR TITLE
refactor(widget): extract shared dropdown rendering logic

### DIFF
--- a/src/widget/input/input_widgets/combobox/render.rs
+++ b/src/widget/input/input_widgets/combobox/render.rs
@@ -1,7 +1,10 @@
 //! View implementation for Combobox
 
+use super::super::dropdown::{
+    calculate_dropdown_layout, queue_or_inline_overlay, render_options, render_status_row,
+    DropdownColors, DropdownOption,
+};
 use super::super::Combobox;
-use crate::widget::theme::MAX_DROPDOWN_VISIBLE;
 
 /// Render the combobox widget
 pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::RenderContext) {
@@ -84,154 +87,105 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
         return;
     }
 
-    let visible_count = combobox.max_visible.min(MAX_DROPDOWN_VISIBLE as usize);
+    let visible_count = combobox.max_visible.min(
+        crate::widget::theme::MAX_DROPDOWN_VISIBLE as usize,
+    );
 
-    // Calculate overlay position, flip above if near bottom
-    let (abs_x, abs_y) = ctx.absolute_position();
+    let colors = DropdownColors {
+        fg: combobox.fg,
+        bg: combobox.bg,
+        selected_fg: combobox.selected_fg,
+        selected_bg: combobox.selected_bg,
+        highlight_fg: combobox.highlight_fg,
+        disabled_fg: combobox.disabled_fg,
+    };
+
+    // Calculate dropdown height, accounting for scroll offset
+    let items_after_scroll = combobox
+        .filtered
+        .len()
+        .saturating_sub(combobox.scroll_offset);
     let dropdown_h = if combobox.loading || combobox.filtered.is_empty() {
         1u16
     } else {
-        (combobox
-            .filtered
-            .len()
-            .saturating_sub(combobox.scroll_offset)
-            .min(visible_count) as u16)
-            .max(1)
+        (items_after_scroll.min(visible_count) as u16).max(1)
     };
-    let buf_height = ctx.buffer.height();
-    let space_below = buf_height.saturating_sub(abs_y + 1);
-    let overlay_y = if space_below >= dropdown_h {
-        abs_y + 1
-    } else {
-        abs_y.saturating_sub(dropdown_h)
-    };
-    let overlay_area = crate::layout::Rect::new(abs_x, overlay_y, width, dropdown_h);
+
+    // Position the overlay
+    let layout = calculate_dropdown_layout(ctx, dropdown_h);
+    let (abs_x, _) = ctx.absolute_position();
+    let overlay_area = crate::layout::Rect::new(abs_x, layout.overlay_y, width, dropdown_h);
     let mut entry = crate::widget::traits::OverlayEntry::new(100, overlay_area);
 
     // Loading state
     if combobox.loading {
-        for x in 0..width {
-            let mut cell = crate::render::Cell::new(' ');
-            cell.fg = combobox.fg;
-            cell.bg = combobox.bg;
-            entry.push(x, 0, cell);
-        }
-        let loading_truncated = crate::utils::truncate_to_width(&combobox.loading_text, text_width);
-        let mut cx: u16 = 1;
-        for ch in loading_truncated.chars() {
-            let mut cell = crate::render::Cell::new(ch);
-            cell.fg = combobox.disabled_fg;
-            cell.bg = combobox.bg;
-            entry.push(cx, 0, cell);
-            cx += crate::utils::char_width(ch) as u16;
-        }
-        if !ctx.queue_overlay(entry.clone()) {
-            for oc in &entry.cells {
-                ctx.set(oc.x, oc.y + 1, oc.cell);
-            }
-        }
+        render_status_row(
+            &mut entry,
+            &combobox.loading_text,
+            width,
+            combobox.fg,
+            combobox.bg,
+            combobox.disabled_fg,
+        );
+        queue_or_inline_overlay(ctx, entry);
         return;
     }
 
     // Empty state
     if combobox.filtered.is_empty() {
-        for x in 0..width {
-            let mut cell = crate::render::Cell::new(' ');
-            cell.fg = combobox.fg;
-            cell.bg = combobox.bg;
-            entry.push(x, 0, cell);
-        }
-        let empty_truncated = crate::utils::truncate_to_width(&combobox.empty_text, text_width);
-        let mut cx: u16 = 1;
-        for ch in empty_truncated.chars() {
-            let mut cell = crate::render::Cell::new(ch);
-            cell.fg = combobox.disabled_fg;
-            cell.bg = combobox.bg;
-            entry.push(cx, 0, cell);
-            cx += crate::utils::char_width(ch) as u16;
-        }
-        if !ctx.queue_overlay(entry.clone()) {
-            for oc in &entry.cells {
-                ctx.set(oc.x, oc.y + 1, oc.cell);
-            }
-        }
+        render_status_row(
+            &mut entry,
+            &combobox.empty_text,
+            width,
+            combobox.fg,
+            combobox.bg,
+            combobox.disabled_fg,
+        );
+        queue_or_inline_overlay(ctx, entry);
         return;
     }
 
-    // Render visible options
-    for (row, &option_idx) in combobox
+    // Build option descriptors
+    let dropdown_options: Vec<DropdownOption<'_>> = combobox
         .filtered
         .iter()
         .skip(combobox.scroll_offset)
         .take(visible_count)
         .enumerate()
-    {
-        let y = row as u16;
-        let option = &combobox.options[option_idx];
-        let is_highlighted = row + combobox.scroll_offset == combobox.selected_idx;
-        let is_multi_selected = combobox.multi_select && combobox.is_selected(option.get_value());
+        .map(|(row, &option_idx)| {
+            let option = &combobox.options[option_idx];
+            let is_highlighted = row + combobox.scroll_offset == combobox.selected_idx;
+            let is_multi_selected =
+                combobox.multi_select && combobox.is_selected(option.get_value());
 
-        let (fg, bg) = if is_highlighted {
-            (combobox.selected_fg, combobox.selected_bg)
-        } else {
-            (combobox.fg, combobox.bg)
-        };
-
-        let fg = if option.disabled {
-            combobox.disabled_fg
-        } else {
-            fg
-        };
-
-        // Draw background
-        for x in 0..width {
-            let mut cell = crate::render::Cell::new(' ');
-            cell.fg = fg;
-            cell.bg = bg;
-            entry.push(x, y, cell);
-        }
-
-        // Draw selection indicator
-        if combobox.multi_select {
-            let indicator = if is_multi_selected { '☑' } else { '☐' };
-            let mut cell = crate::render::Cell::new(indicator);
-            cell.fg = fg;
-            cell.bg = bg;
-            entry.push(0, y, cell);
-        } else {
-            let indicator = if is_highlighted { '›' } else { ' ' };
-            let mut cell = crate::render::Cell::new(indicator);
-            cell.fg = fg;
-            cell.bg = bg;
-            entry.push(0, y, cell);
-        }
-
-        // Get match indices for highlighting (HashSet for O(1) lookup)
-        let match_indices: std::collections::HashSet<usize> = combobox
-            .get_match(&option.label)
-            .map(|m| m.indices.into_iter().collect())
-            .unwrap_or_default();
-
-        // Draw option text with highlighting
-        let truncated =
-            crate::utils::truncate_to_width(&option.label, text_width.saturating_sub(1));
-        let mut cx: u16 = 2;
-        for (j, ch) in truncated.chars().enumerate() {
-            let mut cell = crate::render::Cell::new(ch);
-            cell.bg = bg;
-
-            if option.disabled {
-                cell.fg = combobox.disabled_fg;
-            } else if match_indices.contains(&j) {
-                cell.fg = combobox.highlight_fg;
+            let indicator = if combobox.multi_select {
+                if is_multi_selected {
+                    '☑'
+                } else {
+                    '☐'
+                }
+            } else if is_highlighted {
+                '›'
             } else {
-                cell.fg = fg;
-            }
+                ' '
+            };
 
-            entry.push(cx, y, cell);
-            cx += crate::utils::char_width(ch) as u16;
-        }
-    }
+            let match_indices: std::collections::HashSet<usize> = combobox
+                .get_match(&option.label)
+                .map(|m| m.indices.into_iter().collect())
+                .unwrap_or_default();
+
+            DropdownOption {
+                label: &option.label,
+                is_highlighted,
+                is_disabled: option.disabled,
+                match_indices,
+                indicator,
+            }
+        })
+        .collect();
+
+    render_options(&mut entry, &dropdown_options, width, &colors);
 
     // Draw scroll indicators
     let total_filtered = combobox.filtered.len();
@@ -250,10 +204,5 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
         }
     }
 
-    // Queue as overlay; fallback to inline
-    if !ctx.queue_overlay(entry.clone()) {
-        for oc in &entry.cells {
-            ctx.set(oc.x, oc.y + 1, oc.cell);
-        }
-    }
+    queue_or_inline_overlay(ctx, entry);
 }

--- a/src/widget/input/input_widgets/combobox/render.rs
+++ b/src/widget/input/input_widgets/combobox/render.rs
@@ -87,9 +87,9 @@ pub fn render_combobox(combobox: &Combobox, ctx: &mut crate::widget::traits::Ren
         return;
     }
 
-    let visible_count = combobox.max_visible.min(
-        crate::widget::theme::MAX_DROPDOWN_VISIBLE as usize,
-    );
+    let visible_count = combobox
+        .max_visible
+        .min(crate::widget::theme::MAX_DROPDOWN_VISIBLE as usize);
 
     let colors = DropdownColors {
         fg: combobox.fg,

--- a/src/widget/input/input_widgets/dropdown.rs
+++ b/src/widget/input/input_widgets/dropdown.rs
@@ -1,0 +1,177 @@
+//! Shared dropdown rendering helpers for Combobox and Select widgets
+//!
+//! Extracts common overlay positioning, option rendering, and overlay queuing
+//! logic to eliminate duplication between dropdown-style widgets.
+
+use crate::render::Cell;
+use crate::style::Color;
+use crate::widget::theme::MAX_DROPDOWN_VISIBLE;
+use crate::widget::traits::{OverlayEntry, RenderContext};
+
+/// Calculated overlay position and dimensions for a dropdown
+pub struct DropdownLayout {
+    /// Absolute Y coordinate for the overlay
+    pub overlay_y: u16,
+    /// Height of the dropdown in rows
+    pub height: u16,
+}
+
+/// Calculate dropdown overlay position, flipping above the anchor if
+/// there isn't enough space below.
+pub fn calculate_dropdown_layout(ctx: &RenderContext, dropdown_height: u16) -> DropdownLayout {
+    let (_, abs_y) = ctx.absolute_position();
+    let buf_height = ctx.buffer.height();
+    let space_below = buf_height.saturating_sub(abs_y + 1);
+    let overlay_y = if space_below >= dropdown_height {
+        abs_y + 1
+    } else {
+        abs_y.saturating_sub(dropdown_height)
+    };
+    DropdownLayout {
+        overlay_y,
+        height: dropdown_height,
+    }
+}
+
+/// Calculate the visible dropdown height from a count of items and an
+/// optional per-widget cap.
+pub fn dropdown_height(item_count: usize, max_visible: Option<usize>) -> u16 {
+    if item_count == 0 {
+        return 1; // room for "No results" / loading row
+    }
+    let cap = max_visible
+        .map(|mv| mv.min(MAX_DROPDOWN_VISIBLE as usize))
+        .unwrap_or(MAX_DROPDOWN_VISIBLE as usize);
+    (item_count.min(cap) as u16).max(1)
+}
+
+/// A single option to be rendered in the dropdown.
+pub struct DropdownOption<'a> {
+    /// Display text for this option
+    pub label: &'a str,
+    /// Whether this option is currently highlighted/selected
+    pub is_highlighted: bool,
+    /// Whether this option is disabled (grayed out)
+    pub is_disabled: bool,
+    /// Character indices that matched the search query (for highlighting)
+    pub match_indices: std::collections::HashSet<usize>,
+    /// Leading indicator character (e.g. '›', '☑', '☐', ' ')
+    pub indicator: char,
+}
+
+/// Colors used for dropdown rendering.
+pub struct DropdownColors {
+    /// Default foreground
+    pub fg: Option<Color>,
+    /// Default background
+    pub bg: Option<Color>,
+    /// Foreground for highlighted/selected option
+    pub selected_fg: Option<Color>,
+    /// Background for highlighted/selected option
+    pub selected_bg: Option<Color>,
+    /// Foreground for fuzzy-match highlighted characters
+    pub highlight_fg: Option<Color>,
+    /// Foreground for disabled options
+    pub disabled_fg: Option<Color>,
+}
+
+/// Render a status row (loading / empty) into the overlay entry.
+pub fn render_status_row(
+    entry: &mut OverlayEntry,
+    text: &str,
+    width: u16,
+    fg: Option<Color>,
+    bg: Option<Color>,
+    text_fg: Option<Color>,
+) {
+    let text_width = (width - 2) as usize;
+    // Background
+    for x in 0..width {
+        let mut cell = Cell::new(' ');
+        cell.fg = fg;
+        cell.bg = bg;
+        entry.push(x, 0, cell);
+    }
+    // Text
+    let truncated = crate::utils::truncate_to_width(text, text_width);
+    let mut cx: u16 = 1;
+    for ch in truncated.chars() {
+        let mut cell = Cell::new(ch);
+        cell.fg = text_fg;
+        cell.bg = bg;
+        entry.push(cx, 0, cell);
+        cx += crate::utils::char_width(ch) as u16;
+    }
+}
+
+/// Render a list of options into an overlay entry.
+///
+/// Each option gets: background fill, indicator character, label with
+/// fuzzy-match highlighting.
+pub fn render_options(
+    entry: &mut OverlayEntry,
+    options: &[DropdownOption<'_>],
+    width: u16,
+    colors: &DropdownColors,
+) {
+    let text_width = (width - 2) as usize;
+
+    for (row, opt) in options.iter().enumerate() {
+        let y = row as u16;
+
+        let (fg, bg) = if opt.is_highlighted {
+            (colors.selected_fg, colors.selected_bg)
+        } else {
+            (colors.fg, colors.bg)
+        };
+
+        let fg = if opt.is_disabled {
+            colors.disabled_fg
+        } else {
+            fg
+        };
+
+        // Background
+        for x in 0..width {
+            let mut cell = Cell::new(' ');
+            cell.fg = fg;
+            cell.bg = bg;
+            entry.push(x, y, cell);
+        }
+
+        // Indicator
+        let mut cell = Cell::new(opt.indicator);
+        cell.fg = fg;
+        cell.bg = bg;
+        entry.push(0, y, cell);
+
+        // Label with match highlighting
+        let truncated = crate::utils::truncate_to_width(opt.label, text_width.saturating_sub(1));
+        let mut cx: u16 = 2;
+        for (j, ch) in truncated.chars().enumerate() {
+            let mut cell = Cell::new(ch);
+            cell.bg = bg;
+
+            if opt.is_disabled {
+                cell.fg = colors.disabled_fg;
+            } else if opt.match_indices.contains(&j) {
+                cell.fg = colors.highlight_fg;
+            } else {
+                cell.fg = fg;
+            }
+
+            entry.push(cx, y, cell);
+            cx += crate::utils::char_width(ch) as u16;
+        }
+    }
+}
+
+/// Queue an overlay entry, falling back to inline rendering if the
+/// overlay system is unavailable.
+pub fn queue_or_inline_overlay(ctx: &mut RenderContext, entry: OverlayEntry) {
+    if !ctx.queue_overlay(entry.clone()) {
+        for oc in &entry.cells {
+            ctx.set(oc.x, oc.y + 1, oc.cell);
+        }
+    }
+}

--- a/src/widget/input/input_widgets/mod.rs
+++ b/src/widget/input/input_widgets/mod.rs
@@ -106,11 +106,11 @@
 //! ```
 
 pub mod autocomplete;
-pub mod dropdown;
 pub mod button;
 pub mod checkbox;
 pub mod color_picker;
 pub mod combobox;
+pub mod dropdown;
 pub mod input;
 pub mod number_input;
 pub mod radio;

--- a/src/widget/input/input_widgets/mod.rs
+++ b/src/widget/input/input_widgets/mod.rs
@@ -106,6 +106,7 @@
 //! ```
 
 pub mod autocomplete;
+pub mod dropdown;
 pub mod button;
 pub mod checkbox;
 pub mod color_picker;

--- a/src/widget/input/input_widgets/select/render.rs
+++ b/src/widget/input/input_widgets/select/render.rs
@@ -3,9 +3,13 @@
 use crate::render::Cell;
 use crate::style::Color;
 use crate::utils::truncate_to_width;
-use crate::widget::theme::{MAX_DROPDOWN_VISIBLE, PLACEHOLDER_FG};
+use crate::widget::theme::PLACEHOLDER_FG;
 use crate::widget::traits::{RenderContext, View};
 
+use super::super::dropdown::{
+    calculate_dropdown_layout, dropdown_height, queue_or_inline_overlay, render_options,
+    render_status_row, DropdownColors, DropdownOption,
+};
 use super::Select;
 
 impl View for Select {
@@ -30,7 +34,6 @@ impl View for Select {
 
         // Render the closed/header row
         let display_text = if self.open && self.searchable && !self.query.is_empty() {
-            // Show search query when searching
             &self.query
         } else {
             self.value().unwrap_or(&self.placeholder)
@@ -67,109 +70,76 @@ impl View for Select {
             cx += crate::utils::char_width(ch) as u16;
         }
 
-        // If open, render dropdown options as overlay (escapes parent clipping)
-        if self.open {
-            // Determine which options to show
-            let visible_options: Vec<(usize, &String)> = if self.query.is_empty() {
-                self.options.iter().enumerate().collect()
-            } else {
-                self.filtered
-                    .iter()
-                    .filter_map(|&i| self.options.get(i).map(|opt| (i, opt)))
-                    .collect()
-            };
+        // If open, render dropdown options as overlay
+        if !self.open {
+            return;
+        }
 
-            // Calculate dropdown height (limited to 10 or option count)
-            let dropdown_height = if visible_options.is_empty() {
-                1u16 // "No results" row
-            } else {
-                (visible_options.len() as u16).min(MAX_DROPDOWN_VISIBLE)
-            };
-
-            // Calculate absolute position for overlay, flip above if near bottom
-            let (abs_x, abs_y) = ctx.absolute_position();
-            let buf_height = ctx.buffer.height();
-            let space_below = buf_height.saturating_sub(abs_y + 1);
-            let overlay_y = if space_below >= dropdown_height {
-                abs_y + 1 // Render below
-            } else {
-                abs_y.saturating_sub(dropdown_height) // Render above
-            };
-            let overlay_area = crate::layout::Rect::new(abs_x, overlay_y, width, dropdown_height);
-
-            let mut entry = crate::widget::traits::OverlayEntry::new(100, overlay_area);
-
-            if visible_options.is_empty() && !self.query.is_empty() {
-                // "No results" message
-                let msg = "No results";
-                for (i, ch) in msg.chars().enumerate() {
-                    let mut cell = Cell::new(ch);
-                    cell.fg = Some(PLACEHOLDER_FG);
-                    entry.push(2 + i as u16, 0, cell);
-                }
-            }
-
-            for (row, (option_idx, option)) in visible_options
+        // Determine which options to show
+        let visible_options: Vec<(usize, &String)> = if self.query.is_empty() {
+            self.options.iter().enumerate().collect()
+        } else {
+            self.filtered
                 .iter()
-                .enumerate()
-                .take(dropdown_height as usize)
-            {
-                let y = row as u16;
+                .filter_map(|&i| self.options.get(i).map(|opt| (i, opt)))
+                .collect()
+        };
+
+        let dropdown_h = dropdown_height(visible_options.len(), None);
+
+        let layout = calculate_dropdown_layout(ctx, dropdown_h);
+        let (abs_x, _) = ctx.absolute_position();
+        let overlay_area = crate::layout::Rect::new(abs_x, layout.overlay_y, width, dropdown_h);
+        let mut entry = crate::widget::traits::OverlayEntry::new(100, overlay_area);
+
+        // Empty state
+        if visible_options.is_empty() && !self.query.is_empty() {
+            render_status_row(
+                &mut entry,
+                "No results",
+                width,
+                self.fg,
+                self.bg,
+                Some(PLACEHOLDER_FG),
+            );
+            queue_or_inline_overlay(ctx, entry);
+            return;
+        }
+
+        let colors = DropdownColors {
+            fg: self.fg,
+            bg: self.bg,
+            selected_fg: self.selected_fg,
+            selected_bg: self.selected_bg,
+            highlight_fg: self.highlight_fg,
+            disabled_fg: None,
+        };
+
+        // Build option descriptors
+        let dropdown_options: Vec<DropdownOption<'_>> = visible_options
+            .iter()
+            .take(dropdown_h as usize)
+            .map(|(option_idx, option)| {
                 let is_selected = self.selection.is_selected(*option_idx);
-
-                let (fg, bg) = if is_selected {
-                    (self.selected_fg, self.selected_bg)
-                } else {
-                    (self.fg, self.bg)
-                };
-
-                // Draw background
-                for x in 0..width {
-                    let mut cell = Cell::new(' ');
-                    cell.fg = fg;
-                    cell.bg = bg;
-                    entry.push(x, y, cell);
-                }
-
-                // Draw selection indicator
                 let indicator = if is_selected { '›' } else { ' ' };
-                let mut cell = Cell::new(indicator);
-                cell.fg = fg;
-                cell.bg = bg;
-                entry.push(0, y, cell);
 
-                // Get fuzzy match indices for highlighting (HashSet for O(1) lookup)
                 let match_indices: std::collections::HashSet<usize> = self
                     .get_match(option)
                     .map(|m| m.indices.into_iter().collect())
                     .unwrap_or_default();
 
-                // Draw option text with highlighting
-                let truncated = truncate_to_width(option, text_width);
-                let mut cx: u16 = 2;
-                for (j, ch) in truncated.chars().enumerate() {
-                    let mut cell = Cell::new(ch);
-                    cell.bg = bg;
-
-                    if match_indices.contains(&j) {
-                        cell.fg = self.highlight_fg;
-                    } else {
-                        cell.fg = fg;
-                    }
-
-                    entry.push(cx, y, cell);
-                    cx += crate::utils::char_width(ch) as u16;
+                DropdownOption {
+                    label: option.as_str(),
+                    is_highlighted: is_selected,
+                    is_disabled: false,
+                    match_indices,
+                    indicator,
                 }
-            }
+            })
+            .collect();
 
-            // Queue as overlay; falls back to inline if no overlay support
-            if !ctx.queue_overlay(entry.clone()) {
-                // Fallback: render inline (clipped by parent)
-                for oc in &entry.cells {
-                    ctx.set(oc.x, oc.y + 1, oc.cell);
-                }
-            }
-        }
+        render_options(&mut entry, &dropdown_options, width, &colors);
+        queue_or_inline_overlay(ctx, entry);
     }
 
     crate::impl_view_meta!("Select");


### PR DESCRIPTION
## Summary
- Extract common dropdown overlay positioning, option rendering, and overlay queuing logic from Combobox and Select into a shared `dropdown` module
- New helpers: `DropdownLayout`, `DropdownColors`, `DropdownOption`, `calculate_dropdown_layout()`, `dropdown_height()`, `render_options()`, `render_status_row()`, `queue_or_inline_overlay()`

## Test plan
- [x] All 5464 lib tests pass
- [x] Clippy clean with `--all-features`
- [x] No behavioral changes — pure refactor

Closes #564