### PR TITLE
feat(datagrid): render frozen columns and horizontal scroll

### DIFF
--- a/docs/FRAMEWORK_COMPARISON.md
+++ b/docs/FRAMEWORK_COMPARISON.md
@@ -75,7 +75,7 @@ accurate. Corrections from source-tree verification are called out.
 | Widget | Revue | Textual | ratatui | Notes |
 |--------|-------|---------|---------|-------|
 | Table (basic) | ✅ | ✅ | ✅ | — |
-| **DataGrid** | ✅ | DataTable | ❌ | **See §7.2 — revue now leads on resize/reorder** |
+| **DataGrid** | ✅ | DataTable | ❌ | **See §7.2 — revue leads on resize/reorder, parity on column freeze** |
 | List / OptionList / SelectionList | ✅ | ✅ | partial | — |
 | VirtualList | ✅ | (implicit) | ❌ | — |
 | Tree / FileTree | ✅ | ✅ / ❌ | ❌ | FileTree revue-unique |
@@ -176,7 +176,7 @@ full PTY Terminal widget. (Textual has no equivalents.)
 | **Virtual scroll** | ✅ (`render_rows_virtual`, overscan) | (implicit) | parity+ |
 | **Column resize** | ✅ (mouse + render cursor, tested) | ❌ | **Revue leads** |
 | **Column reorder** | ✅ (drag + keyboard, tested) | ❌ | **Revue leads** |
-| **Column freeze (pin)** | ⚠️ PARTIAL | ✅ (fixed rows/cols) | **Textual leads** — revue has state/API + tests but `render.rs` ignores `frozen_*`/`scroll_col`, so columns don't actually pin |
+| **Column freeze (pin)** | ✅ (pin left/right + horizontal scroll, render + tests) | ✅ (fixed rows/cols) | parity — `render.rs` positions columns from `frozen_left`/`frozen_right`/`scroll_col`; scroll via `scroll_col_left/right` + mouse |
 
 ---
 
@@ -198,7 +198,7 @@ Two real, wired-up implementations (both were previously mislabeled "missing"):
 
 | # | Gap | Current state | Impact | Effort |
 |---|-----|---------------|--------|--------|
-| 1 | **DataGrid column freeze render** | PARTIAL (state/API/tests done; render not wired) | Medium | Small–Medium |
+| 1 | ~~**DataGrid column freeze render**~~ | ✅ DONE — render reads `frozen_*`/`scroll_col` (pin left/right + horizontal scroll), tested | — | — |
 | 2 | **Key bindings for find/replace & multi-cursor** | API-only; not in `handle_key` | Medium (UX) | Small |
 | 3 | **Multi-cursor editing** | Editing applies to primary cursor only | Low–Medium | Medium–Hard |
 | 4 | **Regex search** in find/replace | Stub (literal fallback) | Low | Small |
@@ -208,7 +208,8 @@ Two real, wired-up implementations (both were previously mislabeled "missing"):
 
 ### 9.2 Already done — remove from any "TODO" list
 
-DataGrid virtual scroll / column resize / column reorder; TextArea find-replace
+DataGrid virtual scroll / column resize / column reorder / column freeze render
+(pin left/right + horizontal scroll); TextArea find-replace
 engine; TextArea soft wrap (word-boundary); Pilot testing; Worker system;
 message/event bus; CSS Grid; Input copy-paste & shift-selection. **These are
 shipped and tested** — the old doc's "❌ TODO" markers were wrong.
@@ -246,7 +247,7 @@ adoption, ergonomics, and docs — not raw feature count.
 
 | vs Framework | Revue standing | Notes |
 |--------------|----------------|-------|
