### PR TITLE
fix(link): stop accidental browser launches

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -539,6 +539,7 @@ DevTools panels:
 |----------|---------|
 | `REVUE_UPDATE_SNAPSHOTS=1` | Update snapshot files instead of comparing |
 | `REVUE_UPDATE_VISUALS=1` | Update visual golden files instead of comparing |
+| `REVUE_NO_BROWSER=1` | Suppress launching the system browser/opener (e.g. from the `Link` widget). Input is still validated and success is still reported, but no process is spawned — useful for demos, tests, and CI. |
 
 ## Best Practices
 

--- a/src/utils/browser.rs
+++ b/src/utils/browser.rs
@@ -212,6 +212,22 @@ fn validate_input(input: &str) -> Result<(), BrowserError> {
     Ok(())
 }
 
+/// Environment variable that suppresses actually launching an external
+/// application (browser, file manager, opener).
+///
+/// When set to any non-empty value, the `open_*` / `reveal_*` functions still
+/// validate their input and report success, but do not spawn a process. This is
+/// useful for running examples, demos, tests, and CI without real browser
+/// windows popping up.
+pub const NO_LAUNCH_ENV: &str = "REVUE_NO_BROWSER";
+
+/// Whether launching external applications is currently suppressed.
+///
+/// See [`NO_LAUNCH_ENV`].
+pub fn launch_suppressed() -> bool {
+    std::env::var_os(NO_LAUNCH_ENV).is_some_and(|v| !v.is_empty())
+}
+
 /// Open a URL or file in the system's default browser/application
 ///
 /// Platform support:
