### PR TITLE
docs: sync TextArea find/replace & multi-cursor key-binding status

### DIFF
--- a/docs/FRAMEWORK_COMPARISON.md
+++ b/docs/FRAMEWORK_COMPARISON.md
@@ -162,8 +162,8 @@ full PTY Terminal widget. (Textual has no equivalents.)
 | Line numbers | ✅ | ✅ | parity |
 | Syntax highlight (tree-sitter) | ✅ | ✅ | parity |
 | **Soft wrap** | ✅ | ✅ | parity — word-boundary soft wrap in `view.rs` (was a stub; now flows long lines onto multiple visual rows) |
-| **Find / Replace** | ✅ (regex = stub; API-only) | ❌ core (3rd-party pkg) | **Revue leads** — engine done in `find_impl.rs` (~346L); regex falls back to literal; not bound in `handle_key` |
-| **Multiple cursors** | ⚠️ PARTIAL | ❌ | Data + render exist; editing applies to primary cursor only; not key-wired |
+| **Find / Replace** | ✅ (regex = stub) | ❌ core (3rd-party pkg) | **Revue leads** — engine in `find_impl.rs` (~346L), key-wired via `handle_key_event` (Ctrl+F/H, F3/Shift+F3); regex still falls back to literal |
+| **Multiple cursors** | ⚠️ PARTIAL | ❌ | Data + render + key wiring exist (Ctrl+D, Ctrl+Alt+↑/↓); editing still applies to primary cursor only |
 | Suggestion / placeholder | ? (verify) | ✅ (v6) | Textual added; confirm revue status |
 | Bracket matching | (CodeEditor widget) | ✅ | Textual in TextArea; revue's is in separate CodeEditor |
 
@@ -199,7 +199,7 @@ Two real, wired-up implementations (both were previously mislabeled "missing"):
 | # | Gap | Current state | Impact | Effort |
 |---|-----|---------------|--------|--------|
 | 1 | ~~**DataGrid column freeze render**~~ | ✅ DONE — render reads `frozen_*`/`scroll_col` (pin left/right + horizontal scroll), tested | — | — |
-| 2 | **Key bindings for find/replace & multi-cursor** | API-only; not in `handle_key` | Medium (UX) | Small |
+| 2 | ~~**Key bindings for find/replace & multi-cursor**~~ | ✅ DONE — wired via `handle_key_event` (Ctrl+F/H, F3/Shift+F3, Ctrl+D, Ctrl+Alt+↑/↓, Esc) | — | — |
 | 3 | **Multi-cursor editing** | Editing applies to primary cursor only | Low–Medium | Medium–Hard |
 | 4 | **Regex search** in find/replace | Stub (literal fallback) | Low | Small |
 | 5 | **Web deployment** (textual-serve analog) | Missing entirely | Strategic | Very Hard |


### PR DESCRIPTION
## Summary

v2.73.0 shipped the TextArea find/replace + multi-cursor key bindings (`handle_key_event`: Ctrl+F/H, F3/Shift+F3, Ctrl+D, Ctrl+Alt+↑/↓, Esc), but `FRAMEWORK_COMPARISON.md` still described them as "API-only / not key-wired" in §7.1 and §9 gap #2. This corrects the status.

Docs-only — no version impact.