### PR TITLE
feat(textarea): implement soft wrap rendering

### DIFF
--- a/docs/FRAMEWORK_COMPARISON.md
+++ b/docs/FRAMEWORK_COMPARISON.md
@@ -161,7 +161,7 @@ full PTY Terminal widget. (Textual has no equivalents.)
 | Basic editing / undo / selection | ✅ | ✅ | parity |
 | Line numbers | ✅ | ✅ | parity |
 | Syntax highlight (tree-sitter) | ✅ | ✅ | parity |
-| **Soft wrap** | ⚠️ **STUB** | ✅ | **Textual leads** — revue's `wrap` flag only toggles h-scroll; `view.rs` renders 1 visual row per logical line |
+| **Soft wrap** | ✅ | ✅ | parity — word-boundary soft wrap in `view.rs` (was a stub; now flows long lines onto multiple visual rows) |
 | **Find / Replace** | ✅ (regex = stub; API-only) | ❌ core (3rd-party pkg) | **Revue leads** — engine done in `find_impl.rs` (~346L); regex falls back to literal; not bound in `handle_key` |
 | **Multiple cursors** | ⚠️ PARTIAL | ❌ | Data + render exist; editing applies to primary cursor only; not key-wired |
 | Suggestion / placeholder | ? (verify) | ✅ (v6) | Textual added; confirm revue status |
@@ -198,21 +198,20 @@ Two real, wired-up implementations (both were previously mislabeled "missing"):
 
 | # | Gap | Current state | Impact | Effort |
 |---|-----|---------------|--------|--------|
-| 1 | **TextArea soft wrap** | STUB (flag toggles h-scroll only) | High — docs claim it works | Medium |
-| 2 | **DataGrid column freeze render** | PARTIAL (state/API/tests done; render not wired) | Medium | Small–Medium |
-| 3 | **Key bindings for find/replace & multi-cursor** | API-only; not in `handle_key` | Medium (UX) | Small |
-| 4 | **Multi-cursor editing** | Editing applies to primary cursor only | Low–Medium | Medium–Hard |
-| 5 | **Regex search** in find/replace | Stub (literal fallback) | Low | Small |
-| 6 | **Web deployment** (textual-serve analog) | Missing entirely | Strategic | Very Hard |
-| 7 | **Streaming content** (LLM output into Markdown/RichLog) | Verify — Textual added `Markdown.append`/`get_stream` | Medium (modern use case) | Medium |
-| 8 | **Screen stack auto-wiring** | Manager exists but app author must drive it | Low | Medium |
+| 1 | **DataGrid column freeze render** | PARTIAL (state/API/tests done; render not wired) | Medium | Small–Medium |
+| 2 | **Key bindings for find/replace & multi-cursor** | API-only; not in `handle_key` | Medium (UX) | Small |
+| 3 | **Multi-cursor editing** | Editing applies to primary cursor only | Low–Medium | Medium–Hard |
+| 4 | **Regex search** in find/replace | Stub (literal fallback) | Low | Small |
+| 5 | **Web deployment** (textual-serve analog) | Missing entirely | Strategic | Very Hard |
+| 6 | **Streaming content** (LLM output into Markdown/RichLog) | Verify — Textual added `Markdown.append`/`get_stream` | Medium (modern use case) | Medium |
+| 7 | **Screen stack auto-wiring** | Manager exists but app author must drive it | Low | Medium |
 
 ### 9.2 Already done — remove from any "TODO" list
 
 DataGrid virtual scroll / column resize / column reorder; TextArea find-replace
-engine; Pilot testing; Worker system; message/event bus; CSS Grid; Input
-copy-paste & shift-selection. **These are shipped and tested** — the old doc's
-"❌ TODO" markers were wrong.
+engine; TextArea soft wrap (word-boundary); Pilot testing; Worker system;
+message/event bus; CSS Grid; Input copy-paste & shift-selection. **These are
+shipped and tested** — the old doc's "❌ TODO" markers were wrong.
 
 ---
 
