### PR TITLE
chore: never open a real browser during local cargo test/run

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,17 @@
+# Local development environment for this workspace.
+#
+# `[env]` here seeds environment variables for every `cargo` invocation in this
+# repo (build / test / run / examples). It does NOT override a variable already
+# set in your shell, and it does not affect downstream users of the published
+# crate — only local development in this checkout.
+[env]
+# Never launch the system browser during local dev/test.
+#
+# The Link widget and utils::browser honor REVUE_NO_BROWSER: when it is set to a
+# non-empty value, open_browser/open_url/... validate and report success but do
+# not spawn a process. This stops example.com (and friends) from popping open a
+# real browser window while running `cargo test`, `cargo run`, or the examples.
+#
+# To force a real browser open for a single run, unset it for that command:
+#   REVUE_NO_BROWSER= cargo run --example new_widgets
+REVUE_NO_BROWSER = "1"


### PR DESCRIPTION
## Summary

Even after v2.73.0 (Link opens on Enter/click only + `REVUE_NO_BROWSER` kill-switch), local `cargo test`/`run`/examples still popped open a real browser because the env var had to be set by hand each time.

This adds `.cargo/config.toml` with an `[env]` block that seeds `REVUE_NO_BROWSER=1` for every cargo invocation in this workspace. The Link widget / `utils::browser` honor it, so no real browser launches during local dev.

- Scoped to this checkout only — does **not** override a shell-set value, and does **not** affect downstream users of the published crate.
- Force a real open for a single run: `REVUE_NO_BROWSER= cargo run --example new_widgets`.

No `src/` changes → no version bump.

## Verification

`cargo test --test browser_tests` passes under the config (20/20); the shell has no `REVUE_NO_BROWSER` set, confirming cargo is the one seeding it.