### PR TITLE
ci: add CI Gate aggregate check so docs-only PRs aren't blocked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,3 +150,41 @@ jobs:
         with:
           config: .typos.toml
 
+  # Aggregate gate: single required status check for branch protection.
+  # Code jobs are path-filtered (skipped on docs-only PRs); rulesets treat a
+  # skipped required check as *not satisfied*, which would block docs-only PRs
+  # forever. This gate always runs and passes when every upstream job either
+  # succeeded or was skipped, so the ruleset should require ONLY "CI Gate".
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs: [changes, fmt, clippy, test, coverage, msrv, typos]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs succeeded or were skipped
+        env:
+          CHANGES: ${{ needs.changes.result }}
+          FMT: ${{ needs.fmt.result }}
+          CLIPPY: ${{ needs.clippy.result }}
+          TEST: ${{ needs.test.result }}
+          COVERAGE: ${{ needs.coverage.result }}
+          MSRV: ${{ needs.msrv.result }}
+          TYPOS: ${{ needs.typos.result }}
+        run: |
+          fail=0
+          for pair in "changes:$CHANGES" "fmt:$FMT" "clippy:$CLIPPY" "test:$TEST" "coverage:$COVERAGE" "msrv:$MSRV" "typos:$TYPOS"; do
+            job="${pair%%:*}"
+            res="${pair#*:}"
+            if [ "$res" = "success" ] || [ "$res" = "skipped" ]; then
+              echo "OK   $job = $res"
+            else
+              echo "FAIL $job = $res"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::One or more required CI jobs did not succeed."
+            exit 1
+          fi
+          echo "All required CI jobs passed or were skipped."
+


### PR DESCRIPTION
## Problem

The `protect-main` ruleset requires `Format`, `Clippy`, `Coverage`, `MSRV (1.87)`, `Test (*)`, `Typos`. All the code jobs are path-filtered (`needs.changes.outputs.code`), so on a **docs/workflow-only PR they skip** — and a GitHub ruleset counts a *skipped* required check as **unsatisfied**, blocking the merge indefinitely. #575 hit exactly this and had to be admin-merged.

## Fix

Add a single `CI Gate` job that:
- `needs` every code job and `typos`, runs with `if: always()`.
- Passes iff each upstream job result is `success` **or** `skipped`; fails on `failure`/`cancelled`.

Then the ruleset should require **only `CI Gate`** (follow-up, applied after this merges). Docs-only PRs → all code jobs skip → gate green → mergeable. Code PRs → jobs run → gate reflects real result.

## Note

This PR touches `.github/workflows/ci.yml` (in the `code` path filter), so all existing required jobs run and pass here — it merges through the current ruleset without a bypass.