-| vs **Textual** | **~parity, ahead on breadth** | Leads on widgets, viz, DataGrid resize/reorder, TextArea find/replace + soft wrap. Trails on column-freeze render, web serve, streaming content. |
+| vs **Textual** | **~parity, ahead on breadth** | Leads on widgets, viz, DataGrid resize/reorder, TextArea find/replace + soft wrap; parity on DataGrid column freeze. Trails on web serve, streaming content. |
 | vs **ratatui** | Different tier | Higher-level; ratatui wins adoption & is the substrate, not a like-for-like rival. |
 | vs **r3bl_tui / tui-realm / iocraft** | Feature-ahead, adoption-behind | Revue ships far more widgets + CSS; peers have more users/momentum. |
 | vs **reratui / reactive_tui / Cursive** | Not live competition | Negligible / dead / inactive. |
@@ -266,7 +267,7 @@ stub — is now implemented.)
   (`widget/data/datagrid/`, `widget/input/input_widgets/textarea/`,
   `testing/pilot/`, `core/app/screen/`, `state/worker/`, `runtime/event/custom/`)
   and confirming wiring into render/event/key paths and tests — not from prior
-  docs. DataGrid: 203 tests pass. "PARTIAL" = real API/state but a missing
+  docs. DataGrid: 207 tests pass. "PARTIAL" = real API/state but a missing
   render/edit/key link, documented inline above.
 - **Competitor side:** versions/dates/features from PyPI, crates.io, GitHub
   release notes, and official docs (mid-2026). Download counts are cumulative

--- a/src/widget/data/datagrid/core.rs
+++ b/src/widget/data/datagrid/core.rs
@@ -36,11 +36,30 @@ pub(super) struct CellState {
     pub is_editing: bool,
 }
 
+/// A column positioned in the rendered viewport, after applying column freeze
+/// and horizontal scroll.
+///
+/// `x` is absolute and already accounts for the row-number gutter. Columns are
+/// laid out as: left-frozen (pinned left) · scrollable middle (offset by
+/// `scroll_col`) · right-frozen (pinned right).
+pub(super) struct ColumnSlot<'a> {
+    /// Index into `self.columns`.
+    pub orig_idx: usize,
+    /// The column.
+    pub col: &'a GridColumn,
+    /// Position in display order (index into the full `visible_cols` list).
+    pub display_idx: usize,
+    /// Absolute x of the column's first cell.
+    pub x: u16,
+    /// Column width (excluding the trailing separator).
+    pub width: u16,
+}
+
 /// Row rendering parameters
-pub(super) struct RowRenderParams<'a> {
-    pub visible_cols: &'a [(usize, &'a GridColumn)],
-    pub widths: &'a [u16],
+pub(super) struct RowRenderParams<'a, 'b> {
+    pub slots: &'b [ColumnSlot<'a>],
     pub area_x: u16,
+    pub content_end: u16,
     pub start_y: u16,
     pub row_num_width: u16,
     pub visible_height: usize,

--- a/src/widget/data/datagrid/render.rs
+++ b/src/widget/data/datagrid/render.rs
@@ -1,6 +1,7 @@
 //! DataGrid rendering
 
-use super::core::{CellPos, CellState, DataGrid, RowRenderParams};
+use super::core::{CellPos, CellState, ColumnSlot, DataGrid, RowRenderParams};
+use super::types::GridColumn;
 use crate::layout::Rect;
 use crate::render::{Cell, Modifier};
 use crate::style::Color;
@@ -48,11 +49,17 @@ impl View for DataGrid {
         };
         let header_height: u16 = if self.options.show_header { 1 } else { 0 };
 
+        // Position columns for this viewport, applying column freeze and
+        // horizontal scroll. Both the header and the rows draw from this plan so
+        // they stay aligned.
+        let content_end = area.width;
+        let slots = self.compute_column_slots(&visible_cols, &widths, 0, area.width, row_num_width);
+
         let mut y = 0u16;
 
         // Draw header
         if self.options.show_header {
-            self.render_header(ctx, &visible_cols, &widths, row_num_width, y);
+            self.render_header(ctx, &slots, content_end, row_num_width, y);
             y += 1;
         }
 