@@ -247,16 +246,17 @@ adoption, ergonomics, and docs — not raw feature count.
 
 | vs Framework | Revue standing | Notes |
 |--------------|----------------|-------|
-| vs **Textual** | **~parity, ahead on breadth** | Leads on widgets, viz, DataGrid resize/reorder, TextArea find/replace. Trails on soft-wrap, column-freeze render, web serve, streaming content. |
+| vs **Textual** | **~parity, ahead on breadth** | Leads on widgets, viz, DataGrid resize/reorder, TextArea find/replace + soft wrap. Trails on column-freeze render, web serve, streaming content. |
 | vs **ratatui** | Different tier | Higher-level; ratatui wins adoption & is the substrate, not a like-for-like rival. |
 | vs **r3bl_tui / tui-realm / iocraft** | Feature-ahead, adoption-behind | Revue ships far more widgets + CSS; peers have more users/momentum. |
 | vs **reratui / reactive_tui / Cursive** | Not live competition | Negligible / dead / inactive. |
 
 **Bottom line:** Revue is **not "far behind" Textual** — that impression came
 from a stale comparison. On breadth and several depth features it already leads.
-The real, verified work is a short list: finish soft-wrap, wire up column-freeze
-rendering, bind keys for find/replace & multi-cursor, and decide whether to
-pursue streaming-content and web-serve as strategic bets.
+The real, verified work is a short list: wire up column-freeze rendering, bind
+keys for find/replace & multi-cursor, and decide whether to pursue
+streaming-content and web-serve as strategic bets. (Soft wrap — previously a
+stub — is now implemented.)
 
 ---
 

--- a/src/widget/input/input_widgets/textarea/view.rs
+++ b/src/widget/input/input_widgets/textarea/view.rs
@@ -5,6 +5,56 @@ use crate::style::Color;
 use crate::widget::theme::PLACEHOLDER_FG;
 use crate::widget::traits::{RenderContext, View};
 
+/// Split a logical line into visual segments `[start, end)` (character indices) that each
+/// fit within `width` display columns. Prefers breaking at word boundaries (after a space)
+/// and lets trailing spaces overflow onto the current row; falls back to a hard break when
+/// a single word is longer than the width. Always makes forward progress, so it terminates
+/// even for zero-width characters or `width == 0`.
+fn wrap_segments(chars: &[char], width: u16) -> Vec<(usize, usize)> {
+    if chars.is_empty() {
+        return vec![(0, 0)];
+    }
+
+    let width = width.max(1);
+    let mut segments = Vec::new();
+    let mut start = 0usize;
+    let mut col: u16 = 0;
+    let mut last_space_end: Option<usize> = None;
+    let mut i = 0usize;
+
+    while i < chars.len() {
+        let cw = (crate::utils::char_width(chars[i]) as u16).max(1);
+
+        if col + cw > width && i > start {
+            if chars[i] == ' ' {
+                // Trailing space overflowing the row: keep it on the current visual
+                // row rather than pushing a lone space to the next one.
+                i += 1;
+                continue;
+            }
+            let brk = match last_space_end {
+                Some(b) if b > start => b,
+                _ => i,
+            };
+            segments.push((start, brk));
+            start = brk;
+            col = 0;
+            last_space_end = None;
+            i = brk;
+            continue;
+        }
+
+        col += cw;
+        if chars[i] == ' ' {
+            last_space_end = Some(i + 1);
+        }
+        i += 1;
+    }
+
+    segments.push((start, chars.len()));
+    segments
+}
+
 impl TextArea {
     /// Get line number width
     fn line_number_width(&self) -> u16 {
@@ -15,6 +65,45 @@ impl TextArea {
         } else {
             0
         }
+    }
+
+    /// Build the list of visual rows to render, starting from the vertical scroll offset.
+    ///
+    /// Each entry is `(line_idx, seg_start, seg_end, is_first_segment)`. When `wrap` is on a
+    /// single logical line may span several visual rows; otherwise every logical line maps to
+    /// exactly one visual row (honoring the horizontal scroll offset).
+    fn visual_rows(
+        &self,
+        text_width: u16,
+        visible_lines: usize,
+    ) -> Vec<(usize, usize, usize, bool)> {
+        let mut rows = Vec::with_capacity(visible_lines);
+        let mut line_idx = self.scroll.0;
+
+        while rows.len() < visible_lines && line_idx < self.lines.len() {
+            let char_count = self.lines[line_idx].chars().count();
+
+            if self.wrap && text_width > 0 {
+                let chars: Vec<char> = self.lines[line_idx].chars().collect();
+                for (k, (s, e)) in wrap_segments(&chars, text_width).into_iter().enumerate() {
+                    if rows.len() >= visible_lines {
+                        break;
+                    }
+                    rows.push((line_idx, s, e, k == 0));
+                }
+            } else {
+                let start = if self.wrap {
+                    0
+                } else {
+                    self.scroll.1.min(char_count)
+                };
+                rows.push((line_idx, start, char_count, true));
+            }
+
+            line_idx += 1;
+        }
+
+        rows
     }
 }
 
