### PR TITLE
refactor(widget): standardize widget event handler pattern

### DIFF
--- a/src/widget/input/input_widgets/button.rs
+++ b/src/widget/input/input_widgets/button.rs
@@ -333,6 +333,7 @@ impl Interactive for Button {
 
     fn on_blur(&mut self) {
         self.state.focused = false;
+        // Button has extra cleanup on blur
         self.state.reset_transient();
     }
 }

--- a/src/widget/input/input_widgets/checkbox.rs
+++ b/src/widget/input/input_widgets/checkbox.rs
@@ -237,17 +237,7 @@ impl Interactive for Checkbox {
         }
     }
 
-    fn focusable(&self) -> bool {
-        !self.state.disabled
-    }
-
-    fn on_focus(&mut self) {
-        self.state.focused = true;
-    }
-
-    fn on_blur(&mut self) {
-        self.state.focused = false;
-    }
+    crate::impl_focus_handlers!(state);
 }
 
 /// Create a checkbox

--- a/src/widget/input/input_widgets/select/input.rs
+++ b/src/widget/input/input_widgets/select/input.rs
@@ -104,13 +104,7 @@ impl Interactive for Select {
         }
     }
 
-    fn focusable(&self) -> bool {
-        !self.disabled
-    }
-
-    fn on_focus(&mut self) {
-        self.focused = true;
-    }
+    crate::impl_focus_handlers!(direct, no_blur);
 
     fn on_blur(&mut self) {
         self.focused = false;

--- a/src/widget/input/input_widgets/switch.rs
+++ b/src/widget/input/input_widgets/switch.rs
@@ -516,17 +516,7 @@ impl Interactive for Switch {
         }
     }
 
-    fn focusable(&self) -> bool {
-        !self.disabled
-    }
-
-    fn on_focus(&mut self) {
-        self.focused = true;
-    }
-
-    fn on_blur(&mut self) {
-        self.focused = false;
-    }
+    crate::impl_focus_handlers!(direct);
 }
 
 /// Helper to create a switch

--- a/src/widget/link.rs
+++ b/src/widget/link.rs
@@ -317,17 +317,7 @@ impl Interactive for Link {
         }
     }
 
-    fn focusable(&self) -> bool {
-        !self.disabled
-    }
-
-    fn on_focus(&mut self) {
-        self.focused = true;
-    }
-
-    fn on_blur(&mut self) {
-        self.focused = false;
-    }
+    crate::impl_focus_handlers!(direct);
 }
 
 impl_styled_view!(Link);

--- a/src/widget/multi_select/key_handling.rs
+++ b/src/widget/multi_select/key_handling.rs
@@ -20,13 +20,7 @@ impl Interactive for MultiSelect {
         }
     }
 
-    fn focusable(&self) -> bool {
-        !self.state.disabled
-    }
-
-    fn on_focus(&mut self) {
-        self.state.focused = true;
-    }
+    crate::impl_focus_handlers!(state, no_blur);
 
     fn on_blur(&mut self) {
         self.state.focused = false;

--- a/src/widget/traits/mod.rs
+++ b/src/widget/traits/mod.rs
@@ -360,3 +360,74 @@ macro_rules! impl_styled_view {
         }
     };
 }
+
+/// Generate standard `Interactive` focus management methods for widgets.
+///
+/// Use inside an `impl Interactive` block. Generates `focusable()`,
+/// `on_focus()`, and `on_blur()` methods.
+///
+/// # Variants
+///
+/// - `impl_focus_handlers!(state)` — for widgets with `state: WidgetState`
+/// - `impl_focus_handlers!(direct)` — for widgets with direct `disabled`/`focused` fields
+/// - `impl_focus_handlers!(state, no_blur)` / `impl_focus_handlers!(direct, no_blur)` —
+///   same but omits `on_blur()` so you can provide a custom implementation
+///
+/// # Example
+/// ```rust,ignore
+/// impl Interactive for MyWidget {
+///     fn handle_key(&mut self, event: &KeyEvent) -> EventResult { /* ... */ }
+///     crate::impl_focus_handlers!(state);
+/// }
+///
+/// // With custom on_blur:
+/// impl Interactive for MyDropdown {
+///     fn handle_key(&mut self, event: &KeyEvent) -> EventResult { /* ... */ }
+///     crate::impl_focus_handlers!(direct, no_blur);
+///     fn on_blur(&mut self) {
+///         self.focused = false;
+///         self.close_dropdown();
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! impl_focus_handlers {
+    (state) => {
+        fn focusable(&self) -> bool {
+            !self.state.disabled
+        }
+        fn on_focus(&mut self) {
+            self.state.focused = true;
+        }
+        fn on_blur(&mut self) {
+            self.state.focused = false;
+        }
+    };
+    (direct) => {
+        fn focusable(&self) -> bool {
+            !self.disabled
+        }
+        fn on_focus(&mut self) {
+            self.focused = true;
+        }
+        fn on_blur(&mut self) {
+            self.focused = false;
+        }
+    };
+    (state, no_blur) => {
+        fn focusable(&self) -> bool {
+            !self.state.disabled
+        }
+        fn on_focus(&mut self) {
+            self.state.focused = true;
+        }
+    };
+    (direct, no_blur) => {
+        fn focusable(&self) -> bool {
+            !self.disabled
+        }
+        fn on_focus(&mut self) {
+            self.focused = true;
+        }
+    };
+}


### PR DESCRIPTION
## Summary
- Add `impl_focus_handlers!` macro for generating standard `focusable()`, `on_focus()`, `on_blur()` Interactive methods
- Two variants: `state` (for `WidgetState` field) and `direct` (for direct `disabled`/`focused` fields)
- Optional `no_blur` modifier for widgets needing custom `on_blur` behavior
- Applied to 5 widgets: Checkbox, Switch, Select, Link, MultiSelect

## Test plan
- [x] All lib + widget tests pass (5464 + 4199)
- [x] Clippy clean with `--all-features`
- [x] No behavioral changes — pure refactor

Closes #567