### PR TITLE
ci(cd): serialize Pages deployments to stop flaky 'try again later' failures

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Serialize Pages deployments: GitHub Pages allows only one active
+# deployment per environment, so overlapping runs (e.g. several merges to
+# main in quick succession) collide with "Deployment failed, try again
+# later". Queue them instead, and let an in-progress deploy finish.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 permissions:
   pages: write
   id-token: write


### PR DESCRIPTION
## Problem

The **CD → Deploy Docs** job (`actions/deploy-pages`) has been failing intermittently with `Deployment failed, try again later` (3 of the last 5 pushes to main). The Build Docs job succeeds and uploads the artifact; the failure is purely at the GitHub Pages deploy backend, which permits **only one active deployment per environment** — overlapping CD runs (several merges to main in quick succession) collide.

## Fix

Add the canonical GitHub Pages concurrency group to `cd.yml`:

```yaml
concurrency:
  group: "pages"
  cancel-in-progress: false
```

Runs now queue instead of racing, and an in-progress deploy is allowed to finish. This matches GitHub's official Pages starter workflow.

## Notes

- The immediate failure was already cleared by re-running the deploy (docs are live).
- Non-blocking: the Build Docs "Node.js 20 deprecation" warning comes from a transitive action inside `actions/upload-pages-artifact` and is auto-forced to Node 24 by the runner — cosmetic, left as-is.
- Workflow-only change → CI code jobs skip → merges via CI Gate without a bypass.