@@ -59,16 +148,13 @@ impl View for TextArea {
             }
         }
 
-        // Render visible lines
-        for (view_row, line_idx) in (self.scroll.0..self.scroll.0 + visible_lines).enumerate() {
-            if line_idx >= self.lines.len() {
-                break;
-            }
-
+        // Render visible visual rows (a logical line may span multiple rows when wrapping).
+        let rows = self.visual_rows(text_width, visible_lines);
+        for (view_row, &(line_idx, seg_start, seg_end, is_first)) in rows.iter().enumerate() {
             let y = view_row as u16;
 
-            // Draw line numbers
-            if self.show_line_numbers {
+            // Draw line numbers (only on the first visual row of a logical line)
+            if self.show_line_numbers && is_first {
                 let num_str = format!(
                     "{:>width$} ",
                     line_idx + 1,
@@ -86,14 +172,14 @@ impl View for TextArea {
             // Draw text
             let line = &self.lines[line_idx];
             let chars: Vec<char> = line.chars().collect();
-            let scroll_col = if self.wrap { 0 } else { self.scroll.1 };
+            let is_last_segment = seg_end >= chars.len();
 
             // Get syntax highlighting spans for this line
             let highlights = self.highlighter.as_ref().map(|h| h.highlight_line(line));
 
-            // Render characters with display-width awareness
+            // Render characters within this segment with display-width awareness
             let mut display_x: u16 = 0;
-            for (char_idx, &ch) in chars.iter().enumerate().skip(scroll_col) {
+            for (char_idx, &ch) in chars.iter().enumerate().take(seg_end).skip(seg_start) {
                 let cw = crate::utils::char_width(ch) as u16;
                 if display_x + cw > text_width {
                     break;
@@ -179,14 +265,13 @@ impl View for TextArea {
                 display_x += cw;
             }
 
-            // Draw cursors at end of line if needed
-            if self.focused {
+            // Draw cursors at end of line if needed (only on the last visual row of the line)
+            if self.focused && is_last_segment {
                 for cursor in self.cursors.iter() {
                     if cursor.pos.line == line_idx && cursor.pos.col >= chars.len() {
-                        // Calculate display position from character widths
-                        let cursor_display_x: u16 = chars
+                        // Calculate display position from the widths of this segment's chars
+                        let cursor_display_x: u16 = chars[seg_start..chars.len()]
                             .iter()
-                            .skip(scroll_col)
                             .map(|&ch| crate::utils::char_width(ch) as u16)
                             .sum();
                         let cursor_x = text_start_x + cursor_display_x;
@@ -203,3 +288,80 @@ impl View for TextArea {
 }
 
 use super::TextArea;
+
+#[cfg(test)]
+mod wrap_segment_tests {
+    use super::wrap_segments;
+
+    fn chars(s: &str) -> Vec<char> {
+        s.chars().collect()
+    }
+
+    /// Every segment must reconstruct the original line exactly, in order.
+    fn assert_lossless(s: &str, width: u16) -> Vec<(usize, usize)> {
+        let cs = chars(s);
+        let segs = wrap_segments(&cs, width);
+        // Contiguous, covering, in order.
+        assert_eq!(
+            segs.first().map(|s| s.0),
+            Some(0),
+            "first segment starts at 0"
+        );
+        assert_eq!(
+            segs.last().map(|s| s.1),
+            Some(cs.len()),
+            "last segment ends at len"
+        );
+        for w in segs.windows(2) {
+            assert_eq!(w[0].1, w[1].0, "segments are contiguous: {:?}", segs);
+            assert!(w[0].0 < w[0].1, "no empty interior segment: {:?}", segs);
+        }
+        segs
+    }
+
+    #[test]
+    fn empty_line_yields_single_empty_segment() {
+        assert_eq!(wrap_segments(&[], 5), vec![(0, 0)]);
+    }
+
+    #[test]
+    fn short_line_is_not_split() {
+        assert_eq!(wrap_segments(&chars("hello"), 10), vec![(0, 5)]);
+        // exact fit
+        assert_eq!(wrap_segments(&chars("hello"), 5), vec![(0, 5)]);
+    }
+
+    #[test]
+    fn long_word_hard_wraps_at_width() {
+        assert_eq!(
+            wrap_segments(&chars("abcdefgh"), 3),
+            vec![(0, 3), (3, 6), (6, 8)]
+        );
+    }
+
+    #[test]
+    fn wraps_at_word_boundary_and_keeps_trailing_space() {
+        // "aa " stays together, "bb" moves to the next row.
+        assert_eq!(wrap_segments(&chars("aa bb"), 3), vec![(0, 3), (3, 5)]);
+    }
+
+    #[test]
+    fn trailing_space_overflow_stays_on_row() {
+        // The space that overflows width should not become a lone next row.
+        let segs = assert_lossless("hello world", 5);
+        assert!(segs.len() >= 2);
+        // No segment is just a single space.
+        let cs = chars("hello world");
+        for (s, e) in &segs {
+            let seg: String = cs[*s..*e].iter().collect();
+            assert_ne!(seg, " ", "no lone-space segment: {:?}", segs);
+        }
+    }
+
+    #[test]
+    fn always_makes_progress_on_zero_width() {
+        // Must terminate and cover the whole line even with width 0.
+        let segs = assert_lossless("abc", 0);
+        assert!(!segs.is_empty());
+    }
+}

--- a/tests/textarea_wrap_tests.rs
+++ b/tests/textarea_wrap_tests.rs
@@ -1,0 +1,109 @@
+//! Soft-wrap rendering tests for TextArea.
+//!
+//! Regression coverage for the previously-stubbed `wrap` flag: with `wrap(true)`
+//! a logical line longer than the viewport width must flow onto additional visual
+//! rows instead of being truncated, and `wrap(false)` must keep the original
+//! single-row (horizontally-scrolled) behavior.
+
+use revue::layout::Rect;
+use revue::render::Buffer;
+use revue::widget::traits::{RenderContext, View};
+use revue::widget::TextArea;
+
+/// Render a TextArea into a fresh `w x h` buffer.
+fn render(ta: &TextArea, w: u16, h: u16) -> Buffer {
+    let mut buffer = Buffer::new(w, h);
+    let area = Rect::new(0, 0, w, h);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+    ta.render(&mut ctx);
+    buffer
+}
+
+/// Read visual row `y` as a string with trailing blanks trimmed.
+fn row(buffer: &Buffer, y: u16, w: u16) -> String {
+    let mut s = String::new();
+    for x in 0..w {
+        if let Some(cell) = buffer.get(x, y) {
+            s.push(cell.symbol);
+        }
+    }
+    s.trim_end().to_string()
+}
+
+#[test]
+fn wrap_true_flows_long_line_onto_multiple_rows() {
+    let ta = TextArea::new()
+        .line_numbers(false)
+        .wrap(true)
+        .content("abcdefghij"); // 10 chars, width 5 -> two rows
+    let buf = render(&ta, 5, 5);
+
+    assert_eq!(row(&buf, 0, 5), "abcde");
+    assert_eq!(row(&buf, 1, 5), "fghij");
+    // Nothing lost, nothing on a third row.
+    assert_eq!(row(&buf, 2, 5), "");
+}
+
+#[test]
+fn wrap_false_truncates_to_single_row() {
+    let ta = TextArea::new()
+        .line_numbers(false)
+        .wrap(false)
+        .content("abcdefghij");
+    let buf = render(&ta, 5, 5);
+
+    // Single logical line stays on one row (truncated); no continuation row.
+    assert_eq!(row(&buf, 0, 5), "abcde");
+    assert_eq!(row(&buf, 1, 5), "");
+}
+
+#[test]
+fn wrap_true_breaks_at_word_boundaries() {
+    let ta = TextArea::new()
+        .line_numbers(false)
+        .wrap(true)
+        .content("aa bb cc"); // width 3 -> "aa" / "bb" / "cc"
+    let buf = render(&ta, 3, 5);
+
+    assert_eq!(row(&buf, 0, 3), "aa");
+    assert_eq!(row(&buf, 1, 3), "bb");
+    assert_eq!(row(&buf, 2, 3), "cc");
+}
+
+#[test]
+fn wrap_true_preserves_logical_newlines() {
+    let ta = TextArea::new()
+        .line_numbers(false)
+        .wrap(true)
+        .content("hello world\nfoo"); // line 0 wraps at width 5, line 1 short
+    let buf = render(&ta, 5, 5);
+
+    assert_eq!(row(&buf, 0, 5), "hello");
+    assert_eq!(row(&buf, 1, 5), "world");
+    assert_eq!(row(&buf, 2, 5), "foo");
+}
+
+#[test]
+fn wrap_true_line_numbers_only_on_first_visual_row() {
+    // Line numbers occupy a gutter; a wrapped continuation row must not repeat the number.
+    let ta = TextArea::new()
+        .line_numbers(true)
+        .wrap(true)
+        .content("abcdefgh"); // one logical line, wraps across rows
+    let buf = render(&ta, 8, 5);
+
+    // Gutter for a single line is "1" right-aligned in (digits+2)=3 cols: "1 " + separator.
+    let r0 = row(&buf, 0, 8);
+    let r1 = row(&buf, 1, 8);
+    assert!(
+        r0.trim_start().starts_with('1'),
+        "row0 shows line number: {r0:?}"
+    );
+    // Continuation row must NOT start with the digit '1' in the gutter.
+    assert!(
+        !r1.trim_start().starts_with('1'),
+        "continuation row must not repeat the line number: {r1:?}"
+    );
+    // But it must still contain wrapped text.
+    assert!(!r1.is_empty(), "continuation row should carry wrapped text");
+}


### PR DESCRIPTION
## Summary

`TextArea`'s `wrap` flag was a **stub** — `view.rs` rendered one visual row per logical line and truncated at the viewport width, so `.wrap(true)` never wrapped (the docs advertised word wrap). This makes it real.

## Changes

- Rewrite `view.rs` rendering around **visual rows**. When wrap is on, each logical line is split into word-boundary segments (`wrap_segments`): break at the last space, hard-break words longer than the width, absorb trailing spaces so a lone space never becomes its own row. Each segment renders as its own row.
- Line numbers render only on the **first** visual row of a logical line; cursor / selection / find-match / syntax highlighting all keep working via absolute char indices.
- The **non-wrap path is preserved exactly** (single row per line + horizontal scroll).

## Tests

- `wrap_segments` unit tests (empty, exact-fit, long-word hard wrap, word-boundary, trailing-space, zero-width progress).
- `tests/textarea_wrap_tests.rs` integration: multi-row flow, non-wrap truncation, word-boundary rows, logical-newline preservation, line-number gutter on continuation rows.
- Existing textarea suites (bounds/unicode/undo + snapshots) still pass; `cargo fmt` clean; `clippy --all-features -D warnings` clean.

Docs: `FRAMEWORK_COMPARISON.md` soft-wrap status STUB → done.