@@ -73,9 +80,9 @@ impl View for DataGrid {
         };
 
         let params = RowRenderParams {
-            visible_cols: &visible_cols,
-            widths: &widths,
+            slots: &slots,
             area_x: 0,
+            content_end,
             start_y: y,
             row_num_width,
             visible_height,
@@ -90,13 +97,100 @@ impl View for DataGrid {
 }
 
 impl DataGrid {
+    /// Position the visible columns for the current viewport.
+    ///
+    /// Applies column freeze and horizontal scroll: the first `frozen_left`
+    /// display columns are pinned to the left, the last `frozen_right` are
+    /// pinned flush to the right, and the columns in between scroll horizontally
+    /// by `scroll_col`. Middle columns that would collide with the right-frozen
+    /// region are dropped.
+    ///
+    /// `widths` is parallel to `visible_cols` (display order). Returned slots
+    /// carry absolute x positions including the `row_num_width` gutter.
+    pub(super) fn compute_column_slots<'a>(
+        &self,
+        visible_cols: &[(usize, &'a GridColumn)],
+        widths: &[u16],
+        area_x: u16,
+        area_width: u16,
+        row_num_width: u16,
+    ) -> Vec<ColumnSlot<'a>> {
+        let n = visible_cols.len();
+        let content_start = area_x + row_num_width;
+        let content_end = area_x + area_width;
+        if n == 0 || content_end <= content_start {
+            return Vec::new();
+        }
+
+        let frozen_left = self.frozen_left.min(n);
+        let frozen_right = self.frozen_right.min(n - frozen_left);
+        let width_at = |i: usize| widths.get(i).copied().unwrap_or(0);
+        // Column width plus its trailing separator.
+        let span_at = |i: usize| width_at(i).saturating_add(1);
+
+        let mut slots: Vec<ColumnSlot<'a>> = Vec::with_capacity(n);
+
+        // 1) Left-frozen columns, pinned to the left in order.
+        let mut x = content_start;
+        for (i, &(orig, col)) in visible_cols.iter().enumerate().take(frozen_left) {
+            slots.push(ColumnSlot {
+                orig_idx: orig,
+                col,
+                display_idx: i,
+                x,
+                width: width_at(i),
+            });
+            x = x.saturating_add(span_at(i));
+        }
+        let left_end = x;
+
+        // 2) Right-frozen columns, pinned flush to the right in order (never
+        //    overlapping the left-frozen region).
+        let right_total: u16 = (n - frozen_right..n).map(span_at).sum();
+        let right_start = content_end.saturating_sub(right_total).max(left_end);
+        let mut rx = right_start;
+        for (i, &(orig, col)) in visible_cols.iter().enumerate().skip(n - frozen_right) {
+            slots.push(ColumnSlot {
+                orig_idx: orig,
+                col,
+                display_idx: i,
+                x: rx,
+                width: width_at(i),
+            });
+            rx = rx.saturating_add(span_at(i));
+        }
+
+        // 3) Scrollable middle columns, offset by scroll_col, stopping before
+        //    the right-frozen region.
+        let mid_lo = frozen_left;
+        let mid_hi = n - frozen_right;
+        let first = mid_lo + self.scroll_col.min(mid_hi.saturating_sub(mid_lo));
+        let mut mx = left_end;
+        for (i, &(orig, col)) in visible_cols.iter().enumerate().take(mid_hi).skip(first) {
+            let w = width_at(i);
+            if mx.saturating_add(w) > right_start {
+                break;
+            }
+            slots.push(ColumnSlot {
+                orig_idx: orig,
+                col,
+                display_idx: i,
+                x: mx,
+                width: w,
+            });
+            mx = mx.saturating_add(span_at(i));
+        }
+
+        slots
+    }
+
     /// Render rows using virtual scrolling (index-based, no allocation)
     pub(super) fn render_rows_virtual(
         &self,
         ctx: &mut RenderContext,
         render_start: usize,
         render_end: usize,
-        params: &RowRenderParams<'_>,
+        params: &RowRenderParams<'_, '_>,
     ) {
         let filtered_indices = self.filtered_indices();
 
@@ -138,36 +232,37 @@ impl DataGrid {
                 self.render_row_number(ctx, params.area_x, row_y, render_idx + 1, row_bg);
             }
 
-            // Draw cells
-            let mut x = params.area_x + params.row_num_width;
-            for (col_idx, (orig_col_idx, col)) in params.visible_cols.iter().enumerate() {
-                if col_idx >= params.widths.len() {
-                    break;
-                }
-                let w = params.widths[col_idx];
+            // Fill the content background first so any gap between the scrolled
+            // middle and the right-frozen columns is covered.
+            for gx in (params.area_x + params.row_num_width)..params.content_end {
+                let mut cell = Cell::new(' ');
+                cell.bg = Some(row_bg);
+                ctx.set(gx, row_y, cell);
+            }
+
+            // Draw cells from the positioned column slots.
+            for slot in params.slots {
                 let is_editing = self.edit_state.active
                     && render_idx == self.selected_row
-                    && *orig_col_idx == self.edit_state.col;
+                    && slot.orig_idx == self.edit_state.col;
 
                 let pos = CellPos {
-                    x,
+                    x: slot.x,
                     y: row_y,
-                    width: w,
+                    width: slot.width,
                 };
                 let state = CellState {
                     row_bg,
                     is_selected,
                     is_editing,
                 };
-                self.render_cell(ctx, row, col, &pos, &state);
+                self.render_cell(ctx, row, slot.col, &pos, &state);
 
                 // Draw separator
                 let mut sep = Cell::new('│');
                 sep.fg = Some(self.colors.border_color);
                 sep.bg = Some(row_bg);
-                ctx.set(x + w, row_y, sep);
-
-                x += w + 1;
+                ctx.set(slot.x + slot.width, row_y, sep);
             }
         }
     }
@@ -176,21 +271,27 @@ impl DataGrid {
     pub(super) fn render_header(
         &self,
         ctx: &mut RenderContext,
-        visible_cols: &[(usize, &super::types::GridColumn)],
-        widths: &[u16],
-        start_x: u16,
+        slots: &[ColumnSlot<'_>],
+        content_end: u16,
+        row_num_width: u16,
         y: u16,
     ) {
-        let mut x = start_x;
+        // Fill the header background first so gaps (from horizontal scroll with
+        // frozen-right columns) are covered.
+        for gx in row_num_width..content_end {
+            let mut cell = Cell::new(' ');
+            cell.bg = Some(self.colors.header_bg);
+            ctx.set(gx, y, cell);
+        }
 
-        for (col_idx, (orig_idx, col)) in visible_cols.iter().enumerate() {
-            if col_idx >= widths.len() {
-                break;
-            }
-            let w = widths[col_idx];
-            let is_sort_col = self.sort_column == Some(*orig_idx);
-            let is_selected = *orig_idx == self.selected_col;
-            let is_dragging = self.dragging_col == Some(*orig_idx);
+        for slot in slots {
+            let (orig_idx, col) = (slot.orig_idx, slot.col);
+            let x = slot.x;
+            let w = slot.width;
+            let col_idx = slot.display_idx;
+            let is_sort_col = self.sort_column == Some(orig_idx);
+            let is_selected = orig_idx == self.selected_col;
+            let is_dragging = self.dragging_col == Some(orig_idx);
 
             // Draw drop indicator before this column
             if self.drop_target_col == Some(col_idx) && self.dragging_col.is_some() {
@@ -216,7 +317,7 @@ impl DataGrid {
             let mut title = col.title.clone();
             if !self.sort_columns.is_empty() {
                 // Multi-column sort: show priority number
-                if let Some(pos) = self.sort_columns.iter().position(|(c, _)| *c == *orig_idx) {
+                if let Some(pos) = self.sort_columns.iter().position(|(c, _)| *c == orig_idx) {
                     let (_, dir) = self.sort_columns[pos];
                     title.push(' ');
                     title.push(dir.icon());
@@ -254,8 +355,8 @@ impl DataGrid {
             }
 
             // Draw separator with resize indicator
-            let is_resize_hover = self.hovered_resize == Some(*orig_idx);
-            let is_resizing = self.resizing_col == Some(*orig_idx);
+            let is_resize_hover = self.hovered_resize == Some(orig_idx);
+            let is_resizing = self.resizing_col == Some(orig_idx);
             let sep_char = if is_resize_hover || is_resizing {
                 '⇔'
             } else {
@@ -273,17 +374,21 @@ impl DataGrid {
             sep.fg = Some(sep_color);
             sep.bg = Some(bg);
             ctx.set(x + w, y, sep);
-
-            x += w + 1;
         }
 
-        // Draw drop indicator at the end if dropping after last column
+        // Draw drop indicator at the end if dropping after the last slot.
         if let Some(target) = self.drop_target_col {
-            if target >= visible_cols.len() && self.dragging_col.is_some() {
+            let past_last = slots.last().map(|s| s.display_idx + 1).unwrap_or(0);
+            if target >= past_last && self.dragging_col.is_some() {
+                let end_x = slots
+                    .iter()
+                    .map(|s| s.x + s.width + 1)
+                    .max()
+                    .unwrap_or(row_num_width);
                 let mut cell = Cell::new('│');
                 cell.fg = Some(Color::CYAN);
                 cell.modifier |= Modifier::BOLD;
-                ctx.set(x.saturating_sub(1), y, cell);
+                ctx.set(end_x.saturating_sub(1), y, cell);
             }
         }
     }

--- a/src/widget/data/datagrid/tests/freeze_tests.rs
+++ b/src/widget/data/datagrid/tests/freeze_tests.rs
@@ -1,6 +1,37 @@
 #![allow(unused_imports)]
 
 use super::super::*;
+use crate::layout::Rect;
+use crate::render::Buffer;
+use crate::widget::traits::{RenderContext, View};
+
+/// Render a grid into a fresh buffer of the given size.
+fn render_to(grid: &DataGrid, w: u16, h: u16) -> Buffer {
+    let mut buffer = Buffer::new(w, h);
+    let area = Rect::new(0, 0, w, h);
+    let mut ctx = RenderContext::new(&mut buffer, area);
+    grid.render(&mut ctx);
+    buffer
+}
+
+/// Read a full row of rendered symbols as a string.
+fn row_text(buf: &Buffer, y: u16, w: u16) -> String {
+    (0..w)
+        .map(|x| buf.get(x, y).map(|c| c.symbol).unwrap_or(' '))
+        .collect()
+}
+
+/// Six fixed-width columns "C0".."C5" so positions are deterministic.
+fn six_col_grid() -> DataGrid {
+    DataGrid::new()
+        .column(GridColumn::new("c0", "C0").width(6))
+        .column(GridColumn::new("c1", "C1").width(6))
+        .column(GridColumn::new("c2", "C2").width(6))
+        .column(GridColumn::new("c3", "C3").width(6))
+        .column(GridColumn::new("c4", "C4").width(6))
+        .column(GridColumn::new("c5", "C5").width(6))
+        .row(GridRow::new())
+}
 
 #[test]
 fn test_freeze_columns_left() {
@@ -53,4 +84,89 @@ fn test_horizontal_scroll() {
     grid.scroll_col_left();
     grid.scroll_col_left();
     assert_eq!(grid.scroll_col, 0);
+}
+
+// --- Rendering: column freeze + horizontal scroll ---
+
+#[test]
+fn all_columns_render_without_freeze() {
+    // Baseline: with no freeze/scroll every column header is drawn left to right.
+    let grid = six_col_grid();
+    let buf = render_to(&grid, 80, 5);
+    let header = row_text(&buf, 0, 80);
+    for title in ["C0", "C1", "C2", "C3", "C4", "C5"] {
+        assert!(header.contains(title), "missing {title}: {header:?}");
+    }
+    assert!(
+        header.starts_with("C0"),
+        "first column not at left: {header:?}"
+    );
+}
+
+#[test]
+fn frozen_left_column_survives_horizontal_scroll() {
+    let mut grid = six_col_grid().freeze_columns_left(1);
+    grid.scroll_col = 2;
+
+    let buf = render_to(&grid, 80, 5);
+    let header = row_text(&buf, 0, 80);
+
+    // The frozen first column stays pinned at the left edge.
+    assert!(
+        header.starts_with("C0"),
+        "frozen col not pinned left: {header:?}"
+    );
+    // Columns scrolled past are hidden.
+    assert!(
+        !header.contains("C1"),
+        "scrolled col should be hidden: {header:?}"
+    );
+    assert!(
+        !header.contains("C2"),
+        "scrolled col should be hidden: {header:?}"
+    );
+    // Columns after the scroll offset are shown, right after the frozen column.
+    assert!(header.contains("C3"), "post-scroll col missing: {header:?}");
+    assert!(header.contains("C5"), "post-scroll col missing: {header:?}");
+}
+
+#[test]
+fn frozen_right_column_is_pinned_to_the_right() {
+    let grid = six_col_grid().freeze_columns_right(1);
+
+    let buf = render_to(&grid, 80, 5);
+    let header = row_text(&buf, 0, 80);
+
+    // C0..C4 render from the left...
+    for title in ["C0", "C1", "C2", "C3", "C4"] {
+        assert!(header.contains(title), "missing {title}: {header:?}");
+    }
+    // ...and the frozen-right column is pinned near the right edge.
+    let idx = header.find("C5").expect("frozen-right column missing");
+    assert!(
+        idx >= 70,
+        "frozen-right not pinned right (idx {idx}): {header:?}"
+    );
+}
+
+#[test]
+fn frozen_both_sides_keep_edges_while_middle_scrolls() {
+    let mut grid = six_col_grid()
+        .freeze_columns_left(1)
+        .freeze_columns_right(1);
+    grid.scroll_col = 1;
+
+    let buf = render_to(&grid, 80, 5);
+    let header = row_text(&buf, 0, 80);
+
+    // Both frozen edges are present regardless of scroll.
+    assert!(header.starts_with("C0"), "left edge not pinned: {header:?}");
+    let idx = header.find("C5").expect("right edge missing");
+    assert!(idx >= 70, "right edge not pinned (idx {idx}): {header:?}");
+    // The first scrollable middle column (C1) is scrolled out of view.
+    assert!(!header.contains("C1"), "middle should scroll: {header:?}");
+    assert!(
+        header.contains("C2"),
+        "middle after offset missing: {header:?}"
+    );
 }


### PR DESCRIPTION
## Summary

Column-freeze state, builders (`freeze_columns_left/right`), and `scroll_col_left/right` existed with tests, but `render.rs` ignored `frozen_left`/`frozen_right`/`scroll_col` — so columns never actually pinned and horizontal scroll had no visual effect.

## Changes

- New `compute_column_slots()` positions the visible columns for the viewport:
  - **left-frozen** pinned to the left,
  - **right-frozen** pinned flush to the right,
  - **middle** columns scrolled by `scroll_col`, dropping any that would collide with the right-frozen region.
- Header and rows both draw from this shared plan (via `ColumnSlot`), with a background fill so gaps between the scrolled middle and right-frozen columns stay clean.
- Horizontal scroll is reachable via the existing `scroll_col_left/right` API + mouse. (Keyboard auto-scroll-to-selected is a natural follow-up; it needs viewport-width caching.)

## Testing

- 4 new render tests assert pinning + scroll against the rendered buffer (frozen-left survives scroll, frozen-right pinned right, both-sides edges hold while middle scrolls, no-freeze baseline).
- DataGrid suite: 207 pass. Full lib + widget suites + clippy + fmt clean.
- Updated `docs/FRAMEWORK_COMPARISON.md` (§7.2 / §9) — this was tracked as "PARTIAL: render not wired", now parity.