@@ -231,6 +247,11 @@ fn validate_input(input: &str) -> Result<(), BrowserError> {
 pub fn open_browser(url: &str) -> bool {
     if validate_input(url).is_err() {
         return false;
+    }
+
+    // Suppressed (e.g. demos/tests/CI): validated successfully, but don't launch.
+    if launch_suppressed() {
+        return true;
     }
 
     #[cfg(target_os = "macos")]
@@ -264,6 +285,11 @@ pub fn open_browser(url: &str) -> bool {
 /// - The browser command cannot be spawned
 pub fn open_url(url: &str) -> Result<(), BrowserError> {
     validate_input(url)?;
+
+    // Suppressed (e.g. demos/tests/CI): validated successfully, but don't launch.
+    if launch_suppressed() {
+        return Ok(());
+    }
 
     #[cfg(target_os = "macos")]
     let child = Command::new("open")
@@ -311,6 +337,11 @@ pub fn open_folder(path: &str) -> bool {
         return false;
     }
 
+    // Suppressed (e.g. demos/tests/CI): validated successfully, but don't launch.
+    if launch_suppressed() {
+        return true;
+    }
+
     #[cfg(target_os = "macos")]
     let result = Command::new("open").arg(path).spawn();
 
@@ -339,6 +370,11 @@ pub fn open_folder(path: &str) -> bool {
 pub fn reveal_in_finder(path: &str) -> bool {
     if validate_input(path).is_err() {
         return false;
+    }
+
+    // Suppressed (e.g. demos/tests/CI): validated successfully, but don't launch.
+    if launch_suppressed() {
+        return true;
     }
 
     #[cfg(target_os = "macos")]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -339,7 +339,10 @@ pub use selection::{wrap_next, wrap_prev, SectionedSelection, Selection};
 pub use layout::BoxLayout;
 
 // Browser utilities
-pub use browser::{open_browser, open_file, open_folder, open_url, reveal_in_finder};
+pub use browser::{
+    launch_suppressed, open_browser, open_file, open_folder, open_url, reveal_in_finder,
+    NO_LAUNCH_ENV,
+};
 
 // Profiler
 pub use profiler::{

--- a/src/widget/link.rs
+++ b/src/widget/link.rs
@@ -288,8 +288,10 @@ impl Interactive for Link {
         }
 
         match event.key {
-            Key::Enter | Key::Char(' ') => {
-                // Open the link - return Consumed to let the app handle opening
+            // Activate on Enter only. Space is deliberately excluded: it is a
+            // common navigation/scroll key, so binding it to "open the browser"
+            // causes accidental launches. Links open on Enter or a mouse click.
+            Key::Enter => {
                 #[cfg(not(target_arch = "wasm32"))]
                 {
                     let _ = self.open();
@@ -331,4 +333,39 @@ pub fn link(url: impl Into<String>, text: impl Into<String>) -> Link {
 /// Create a link with just URL
 pub fn url_link(url: impl Into<String>) -> Link {
     Link::new(url)
+}
+
+#[cfg(test)]
+mod activation_tests {
+    use super::*;
+    use serial_test::serial;
+
+    // Links activate on Enter (and mouse click), but NOT on Space. Space is a
+    // common navigation key, so binding it to "open the browser" caused
+    // accidental launches. The positive Enter case uses REVUE_NO_BROWSER so it
+    // never spawns a real browser.
+
+    #[test]
+    fn space_does_not_activate() {
+        let mut link = Link::new("https://example.com").focused(true);
+        let result = link.handle_key(&KeyEvent::new(Key::Char(' ')));
+        assert_eq!(result, EventResult::Ignored);
+    }
+
+    #[test]
+    #[serial]
+    fn enter_activates() {
+        std::env::set_var(crate::utils::browser::NO_LAUNCH_ENV, "1");
+        let mut link = Link::new("https://example.com").focused(true);
+        let result = link.handle_key(&KeyEvent::new(Key::Enter));
+        assert_eq!(result, EventResult::ConsumedAndRender);
+        std::env::remove_var(crate::utils::browser::NO_LAUNCH_ENV);
+    }
+
+    #[test]
+    fn disabled_ignores_enter() {
+        let mut link = Link::new("https://example.com").disabled(true);
+        let result = link.handle_key(&KeyEvent::new(Key::Enter));
+        assert_eq!(result, EventResult::Ignored);
+    }
 }

--- a/tests/browser_tests.rs
+++ b/tests/browser_tests.rs
@@ -1,6 +1,10 @@
 //! System browser and URL utilities tests
 
-use revue::utils::browser::{open_browser, open_file, open_folder, open_url, reveal_in_finder};
+use revue::utils::browser::{
+    launch_suppressed, open_browser, open_file, open_folder, open_url, reveal_in_finder,
+    NO_LAUNCH_ENV,
+};
+use serial_test::serial;
 
 #[test]
 fn test_functions_exist() {
@@ -126,4 +130,42 @@ fn test_reject_remote_file_urls() {
 fn test_error_messages() {
     let err = open_url("https://example.com & malware").unwrap_err();
     assert!(err.to_string().contains("dangerous") || err.to_string().contains("character"));
+}
+
+// Launch suppression (REVUE_NO_BROWSER) — lets demos/tests/CI run without
+// real browser windows popping up. These tests set a global env var, so they
+// must run serially. They also deliberately pass *valid* URLs, which would
+// otherwise spawn a real browser — the guard is what keeps that from happening.
+
+#[test]
+#[serial]
+fn test_no_browser_env_suppresses_launch() {
+    std::env::set_var(NO_LAUNCH_ENV, "1");
+    assert!(launch_suppressed());
+    // Valid inputs: normally spawn, but must be no-ops here (still report success).
+    assert!(open_browser("https://example.com"));
+    assert!(open_url("https://example.com").is_ok());
+    assert!(open_file("/tmp"));
+    assert!(open_folder("/tmp"));
+    assert!(reveal_in_finder("/tmp"));
+    std::env::remove_var(NO_LAUNCH_ENV);
+    assert!(!launch_suppressed());
+}
+
+#[test]
+#[serial]
+fn test_no_browser_env_empty_does_not_suppress() {
+    std::env::set_var(NO_LAUNCH_ENV, "");
+    assert!(!launch_suppressed());
+    std::env::remove_var(NO_LAUNCH_ENV);
+}
+
+#[test]
+#[serial]
+fn test_suppressed_still_rejects_dangerous_input() {
+    std::env::set_var(NO_LAUNCH_ENV, "1");
+    // Validation happens before the suppression check: dangerous input still fails.
+    assert!(!open_browser("https://example.com; rm -rf /"));
+    assert!(open_url("url | malicious").is_err());
+    std::env::remove_var(NO_LAUNCH_ENV);
 }


### PR DESCRIPTION
## Summary

The `Link` widget shells out to the system browser (`open`/`xdg-open`) on activation. Two changes stop surprise launches:

- **Activate on Enter only, not Space.** Space is a common navigation/scroll key, so binding it to "open the browser" caused accidental launches while navigating (e.g. in the `new_widgets` example). Enter and mouse click still open links.
- **`REVUE_NO_BROWSER` kill-switch** in `utils::browser`. When set to any non-empty value, `open_browser`/`open_url`/`open_folder`/`reveal_in_finder` validate input and report success but never spawn a process — handy for demos, tests, and CI. Exposed as `launch_suppressed()` / `NO_LAUNCH_ENV`.

## Testing

- New tests: Link activates on Enter, ignores Space, ignores when disabled; browser kill-switch suppresses launch while still rejecting dangerous input.
- Full lib + `browser_tests` suites + clippy + fmt clean.
- Documented `REVUE_NO_BROWSER` in `docs/guides/testing.md`.