### PR TITLE
refactor(style): replace Color::rgb() magic values with named constants

### DIFF
--- a/src/core/app/inspector.rs
+++ b/src/core/app/inspector.rs
@@ -3,7 +3,7 @@
 use crate::layout::Rect;
 use crate::render::Cell;
 use crate::style::Color;
-use crate::widget::theme::DARK_GRAY;
+use crate::widget::theme::{DARK_GRAY, EDITOR_BG, MUTED_TEXT};
 use crate::widget::{RenderContext, View};
 
 /// Tree rendering state
@@ -103,7 +103,7 @@ impl Inspector {
             panel_width: 40,
             show_bounds: true,
             highlight_color: Color::CYAN,
-            bg_color: Color::rgb(30, 30, 30),
+            bg_color: EDITOR_BG,
         }
     }
 
@@ -379,7 +379,7 @@ impl Inspector {
         );
         for (i, ch) in bounds_text.chars().take(max_width as usize).enumerate() {
             let mut cell = Cell::new(ch);
-            cell.fg = Some(Color::rgb(180, 180, 180));
+            cell.fg = Some(MUTED_TEXT);
             cell.bg = Some(self.bg_color);
             ctx.buffer.set(x + i as u16, y, cell);
         }
@@ -394,7 +394,7 @@ impl Inspector {
             let prop_text = format!("{}: {}", key, value);
             for (i, ch) in prop_text.chars().take(max_width as usize).enumerate() {
                 let mut cell = Cell::new(ch);
-                cell.fg = Some(Color::rgb(180, 180, 180));
+                cell.fg = Some(MUTED_TEXT);
                 cell.bg = Some(self.bg_color);
                 ctx.buffer.set(x + i as u16, y, cell);
             }

--- a/src/devtools/events/types.rs
+++ b/src/devtools/events/types.rs
@@ -1,6 +1,7 @@
 //! Event types
 
 use crate::style::Color;
+use crate::widget::theme::MUTED_TEXT;
 use std::time::{Duration, Instant};
 
 /// Event type for logging
@@ -62,7 +63,7 @@ impl EventType {
         match self {
             Self::KeyPress | Self::KeyRelease => Color::rgb(130, 180, 255),
             Self::MouseClick => Color::rgb(255, 180, 130),
-            Self::MouseMove => Color::rgb(180, 180, 180),
+            Self::MouseMove => MUTED_TEXT,
             Self::MouseScroll => Color::rgb(180, 255, 180),
             Self::FocusIn | Self::FocusOut => Color::rgb(255, 220, 130),
             Self::Resize => Color::rgb(200, 130, 255),

--- a/src/devtools/profiler/types.rs
+++ b/src/devtools/profiler/types.rs
@@ -137,7 +137,7 @@ impl RenderReason {
             Self::StateChange => Color::rgb(100, 150, 220),   // Blue
             Self::PropsChange => Color::rgb(220, 180, 100),   // Yellow
             Self::ContextChange => Color::rgb(180, 100, 220), // Purple
-            Self::ParentRender => MUTED_TEXT,  // Gray
+            Self::ParentRender => MUTED_TEXT,                 // Gray
             Self::ForceUpdate => Color::rgb(220, 100, 100),   // Red
         }
     }

--- a/src/devtools/profiler/types.rs
+++ b/src/devtools/profiler/types.rs
@@ -1,6 +1,7 @@
 //! Profiler types
 
 use crate::style::Color;
+use crate::widget::theme::MUTED_TEXT;
 use std::time::{Duration, Instant};
 
 /// Profiler view mode
@@ -136,7 +137,7 @@ impl RenderReason {
             Self::StateChange => Color::rgb(100, 150, 220),   // Blue
             Self::PropsChange => Color::rgb(220, 180, 100),   // Yellow
             Self::ContextChange => Color::rgb(180, 100, 220), // Purple
-            Self::ParentRender => Color::rgb(180, 180, 180),  // Gray
+            Self::ParentRender => MUTED_TEXT,  // Gray
             Self::ForceUpdate => Color::rgb(220, 100, 100),   // Red
         }
     }

--- a/src/runtime/style/theme.rs
+++ b/src/runtime/style/theme.rs
@@ -25,6 +25,7 @@
 
 use super::properties::Color;
 use crate::utils::lock::{read_or_recover, write_or_recover};
+use crate::widget::theme::{EDITOR_BG, SECONDARY_TEXT};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
@@ -135,7 +136,7 @@ impl ThemeColors {
     pub fn dark() -> Self {
         Self {
             background: Color::rgb(18, 18, 18),
-            surface: Color::rgb(30, 30, 30),
+            surface: EDITOR_BG,
             text: Color::rgb(255, 255, 255),
             text_muted: Color::rgb(158, 158, 158),
             border: Color::rgb(66, 66, 66),
@@ -167,7 +168,7 @@ impl ThemeColors {
             background: Color::BLACK,
             surface: Color::BLACK,
             text: Color::WHITE,
-            text_muted: Color::rgb(200, 200, 200),
+            text_muted: SECONDARY_TEXT,
             border: Color::WHITE,
             divider: Color::WHITE,
             selection: Color::YELLOW,

--- a/src/widget/callout/view.rs
+++ b/src/widget/callout/view.rs
@@ -4,6 +4,7 @@ use super::core::Callout;
 use super::types::CalloutVariant;
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::widget::theme::{MUTED_TEXT, SECONDARY_TEXT};
 use crate::widget::traits::{RenderContext, View};
 use unicode_width::UnicodeWidthChar;
 
@@ -127,7 +128,7 @@ impl Callout {
                         break;
                     }
                     let mut cell = Cell::new(ch);
-                    cell.fg = Some(Color::rgb(200, 200, 200));
+                    cell.fg = Some(SECONDARY_TEXT);
                     cell.bg = Some(bg_color);
                     ctx.set(content_x + offset, line_y, cell);
                     for i in 1..char_width {
@@ -211,7 +212,7 @@ impl Callout {
                         break;
                     }
                     let mut cell = Cell::new(ch);
-                    cell.fg = Some(Color::rgb(180, 180, 180));
+                    cell.fg = Some(MUTED_TEXT);
                     ctx.set(content_x + offset, line_y, cell);
                     for i in 1..char_width {
                         ctx.set(content_x + offset + i, line_y, Cell::continuation());
@@ -289,7 +290,7 @@ impl Callout {
                         break;
                     }
                     let mut cell = Cell::new(ch);
-                    cell.fg = Some(Color::rgb(180, 180, 180));
+                    cell.fg = Some(MUTED_TEXT);
                     ctx.set(content_x + offset, line_y, cell);
                     for i in 1..char_width {
                         ctx.set(content_x + offset + i, line_y, Cell::continuation());

--- a/src/widget/command_palette/impls.rs
+++ b/src/widget/command_palette/impls.rs
@@ -1,7 +1,7 @@
 use super::{command::Command, core::CommandPalette};
 use crate::style::Color;
 use crate::utils::{fuzzy_match, Selection};
-use crate::widget::theme::DARK_GRAY;
+use crate::widget::theme::{DARK_GRAY, EDITOR_BG};
 use crate::widget::traits::WidgetProps;
 
 impl CommandPalette {
@@ -22,7 +22,7 @@ impl CommandPalette {
             show_descriptions: true,
             show_shortcuts: true,
             show_icons: true,
-            bg_color: Color::rgb(30, 30, 30),
+            bg_color: EDITOR_BG,
             border_color: DARK_GRAY,
             selected_bg: Color::rgb(50, 80, 120),
             match_color: Color::YELLOW,

--- a/src/widget/data/chart/candlechart.rs
+++ b/src/widget/data/chart/candlechart.rs
@@ -20,7 +20,7 @@
 //! ```
 
 use crate::style::Color;
-use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY, PLACEHOLDER_FG};
+use crate::widget::theme::{DARK_BG, DISABLED_FG, EDITOR_BG, LIGHT_GRAY, MUTED_TEXT, PLACEHOLDER_FG, SEPARATOR_COLOR};
 use crate::widget::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -309,7 +309,7 @@ impl CandleChart {
 
     /// Render a single candle column
     fn render_candle(&self, candle: &Candle, min: f64, max: f64) -> Vec<(char, Color)> {
-        let mut column = vec![(' ', Color::rgb(40, 40, 40)); self.height as usize];
+        let mut column = vec![(' ', DARK_BG); self.height as usize];
 
         let high_row = self.price_to_row(candle.high, min, max);
         let low_row = self.price_to_row(candle.low, min, max);
@@ -557,7 +557,7 @@ impl View for CandleChart {
 
             if max_vol > 0.0 {
                 content =
-                    content.child(Text::new("─".repeat(candles.len())).fg(Color::rgb(60, 60, 60)));
+                    content.child(Text::new("─".repeat(candles.len())).fg(SEPARATOR_COLOR));
 
                 for row in 0..self.volume_height {
                     let mut vol_line = hstack();
@@ -579,7 +579,7 @@ impl View for CandleChart {
                             };
                             ('█', color)
                         } else {
-                            (' ', Color::rgb(30, 30, 30))
+                            (' ', EDITOR_BG)
                         };
 
                         vol_line = vol_line.child(Text::new(ch.to_string()).fg(color));
@@ -605,7 +605,7 @@ impl View for CandleChart {
                         .unwrap_or_default(),
                     prec = self.precision
                 );
-                content = content.child(Text::new(info).fg(Color::rgb(180, 180, 180)));
+                content = content.child(Text::new(info).fg(MUTED_TEXT));
             }
         }
 

--- a/src/widget/data/chart/candlechart.rs
+++ b/src/widget/data/chart/candlechart.rs
@@ -20,7 +20,9 @@
 //! ```
 
 use crate::style::Color;
-use crate::widget::theme::{DARK_BG, DISABLED_FG, EDITOR_BG, LIGHT_GRAY, MUTED_TEXT, PLACEHOLDER_FG, SEPARATOR_COLOR};
+use crate::widget::theme::{
+    DARK_BG, DISABLED_FG, EDITOR_BG, LIGHT_GRAY, MUTED_TEXT, PLACEHOLDER_FG, SEPARATOR_COLOR,
+};
 use crate::widget::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -556,8 +558,7 @@ impl View for CandleChart {
                 .fold(0.0f64, f64::max);
 
             if max_vol > 0.0 {
-                content =
-                    content.child(Text::new("─".repeat(candles.len())).fg(SEPARATOR_COLOR));
+                content = content.child(Text::new("─".repeat(candles.len())).fg(SEPARATOR_COLOR));
 
                 for row in 0..self.volume_height {
                     let mut vol_line = hstack();

--- a/src/widget/data/chart/chart_common/grid.rs
+++ b/src/widget/data/chart/chart_common/grid.rs
@@ -1,4 +1,5 @@
 use crate::style::Color;
+use crate::widget::theme::SEPARATOR_COLOR;
 
 /// Grid configuration
 #[derive(Clone, Debug, Default)]
@@ -81,7 +82,7 @@ impl ChartGrid {
 
     /// Get the effective color (default if not set)
     pub fn effective_color(&self) -> Color {
-        self.color.unwrap_or(Color::rgb(60, 60, 60))
+        self.color.unwrap_or(SEPARATOR_COLOR)
     }
 }
 

--- a/src/widget/data/chart/timeseries/mod.rs
+++ b/src/widget/data/chart/timeseries/mod.rs
@@ -13,6 +13,7 @@ pub use types::{
 };
 
 use crate::style::Color;
+use crate::widget::theme::SEPARATOR_COLOR;
 use crate::widget::traits::WidgetProps;
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -72,7 +73,7 @@ impl TimeSeries {
             y_max: None,
             markers: Vec::new(),
             bg_color: None,
-            grid_color: Color::rgb(60, 60, 60),
+            grid_color: SEPARATOR_COLOR,
             height: None,
             props: WidgetProps::new(),
         }

--- a/src/widget/data/timeline.rs
+++ b/src/widget/data/timeline.rs
@@ -5,7 +5,7 @@
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::utils::{char_width, display_width, truncate_to_width};
-use crate::widget::theme::{DARK_GRAY, LIGHT_GRAY};
+use crate::widget::theme::{DARK_GRAY, LIGHT_GRAY, MUTED_TEXT};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -199,7 +199,7 @@ impl Timeline {
             line_color: DARK_GRAY,
             timestamp_color: LIGHT_GRAY,
             title_color: Color::WHITE,
-            desc_color: Color::rgb(180, 180, 180),
+            desc_color: MUTED_TEXT,
             props: WidgetProps::new(),
         }
     }

--- a/src/widget/data/timer/mod.rs
+++ b/src/widget/data/timer/mod.rs
@@ -19,7 +19,7 @@
 //! ```
 
 use crate::style::Color;
-use crate::widget::theme::{LIGHT_GRAY, PLACEHOLDER_FG};
+use crate::widget::theme::{LIGHT_GRAY, MUTED_TEXT, PLACEHOLDER_FG};
 use crate::widget::traits::WidgetProps;
 use crate::widget::{RenderContext, View};
 use crate::{impl_props_builders, impl_styled_view};
@@ -591,7 +591,7 @@ impl View for Stopwatch {
 
         // Lap times
         if self.show_laps && !self.laps.is_empty() {
-            content = content.child(Text::new("Laps:").fg(Color::rgb(180, 180, 180)));
+            content = content.child(Text::new("Laps:").fg(MUTED_TEXT));
 
             let start = self.laps.len().saturating_sub(self.max_laps);
             for (i, &lap_ms) in self.laps.iter().skip(start).enumerate() {

--- a/src/widget/data/virtuallist/core.rs
+++ b/src/widget/data/virtuallist/core.rs
@@ -1,6 +1,7 @@
 use super::types::*;
 use crate::render::Cell;
 use crate::style::Color;
+use crate::widget::theme::DARK_BG;
 use crate::widget::traits::{RenderContext, WidgetProps};
 use std::ops::Range;
 
@@ -64,7 +65,7 @@ impl<T: ToString + Clone> VirtualList<T> {
             item_fg: Color::WHITE,
             show_scrollbar: true,
             scrollbar_fg: Color::WHITE,
-            scrollbar_bg: Color::rgb(40, 40, 40),
+            scrollbar_bg: DARK_BG,
             renderer: None,
             overscan: 2,
             wrap_navigation: false,

--- a/src/widget/debug_overlay/mod.rs
+++ b/src/widget/debug_overlay/mod.rs
@@ -30,6 +30,7 @@ use crate::layout::Rect;
 use crate::render::Buffer;
 use crate::style::Color;
 use crate::utils::draw_text_overlay;
+use crate::widget::theme::{EDITOR_BG, SECONDARY_TEXT};
 use crate::widget::{RenderContext, View};
 
 // =============================================================================
@@ -88,8 +89,8 @@ impl Default for DebugConfig {
             width: 40,
             max_height: 20,
             opacity: 220,
-            bg_color: Color::rgb(30, 30, 30),
-            fg_color: Color::rgb(200, 200, 200),
+            bg_color: EDITOR_BG,
+            fg_color: SECONDARY_TEXT,
             accent_color: Color::rgb(100, 200, 255),
         }
     }

--- a/src/widget/developer/diff.rs
+++ b/src/widget/developer/diff.rs
@@ -6,7 +6,7 @@
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::utils::{char_width, truncate_to_width};
-use crate::widget::theme::DISABLED_FG;
+use crate::widget::theme::{DISABLED_FG, SEPARATOR_COLOR};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 use similar::{ChangeTag, TextDiff};
@@ -89,7 +89,7 @@ impl Default for DiffColors {
             removed_fg: Color::rgb(255, 150, 150),
             modified_bg: Color::rgb(60, 60, 30),
             line_number: DISABLED_FG,
-            separator: Color::rgb(60, 60, 60),
+            separator: SEPARATOR_COLOR,
             header_bg: Color::rgb(40, 40, 60),
         }
     }

--- a/src/widget/developer/httpclient/render.rs
+++ b/src/widget/developer/httpclient/render.rs
@@ -3,7 +3,7 @@
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::widget::developer::httpclient::HttpClient;
-use crate::widget::theme::DISABLED_FG;
+use crate::widget::theme::{DISABLED_FG, SECONDARY_TEXT, SEPARATOR_COLOR};
 use crate::widget::traits::{RenderContext, View};
 
 use super::types::RequestState;
@@ -59,7 +59,7 @@ impl View for HttpClient {
         // Separator
         for sx in 0..area.width {
             let mut cell = Cell::new('─');
-            cell.fg = Some(Color::rgb(60, 60, 60));
+            cell.fg = Some(SEPARATOR_COLOR);
             ctx.set(sx, 1, cell);
         }
 
@@ -146,7 +146,7 @@ impl View for HttpClient {
                             0,
                             content_y + i as u16,
                             line,
-                            Color::rgb(200, 200, 200),
+                            SECONDARY_TEXT,
                             area.width,
                         );
                     }

--- a/src/widget/developer/presentation.rs
+++ b/src/widget/developer/presentation.rs
@@ -5,7 +5,7 @@
 
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
-use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY};
+use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY, SEPARATOR_COLOR};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -474,7 +474,7 @@ impl Presentation {
                 cell.fg = Some(if i < filled {
                     self.accent
                 } else {
-                    Color::rgb(60, 60, 60)
+                    SEPARATOR_COLOR
                 });
                 ctx.set(1 + i, footer_y, cell);
             }

--- a/src/widget/developer/terminal/core.rs
+++ b/src/widget/developer/terminal/core.rs
@@ -560,11 +560,7 @@ impl View for Terminal {
                 if px + cw > area.width {
                     break;
                 }
-                ctx.set(
-                    px,
-                    input_y,
-                    Cell::new(ch).fg(Color::CYAN).bg(DARK_BG),
-                );
+                ctx.set(px, input_y, Cell::new(ch).fg(Color::CYAN).bg(DARK_BG));
                 px += cw;
             }
 
@@ -575,11 +571,7 @@ impl View for Terminal {
                 if ix + cw > area.width {
                     break;
                 }
-                ctx.set(
-                    ix,
-                    input_y,
-                    Cell::new(ch).fg(Color::WHITE).bg(DARK_BG),
-                );
+                ctx.set(ix, input_y, Cell::new(ch).fg(Color::WHITE).bg(DARK_BG));
                 ix += cw;
             }
         }

--- a/src/widget/developer/terminal/core.rs
+++ b/src/widget/developer/terminal/core.rs
@@ -87,6 +87,7 @@ use super::types::{CursorStyle, TermCell, TermLine, TerminalAction};
 use crate::event::{Key, KeyEvent};
 use crate::render::Cell;
 use crate::style::Color;
+use crate::widget::theme::{DARK_BG, EDITOR_BG, MUTED_TEXT, SECONDARY_TEXT, SEPARATOR_COLOR};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -457,15 +458,15 @@ impl Terminal {
     /// Create a shell-style terminal
     pub fn shell(width: u16, height: u16) -> Self {
         Self::new(width, height)
-            .default_fg(Color::rgb(200, 200, 200))
-            .default_bg(Color::rgb(30, 30, 30))
+            .default_fg(SECONDARY_TEXT)
+            .default_bg(EDITOR_BG)
             .cursor_style(CursorStyle::Block)
     }
 
     /// Create a log viewer terminal
     pub fn log_viewer(width: u16, height: u16) -> Self {
         Self::new(width, height)
-            .default_fg(Color::rgb(180, 180, 180))
+            .default_fg(MUTED_TEXT)
             .default_bg(Color::rgb(20, 20, 20))
             .show_cursor(false)
             .max_scrollback(50000)
@@ -549,7 +550,7 @@ impl View for Terminal {
 
             // Clear input line
             for x in 0..area.width {
-                ctx.set(x, input_y, Cell::new(' ').bg(Color::rgb(40, 40, 40)));
+                ctx.set(x, input_y, Cell::new(' ').bg(DARK_BG));
             }
 
             // Render prompt
@@ -562,7 +563,7 @@ impl View for Terminal {
                 ctx.set(
                     px,
                     input_y,
-                    Cell::new(ch).fg(Color::CYAN).bg(Color::rgb(40, 40, 40)),
+                    Cell::new(ch).fg(Color::CYAN).bg(DARK_BG),
                 );
                 px += cw;
             }
@@ -577,7 +578,7 @@ impl View for Terminal {
                 ctx.set(
                     ix,
                     input_y,
-                    Cell::new(ch).fg(Color::WHITE).bg(Color::rgb(40, 40, 40)),
+                    Cell::new(ch).fg(Color::WHITE).bg(DARK_BG),
                 );
                 ix += cw;
             }
@@ -593,7 +594,7 @@ impl View for Terminal {
                     ctx.set(
                         start_x + i as u16,
                         0,
-                        Cell::new(ch).fg(Color::YELLOW).bg(Color::rgb(60, 60, 60)),
+                        Cell::new(ch).fg(Color::YELLOW).bg(SEPARATOR_COLOR),
                     );
                 }
             }

--- a/src/widget/display/gauge.rs
+++ b/src/widget/display/gauge.rs
@@ -6,6 +6,7 @@
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::utils::color::contrast_color;
+use crate::widget::theme::SEPARATOR_COLOR;
 use crate::utils::{char_width, display_width};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
@@ -111,7 +112,7 @@ impl Gauge {
             show_percent: true,
             fill_color: Color::GREEN,
             fill_bg: None,
-            empty_color: Color::rgb(60, 60, 60),
+            empty_color: SEPARATOR_COLOR,
             empty_bg: None,
             border_color: None,
             warning_threshold: None,

--- a/src/widget/display/gauge.rs
+++ b/src/widget/display/gauge.rs
@@ -6,8 +6,8 @@
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::utils::color::contrast_color;
-use crate::widget::theme::SEPARATOR_COLOR;
 use crate::utils::{char_width, display_width};
+use crate::widget::theme::SEPARATOR_COLOR;
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 

--- a/src/widget/display/skeleton.rs
+++ b/src/widget/display/skeleton.rs
@@ -2,6 +2,7 @@
 
 use crate::render::Cell;
 use crate::style::Color;
+use crate::widget::theme::SEPARATOR_COLOR;
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -61,7 +62,7 @@ impl Skeleton {
             lines: 3,
             frame: 0,
             animate: true,
-            color: Color::rgb(60, 60, 60),
+            color: SEPARATOR_COLOR,
             wave_char: '░',
             props: WidgetProps::new(),
         }

--- a/src/widget/display/status_indicator.rs
+++ b/src/widget/display/status_indicator.rs
@@ -21,6 +21,7 @@
 
 use crate::render::Cell;
 use crate::style::Color;
+use crate::widget::theme::{DARK_BG, SECONDARY_TEXT};
 use crate::widget::traits::{RenderContext, View, WidgetProps, WidgetState};
 use crate::{impl_styled_view, impl_widget_builders};
 use unicode_width::UnicodeWidthChar;
@@ -359,7 +360,7 @@ impl StatusIndicator {
                 break;
             }
             let mut cell = Cell::new(ch);
-            cell.fg = Some(Color::rgb(200, 200, 200));
+            cell.fg = Some(SECONDARY_TEXT);
             ctx.set(label_start + offset, 0, cell);
             for i in 1..char_width {
                 ctx.set(label_start + offset + i, 0, Cell::continuation());
@@ -396,7 +397,7 @@ impl StatusIndicator {
         let label = self.get_label();
 
         // Background
-        let bg_color = Color::rgb(40, 40, 40);
+        let bg_color = DARK_BG;
         let total_width = self.width().min(area.width);
 
         for i in 0..total_width {

--- a/src/widget/display/tag.rs
+++ b/src/widget/display/tag.rs
@@ -2,7 +2,7 @@
 
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
-use crate::widget::theme::{DARK_GRAY, SUBTLE_GRAY};
+use crate::widget::theme::{DARK_GRAY, SEPARATOR_COLOR, SUBTLE_GRAY};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -156,7 +156,7 @@ impl Tag {
         let text_color = self.text_color.unwrap_or(Color::WHITE);
 
         if self.disabled {
-            return (Some(Color::rgb(60, 60, 60)), SUBTLE_GRAY);
+            return (Some(SEPARATOR_COLOR), SUBTLE_GRAY);
         }
 
         match self.style {

--- a/src/widget/feedback/alert.rs
+++ b/src/widget/feedback/alert.rs
@@ -344,14 +344,7 @@ impl Alert {
             let max_w = content_width.saturating_sub(icon_offset);
             ctx.draw_text_clipped_bg_bold(text_x, y, title, Color::WHITE, bg_color, max_w);
             y += 1;
-            ctx.draw_text_clipped_bg(
-                text_x,
-                y,
-                &self.message,
-                SECONDARY_TEXT,
-                bg_color,
-                max_w,
-            );
+            ctx.draw_text_clipped_bg(text_x, y, &self.message, SECONDARY_TEXT, bg_color, max_w);
         } else {
             let text_x = content_x + icon_offset;
             let max_w = content_width.saturating_sub(icon_offset);

--- a/src/widget/feedback/alert.rs
+++ b/src/widget/feedback/alert.rs
@@ -27,7 +27,7 @@ use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::utils::char_width;
 use crate::widget::layout::border::{draw_border, BorderType};
-use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY};
+use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY, MUTED_TEXT, SECONDARY_TEXT};
 use crate::widget::traits::{RenderContext, View, WidgetProps, WidgetState};
 use crate::{impl_styled_view, impl_widget_builders};
 
@@ -348,7 +348,7 @@ impl Alert {
                 text_x,
                 y,
                 &self.message,
-                Color::rgb(200, 200, 200),
+                SECONDARY_TEXT,
                 bg_color,
                 max_w,
             );
@@ -422,7 +422,7 @@ impl Alert {
                     break;
                 }
                 let mut cell = Cell::new(ch);
-                cell.fg = Some(Color::rgb(180, 180, 180));
+                cell.fg = Some(MUTED_TEXT);
                 ctx.set(msg_x + dx, y, cell);
                 dx += cw;
             }
@@ -492,7 +492,7 @@ impl Alert {
                         break;
                     }
                     let mut cell = Cell::new(ch);
-                    cell.fg = Some(Color::rgb(180, 180, 180));
+                    cell.fg = Some(MUTED_TEXT);
                     ctx.set(msg_x + dx, y + 1, cell);
                     dx += cw;
                 }

--- a/src/widget/feedback/menu/context_menu.rs
+++ b/src/widget/feedback/menu/context_menu.rs
@@ -4,6 +4,7 @@ use super::types::MenuItem;
 use crate::event::Key;
 use crate::render::Cell;
 use crate::style::Color;
+use crate::widget::theme::DARK_BG;
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -42,7 +43,7 @@ impl ContextMenu {
             y: 0,
             selected: 0,
             visible: false,
-            bg: Color::rgb(40, 40, 40),
+            bg: DARK_BG,
             fg: Color::WHITE,
             selected_bg: Color::rgb(60, 100, 180),
             selected_fg: Color::WHITE,

--- a/src/widget/feedback/menu/menu_bar.rs
+++ b/src/widget/feedback/menu/menu_bar.rs
@@ -4,7 +4,7 @@ use super::types::Menu;
 use crate::event::Key;
 use crate::render::Cell;
 use crate::style::Color;
-use crate::widget::theme::LIGHT_GRAY;
+use crate::widget::theme::{DARK_BG, LIGHT_GRAY};
 use crate::widget::traits::{RenderContext, View, WidgetProps, DISABLED_FG};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -43,7 +43,7 @@ impl MenuBar {
             selected_menu: 0,
             selected_item: None,
             open: false,
-            bg: Color::rgb(40, 40, 40),
+            bg: DARK_BG,
             fg: Color::WHITE,
             selected_bg: Color::rgb(60, 100, 180),
             selected_fg: Color::WHITE,

--- a/src/widget/feedback/notification/core.rs
+++ b/src/widget/feedback/notification/core.rs
@@ -451,11 +451,7 @@ impl NotificationCenter {
             let filled = (progress * bar_width as f64).round() as u16;
             for dx in 0..bar_width {
                 let ch = if dx < filled { '█' } else { '░' };
-                let fg = if dx < filled {
-                    color
-                } else {
-                    SEPARATOR_COLOR
-                };
+                let fg = if dx < filled { color } else { SEPARATOR_COLOR };
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(fg);
                 cell.bg = Some(bg);

--- a/src/widget/feedback/notification/core.rs
+++ b/src/widget/feedback/notification/core.rs
@@ -4,6 +4,7 @@ use super::types::{Notification, NotificationPosition};
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::utils::char_width;
+use crate::widget::theme::SEPARATOR_COLOR;
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -453,7 +454,7 @@ impl NotificationCenter {
                 let fg = if dx < filled {
                     color
                 } else {
-                    Color::rgb(60, 60, 60)
+                    SEPARATOR_COLOR
                 };
                 let mut cell = Cell::new(ch);
                 cell.fg = Some(fg);

--- a/src/widget/feedback/statusbar.rs
+++ b/src/widget/feedback/statusbar.rs
@@ -5,6 +5,7 @@
 
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
+use crate::widget::theme::{DARK_BG, SECONDARY_TEXT};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -151,11 +152,11 @@ impl StatusBar {
             center: Vec::new(),
             right: Vec::new(),
             position: StatusBarPosition::Bottom,
-            bg: Color::rgb(40, 40, 40),
+            bg: DARK_BG,
             fg: Color::WHITE,
             key_hints: Vec::new(),
             key_fg: Color::BLACK,
-            key_bg: Color::rgb(200, 200, 200),
+            key_bg: SECONDARY_TEXT,
             separator: None,
             height: 1,
             props: WidgetProps::new(),

--- a/src/widget/feedback/tooltip.rs
+++ b/src/widget/feedback/tooltip.rs
@@ -5,6 +5,7 @@
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::utils::border::BorderChars;
+use crate::widget::theme::{DARK_BG, EDITOR_BG};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -77,9 +78,9 @@ pub enum TooltipStyle {
 impl TooltipStyle {
     fn colors(&self) -> (Color, Color) {
         match self {
-            TooltipStyle::Plain => (Color::WHITE, Color::rgb(40, 40, 40)),
-            TooltipStyle::Bordered => (Color::WHITE, Color::rgb(30, 30, 30)),
-            TooltipStyle::Rounded => (Color::WHITE, Color::rgb(30, 30, 30)),
+            TooltipStyle::Plain => (Color::WHITE, DARK_BG),
+            TooltipStyle::Bordered => (Color::WHITE, EDITOR_BG),
+            TooltipStyle::Rounded => (Color::WHITE, EDITOR_BG),
             TooltipStyle::Info => (Color::WHITE, Color::rgb(30, 80, 100)),
             TooltipStyle::Warning => (Color::BLACK, Color::rgb(180, 150, 0)),
             TooltipStyle::Error => (Color::WHITE, Color::rgb(150, 30, 30)),

--- a/src/widget/form/form.rs
+++ b/src/widget/form/form.rs
@@ -29,7 +29,7 @@ use crate::patterns::form::FormState;
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::utils::char_width;
-use crate::widget::theme::{DISABLED_FG, SUBTLE_GRAY};
+use crate::widget::theme::{DISABLED_FG, SECONDARY_TEXT, SUBTLE_GRAY};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -243,7 +243,7 @@ impl View for Form {
                     let x = content_x + i as u16;
                     if x < max_x {
                         let mut cell = Cell::new(ch);
-                        cell.fg = Some(Color::rgb(200, 200, 200));
+                        cell.fg = Some(SECONDARY_TEXT);
                         ctx.set(x, current_y, cell);
                     }
                 }
@@ -449,7 +449,7 @@ impl FormFieldWidget {
             for (i, ch) in label.chars().enumerate() {
                 if (i as u16) < area.width {
                     let mut cell = Cell::new(ch);
-                    cell.fg = Some(Color::rgb(200, 200, 200));
+                    cell.fg = Some(SECONDARY_TEXT);
                     ctx.set(i as u16, 0, cell);
                 }
             }
@@ -556,7 +556,7 @@ impl View for FormFieldWidget {
                 let x = i as u16;
                 if x < area.width {
                     let mut cell = Cell::new(ch);
-                    cell.fg = Some(Color::rgb(200, 200, 200));
+                    cell.fg = Some(SECONDARY_TEXT);
                     ctx.set(x, 0, cell);
                 }
             }

--- a/src/widget/input/input_widgets/autocomplete/core.rs
+++ b/src/widget/input/input_widgets/autocomplete/core.rs
@@ -7,7 +7,7 @@ use crate::event::{Key, KeyEvent};
 use crate::render::Cell;
 use crate::style::Color;
 use crate::utils::{fuzzy_match, FilterMode, Selection};
-use crate::widget::theme::{DISABLED_FG, SUBTLE_GRAY};
+use crate::widget::theme::{DARK_BG, DISABLED_FG, EDITOR_BG, SUBTLE_GRAY};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -73,9 +73,9 @@ impl Autocomplete {
             max_suggestions: 10,
             placeholder: String::new(),
             input_fg: Color::WHITE,
-            input_bg: Color::rgb(30, 30, 30),
+            input_bg: EDITOR_BG,
             placeholder_fg: DISABLED_FG,
-            dropdown_bg: Color::rgb(40, 40, 40),
+            dropdown_bg: DARK_BG,
             selected_bg: Color::rgb(60, 100, 180),
             selected_fg: Color::WHITE,
             description_fg: SUBTLE_GRAY,

--- a/src/widget/input/input_widgets/button.rs
+++ b/src/widget/input/input_widgets/button.rs
@@ -4,6 +4,7 @@ use crate::event::{Key, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use crate::layout::Rect;
 use crate::render::Cell;
 use crate::style::Color;
+use crate::widget::theme::{EDITOR_BG, SECONDARY_TEXT, SEPARATOR_COLOR};
 use crate::widget::traits::{
     EventResult, Interactive, RenderContext, View, WidgetProps, WidgetState,
 };
@@ -175,10 +176,10 @@ impl Button {
     /// Get base colors for the variant (without state effects)
     fn get_variant_base_colors(&self) -> (Color, Color) {
         match self.variant {
-            ButtonVariant::Default => (Color::WHITE, Color::rgb(60, 60, 60)),
+            ButtonVariant::Default => (Color::WHITE, SEPARATOR_COLOR),
             ButtonVariant::Primary => (Color::WHITE, Color::rgb(37, 99, 235)),
             ButtonVariant::Danger => (Color::WHITE, Color::rgb(220, 38, 38)),
-            ButtonVariant::Ghost => (Color::rgb(200, 200, 200), Color::rgb(30, 30, 30)),
+            ButtonVariant::Ghost => (SECONDARY_TEXT, EDITOR_BG),
             ButtonVariant::Success => (Color::WHITE, Color::rgb(22, 163, 74)),
         }
     }

--- a/src/widget/input/input_widgets/color_picker/render.rs
+++ b/src/widget/input/input_widgets/color_picker/render.rs
@@ -135,11 +135,7 @@ impl ColorPicker {
             for j in 0..slider_width {
                 let ch = if j < filled { '█' } else { '░' };
                 let mut cell = Cell::new(ch);
-                cell.fg = Some(if j < filled {
-                    *color
-                } else {
-                    SEPARATOR_COLOR
-                });
+                cell.fg = Some(if j < filled { *color } else { SEPARATOR_COLOR });
                 ctx.set(ox + 2 + j as u16, oy + y, cell);
             }
 

--- a/src/widget/input/input_widgets/color_picker/render.rs
+++ b/src/widget/input/input_widgets/color_picker/render.rs
@@ -5,7 +5,7 @@ use crate::layout::Rect;
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::utils::border::render_border;
-use crate::widget::theme::LIGHT_GRAY;
+use crate::widget::theme::{LIGHT_GRAY, SEPARATOR_COLOR};
 use crate::widget::traits::{RenderContext, View};
 
 impl View for ColorPicker {
@@ -138,7 +138,7 @@ impl ColorPicker {
                 cell.fg = Some(if j < filled {
                     *color
                 } else {
-                    Color::rgb(60, 60, 60)
+                    SEPARATOR_COLOR
                 });
                 ctx.set(ox + 2 + j as u16, oy + y, cell);
             }
@@ -189,7 +189,7 @@ impl ColorPicker {
             cell.fg = Some(if i < input_len {
                 Color::CYAN
             } else {
-                Color::rgb(60, 60, 60)
+                SEPARATOR_COLOR
             });
             ctx.set(input_x + i as u16, oy, cell);
         }

--- a/src/widget/input/input_widgets/number_input/core.rs
+++ b/src/widget/input/input_widgets/number_input/core.rs
@@ -10,7 +10,7 @@
 use crate::event::Key;
 use crate::render::Cell;
 use crate::style::Color;
-use crate::widget::theme::{DARK_GRAY, LIGHT_GRAY};
+use crate::widget::theme::{DARK_GRAY, LIGHT_GRAY, SEPARATOR_COLOR};
 use crate::widget::traits::{RenderContext, View, WidgetProps, WidgetState};
 use crate::{impl_styled_view, impl_view_meta, impl_widget_builders};
 /// A number input widget with increment/decrement controls
@@ -482,7 +482,7 @@ impl View for NumberInput {
 
         let (fg, bg) =
             self.state
-                .resolve_colors_interactive(ctx.style, Color::WHITE, Color::rgb(60, 60, 60));
+                .resolve_colors_interactive(ctx.style, Color::WHITE, SEPARATOR_COLOR);
 
         let mut x: u16 = 0;
 

--- a/src/widget/input/input_widgets/slider.rs
+++ b/src/widget/input/input_widgets/slider.rs
@@ -5,7 +5,7 @@
 
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
-use crate::widget::theme::{DARK_GRAY, DISABLED_FG};
+use crate::widget::theme::{DARK_GRAY, DISABLED_FG, SEPARATOR_COLOR};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -88,7 +88,7 @@ impl Slider {
             length: 20,
             show_value: true,
             value_format: None,
-            track_color: Color::rgb(60, 60, 60),
+            track_color: SEPARATOR_COLOR,
             fill_color: Color::CYAN,
             knob_color: Color::WHITE,
             focused: false,

--- a/src/widget/input/input_widgets/stepper.rs
+++ b/src/widget/input/input_widgets/stepper.rs
@@ -4,7 +4,7 @@
 
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
-use crate::widget::theme::{DISABLED_FG, SUBTLE_GRAY};
+use crate::widget::theme::{DISABLED_FG, SEPARATOR_COLOR, SUBTLE_GRAY};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -162,7 +162,7 @@ impl Stepper {
             completed_color: Color::GREEN,
             pending_color: DISABLED_FG,
             error_color: Color::RED,
-            connector_color: Color::rgb(60, 60, 60),
+            connector_color: SEPARATOR_COLOR,
             show_numbers: true,
             props: WidgetProps::new(),
         }

--- a/src/widget/input/input_widgets/switch.rs
+++ b/src/widget/input/input_widgets/switch.rs
@@ -6,7 +6,7 @@ use crate::event::{Key, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use crate::layout::Rect;
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
-use crate::widget::theme::DISABLED_FG;
+use crate::widget::theme::{DISABLED_FG, SEPARATOR_COLOR};
 use crate::widget::traits::{EventResult, Interactive, RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -70,7 +70,7 @@ impl Switch {
             disabled: false,
             on_color: Color::GREEN,
             off_color: DISABLED_FG,
-            track_color: Color::rgb(60, 60, 60),
+            track_color: SEPARATOR_COLOR,
             on_text: None,
             off_text: None,
             props: WidgetProps::new(),

--- a/src/widget/layout/accordion/mod.rs
+++ b/src/widget/layout/accordion/mod.rs
@@ -9,6 +9,7 @@ pub use types::AccordionSection;
 
 use crate::style::Color;
 use crate::utils::Selection;
+use crate::widget::theme::{EDITOR_BG, SECONDARY_TEXT};
 use crate::widget::traits::WidgetProps;
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -56,8 +57,8 @@ impl Accordion {
             header_bg: Color::rgb(50, 50, 50),
             header_fg: Color::WHITE,
             selected_bg: Color::rgb(60, 90, 140),
-            content_bg: Color::rgb(30, 30, 30),
-            content_fg: Color::rgb(200, 200, 200),
+            content_bg: EDITOR_BG,
+            content_fg: SECONDARY_TEXT,
             border_color: None,
             show_dividers: true,
             min_width: 0,

--- a/src/widget/layout/accordion/render.rs
+++ b/src/widget/layout/accordion/render.rs
@@ -1,8 +1,8 @@
 //! View implementation for Accordion
 
 use crate::render::Cell;
-use crate::style::Color;
 use crate::utils::border::render_border;
+use crate::widget::theme::SEPARATOR_COLOR;
 use crate::widget::traits::{RenderContext, View};
 
 use super::Accordion;
@@ -122,7 +122,7 @@ impl View for Accordion {
             if self.show_dividers && section_idx < self.sections.len() - 1 && y < max_y {
                 for x in content_x_off..content_x_off + content_width {
                     let mut cell = Cell::new('─');
-                    cell.fg = Some(Color::rgb(60, 60, 60));
+                    cell.fg = Some(SEPARATOR_COLOR);
                     ctx.set(x, y, cell);
                 }
                 y += 1;

--- a/src/widget/layout/card/core.rs
+++ b/src/widget/layout/card/core.rs
@@ -31,7 +31,7 @@ use crate::event::Key;
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::utils::unicode::char_width;
-use crate::widget::theme::LIGHT_GRAY;
+use crate::widget::theme::{DARK_BG, LIGHT_GRAY};
 use crate::widget::traits::{RenderContext, View, WidgetProps, WidgetState};
 use crate::{impl_styled_view, impl_widget_builders};
 
@@ -346,7 +346,7 @@ impl Card {
             CardVariant::Outlined => Color::rgb(60, 60, 70),
             CardVariant::Filled => Color::rgb(50, 50, 60),
             CardVariant::Elevated => Color::rgb(70, 70, 80),
-            CardVariant::Flat => Color::rgb(40, 40, 40),
+            CardVariant::Flat => DARK_BG,
         };
 
         let default_title = Color::WHITE;

--- a/src/widget/layout/collapsible.rs
+++ b/src/widget/layout/collapsible.rs
@@ -23,7 +23,7 @@ use crate::event::Key;
 use crate::layout::Rect;
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
-use crate::widget::theme::{DARK_GRAY, DISABLED_FG};
+use crate::widget::theme::{DARK_GRAY, DISABLED_FG, SECONDARY_TEXT};
 use crate::widget::traits::{RenderContext, View, WidgetProps, WidgetState};
 use crate::{impl_styled_view, impl_widget_builders};
 
@@ -79,7 +79,7 @@ impl Collapsible {
             expanded_icon: '▼',
             header_fg: Color::WHITE,
             header_bg: None,
-            content_fg: Color::rgb(200, 200, 200),
+            content_fg: SECONDARY_TEXT,
             content_bg: None,
             show_border: true,
             border_color: DARK_GRAY,

--- a/src/widget/markdown_presentation.rs
+++ b/src/widget/markdown_presentation.rs
@@ -46,7 +46,7 @@ use crate::style::Color;
 use crate::utils::figlet::FigletFont;
 use crate::utils::text_sizing::is_supported as text_sizing_supported;
 use crate::widget::slides::{SlideContent, SlideNav};
-use crate::widget::theme::{DARK_GRAY, DISABLED_FG};
+use crate::widget::theme::{DARK_GRAY, DISABLED_FG, SEPARATOR_COLOR};
 use crate::widget::traits::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
 
@@ -496,7 +496,7 @@ impl MarkdownPresentation {
                 cell.fg = Some(if i < filled {
                     self.accent
                 } else {
-                    Color::rgb(60, 60, 60)
+                    SEPARATOR_COLOR
                 });
                 ctx.set(1 + i, footer_y, cell);
             }

--- a/src/widget/mermaid/types.rs
+++ b/src/widget/mermaid/types.rs
@@ -1,6 +1,7 @@
 //! Types for the Mermaid diagram widget
 
 use crate::style::Color;
+use crate::widget::theme::MUTED_TEXT;
 
 /// Diagram type
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -166,7 +167,7 @@ impl Default for DiagramColors {
             node_fg: Color::WHITE,
             node_bg: Color::rgb(40, 60, 80),
             arrow: Color::rgb(100, 150, 200),
-            label: Color::rgb(180, 180, 180),
+            label: MUTED_TEXT,
             title: Color::CYAN,
         }
     }

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -371,7 +371,8 @@ pub use streamline::{
 };
 pub use syntax::{HighlightSpan, Language, SyntaxHighlighter, SyntaxTheme};
 pub use theme::{
-    DARK_GRAY, FOCUS_COLOR, LIGHT_GRAY, MAX_DROPDOWN_VISIBLE, PLACEHOLDER_FG, SUBTLE_GRAY,
+    DARK_BG, DARK_GRAY, EDITOR_BG, FOCUS_COLOR, LIGHT_GRAY, MAX_DROPDOWN_VISIBLE, MUTED_TEXT,
+    PLACEHOLDER_FG, SECONDARY_TEXT, SEPARATOR_COLOR, SUBTLE_GRAY,
 };
 pub use theme_picker::{theme_picker, ThemePicker};
 pub use traits::{

--- a/src/widget/multi_select/render.rs
+++ b/src/widget/multi_select/render.rs
@@ -3,7 +3,7 @@
 use crate::impl_view_meta;
 use crate::render::Cell;
 use crate::style::Color;
-use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY, MAX_DROPDOWN_VISIBLE, PLACEHOLDER_FG};
+use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY, MAX_DROPDOWN_VISIBLE, PLACEHOLDER_FG, SECONDARY_TEXT};
 use crate::widget::traits::{RenderContext, View};
 
 use super::types::MultiSelect;
@@ -56,7 +56,7 @@ impl View for MultiSelect {
                     let tag_fg = if is_tag_selected {
                         Color::WHITE
                     } else {
-                        Color::rgb(200, 200, 200)
+                        SECONDARY_TEXT
                     };
                     let tag_bg_color = if is_tag_selected {
                         Color::rgb(100, 100, 200)

--- a/src/widget/multi_select/render.rs
+++ b/src/widget/multi_select/render.rs
@@ -3,7 +3,9 @@
 use crate::impl_view_meta;
 use crate::render::Cell;
 use crate::style::Color;
-use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY, MAX_DROPDOWN_VISIBLE, PLACEHOLDER_FG, SECONDARY_TEXT};
+use crate::widget::theme::{
+    DISABLED_FG, LIGHT_GRAY, MAX_DROPDOWN_VISIBLE, PLACEHOLDER_FG, SECONDARY_TEXT,
+};
 use crate::widget::traits::{RenderContext, View};
 
 use super::types::MultiSelect;

--- a/src/widget/option_list.rs
+++ b/src/widget/option_list.rs
@@ -27,7 +27,7 @@
 //! ```
 
 use crate::style::Color;
-use crate::widget::theme::{DARK_GRAY, PLACEHOLDER_FG};
+use crate::widget::theme::{DARK_GRAY, MUTED_TEXT, PLACEHOLDER_FG};
 use crate::widget::traits::DISABLED_FG;
 use crate::widget::{RenderContext, View, WidgetProps};
 use crate::{impl_props_builders, impl_styled_view};
@@ -689,7 +689,7 @@ impl View for OptionList {
                     content = content.child(Text::new(line).fg(DARK_GRAY));
                 }
                 OptionEntry::Group(name) => {
-                    content = content.child(Text::new(name).fg(Color::rgb(180, 180, 180)).bold());
+                    content = content.child(Text::new(name).fg(MUTED_TEXT).bold());
                 }
             }
         }

--- a/src/widget/range_picker/view.rs
+++ b/src/widget/range_picker/view.rs
@@ -63,14 +63,7 @@ impl View for RangePicker {
             self.end.date.month,
             self.end.date.day,
         );
-        self.draw_text(
-            ctx,
-            x,
-            summary_y,
-            &range_str,
-            SECONDARY_TEXT,
-            false,
-        );
+        self.draw_text(ctx, x, summary_y, &range_str, SECONDARY_TEXT, false);
 
         // Help text
         let help = "Tab: switch | ←→↑↓: navigate | [/]: month | Enter: select";

--- a/src/widget/range_picker/view.rs
+++ b/src/widget/range_picker/view.rs
@@ -6,7 +6,7 @@ use crate::render::{Cell, Modifier};
 use crate::style::Color;
 use crate::utils::unicode::char_width;
 use crate::widget::data::calendar::{days_in_month, Date};
-use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY};
+use crate::widget::theme::{DISABLED_FG, LIGHT_GRAY, SECONDARY_TEXT};
 use crate::widget::traits::{RenderContext, View};
 use crate::{impl_styled_view, impl_widget_builders};
 
@@ -68,7 +68,7 @@ impl View for RangePicker {
             x,
             summary_y,
             &range_str,
-            Color::rgb(200, 200, 200),
+            SECONDARY_TEXT,
             false,
         );
 

--- a/src/widget/sortable/core.rs
+++ b/src/widget/sortable/core.rs
@@ -2,6 +2,7 @@
 
 use crate::event::drag::DragId;
 use crate::style::Color;
+use crate::widget::theme::SECONDARY_TEXT;
 use crate::widget::traits::{WidgetProps, WidgetState};
 
 use super::types::{generate_id, ReorderCallback, SortableItem};
@@ -62,7 +63,7 @@ impl SortableList {
             on_reorder: None,
             item_height: 1,
             show_handles: true,
-            item_color: Color::rgb(200, 200, 200),
+            item_color: SECONDARY_TEXT,
             selected_color: Color::rgb(100, 150, 255),
             drag_color: Color::rgb(255, 200, 100),
             state: WidgetState::new(),

--- a/src/widget/theme.rs
+++ b/src/widget/theme.rs
@@ -52,6 +52,46 @@ pub const SUBTLE_GRAY: Color = Color {
     a: 255,
 };
 
+/// Border and separator color — `rgb(60, 60, 60)`
+pub const SEPARATOR_COLOR: Color = Color {
+    r: 60,
+    g: 60,
+    b: 60,
+    a: 255,
+};
+
+/// Secondary text / light foreground — `rgb(200, 200, 200)`
+pub const SECONDARY_TEXT: Color = Color {
+    r: 200,
+    g: 200,
+    b: 200,
+    a: 255,
+};
+
+/// Dark container background — `rgb(40, 40, 40)`
+pub const DARK_BG: Color = Color {
+    r: 40,
+    g: 40,
+    b: 40,
+    a: 255,
+};
+
+/// Descriptive / muted text — `rgb(180, 180, 180)`
+pub const MUTED_TEXT: Color = Color {
+    r: 180,
+    g: 180,
+    b: 180,
+    a: 255,
+};
+
+/// Dark editor / panel background — `rgb(30, 30, 30)`
+pub const EDITOR_BG: Color = Color {
+    r: 30,
+    g: 30,
+    b: 30,
+    a: 255,
+};
+
 /// Accent color for focused widgets
 pub const FOCUS_COLOR: Color = Color::CYAN;
 


### PR DESCRIPTION
## Summary
- Define 5 new theme palette constants: `SEPARATOR_COLOR`, `SECONDARY_TEXT`, `DARK_BG`, `MUTED_TEXT`, `EDITOR_BG`
- Replace ~85 magic `Color::rgb()` calls across 47 source files
- Top offenders addressed: `rgb(60,60,60)` x20, `rgb(200,200,200)` x20, `rgb(40,40,40)` x18, `rgb(180,180,180)` x14, `rgb(30,30,30)` x13

## Test plan
- [x] All lib + widget tests pass
- [x] Clippy clean with `--all-features`
- [x] No behavioral changes — pure refactor

Closes #566